### PR TITLE
Update for version 0.5.2

### DIFF
--- a/_posts/releases/2012-01-09-v0.5.2.md
+++ b/_posts/releases/2012-01-09-v0.5.2.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: Bitcoin version 0.5.2 released
+category: releases
+---
+Bitcoin version 0.5.2 is now available for download at:
+<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.2/>
+
+This is a bugfix-only release.
+
+Please report bugs using the issue tracker at github:
+<https://github.com/bitcoin/bitcoin/issues>
+
+BUG FIXES
+---------
+
+* Check all transactions in blocks after the last checkpoint (0.5.0 and 0.5.1
+skipped checking ECDSA signatures during initial blockchain download; this was
+not a security vulnerability).
+
+* Cease locking memory used by non-sensitive information (this caused a huge
+performance hit on some platforms, especially noticable during initial blockchain
+download).
+
+* Fixed some address-handling deadlocks (client freezes).
+
+* No longer accept inbound connections over the internet when Bitcoin is being
+used with Tor (identity leak).
+
+* Re-enable SSL support for the JSON-RPC interface (it was unintentionally
+disabled for the 0.5.0 and 0.5.1 release Linux binaries).
+
+* Use the correct base transaction fee of 0.0005 BTC for accepting transactions
+into mined blocks (since 0.4.0, it was incorrectly accepting 0.0001 BTC which was
+only meant to be relayed).
+
+* Don't show "IP" for transactions which are not necessarily IP transactions.
+
+* Add new DNS seeds (maintained by Pieter Wuille and Luke Dashjr).

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: index
 section: index
 title: P2P digital currency
-DOWNLOAD_VERSION: 0.5.1
+DOWNLOAD_VERSION: 0.5.2
 ALERT_CLASS:
 ALERT:
 ---


### PR DESCRIPTION
Before pulling this, we need to upload the builds to the SourceForge site. BlueMatt did gitian builds for Linux and Windows:
[01:49:10] &lt;BlueMatt&gt; luke-jr: linux build http://dl.dropbox.com/u/29653426/bitcoin-0.5.2rc1.tar.bz2
[02:37:15] &lt;BlueMatt&gt; luke-jr: second one http://dl.dropbox.com/u/29653426/bitcoin-0.5.2rc1-win32.tar.bz2
There are no commits between rc1 and final, so these can be safely renamed.

Gavin was going to also gitian-build, as well as do a Mac build.
