### PR TITLE
Fixed download size for 0.5.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,19 +42,19 @@ ALERT:
 
                     <ul class="unstyled">
                       <li><a href="http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-{{ page.DOWNLOAD_VERSION }}/bitcoin-{{ page.DOWNLOAD_VERSION }}-win32.zip/download">
-                        <img src="img/ico-win.png" class="icon"/>Windows (zip)</a> <small>~8MB</small>
+                        <img src="img/ico-win.png" class="icon"/>Windows (zip)</a> <small>~11MB</small>
                       </li>
                       <li><a href="http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-{{ page.DOWNLOAD_VERSION }}/bitcoin-{{ page.DOWNLOAD_VERSION }}-win32-setup.exe/download">
-                        <img src="img/ico-win.png" class="icon"/>Windows (exe)</a> <small>~8MB</small>
+                        <img src="img/ico-win.png" class="icon"/>Windows (exe)</a> <small>~9MB</small>
                       </li>
                       <li><a href="https://launchpad.net/~bitcoin/+archive/bitcoin">
                         <img src="img/ico-ubuntu.png" class="icon">Ubuntu PPA</a>
                       </li>
                       <li><a href="http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-{{ page.DOWNLOAD_VERSION }}/bitcoin-{{ page.DOWNLOAD_VERSION }}-linux.tar.gz/download">
-                        <img src="img/ico-tux.png" class="icon"/>Linux (tgz, 32/64-bit)</a> <small>~12MB</small>
+                        <img src="img/ico-tux.png" class="icon"/>Linux (tgz, 32/64-bit)</a> <small>~10MB</small>
                       </li>
                       <li><a href="http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-{{ page.DOWNLOAD_VERSION }}/bitcoin-{{ page.DOWNLOAD_VERSION }}-macosx.dmg/download">
-                        <img src="img/ico-osx-uni.png" class="icon">Mac OS X</a> <small>~6MB</small>
+                        <img src="img/ico-osx-uni.png" class="icon">Mac OS X</a> <small>~15MB</small>
                       </li>
                       <li>or get the <a href="https://github.com/bitcoin/bitcoin">source code</a> (GitHub)</li>
                     </ul>


### PR DESCRIPTION
bitcoin-0.5.3-win32.zip is 11.24 MB ~11 MB
bitcoin-0.5.3-win32-setup.exe 8.51 MB ~9 MB
bitcoin-0.5.3-linux.tar.gz is 9.69 MB ~10 MB
bitcoin-0.5.3-macosx.dmg is 14.7 MB ~15 MB
