### PR TITLE
Revert "Added Bitcoin Media."

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,13 +84,6 @@ ALERT:
                 </ul>
               </li>
               <li><a href="http://bitcoincharts.com/">Bitcoin Charts / Markets</a></li>
-              <li><a href="http://bitcoinmedia.com">Bitcoin Media</a>
-                <ul>
-                  <li><a href="http://bitcoinmedia.com/the-future-cannot-exist-without-the-past/">Pre-History of Bitcoin</a></li>
-                  <li><a href="http://bitcoinmedia.com/bulleted-advantages/">Advantages</a></li>
-                  <li><a href="http://bitcoinmedia.com/merchant-developer-tutorial/">Merchant Developer Tutorial</a></li>
-                </ul>
-              </li>
             </ul>
           </div>
           <div class="span6">


### PR DESCRIPTION
This reverts commit f0838d43bbe6aa11f2135856d1244c7dd018b8ea.

A. I (and luke-jr) reject to some of the associations that those articles make with bitcoin.
B. Whether they should be on bitcoin.org or not, genjix unilaterally pushing links to his content to bitcoin.org is definitely not right. This change should have been very heavily discussed before pushing.
