### PR TITLE
Fixed download size for win32 exe.

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ ALERT:
                         <img src="img/ico-win.png" class="icon"/>Windows (zip)</a> <small>~8MB</small>
                       </li>
                       <li><a href="http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-{{ page.DOWNLOAD_VERSION }}/bitcoin-{{ page.DOWNLOAD_VERSION }}-win32-setup.exe/download">
-                        <img src="img/ico-win.png" class="icon"/>Windows (exe)</a> <small>~4MB</small>
+                        <img src="img/ico-win.png" class="icon"/>Windows (exe)</a> <small>~8MB</small>
                       </li>
                       <li><a href="https://launchpad.net/~bitcoin/+archive/bitcoin">
                         <img src="img/ico-ubuntu.png" class="icon">Ubuntu PPA</a>


### PR DESCRIPTION
Windows exe on http://bitcoin.org is not 4MB as stated, it is 8MB.
More precisely, bitcoin-0.5.2-win32-setup.exe is 8427K.
I had to fix index.html (~4MB -> ~8MB).
