### PR TITLE
link to the directory containing files

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ ALERT:
                   <div>
 
                     <p>
-                       <strong>Latest version:</strong> {{ page.WIN32_DOWNLOAD_VERSION }}
+                       <strong>Latest version:</strong> <a href="http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-{{ page.DOWNLOAD_VERSION }}/"{{ page.WIN32_DOWNLOAD_VERSION }}</a>
                     </p>
 
                     <ul class="unstyled">


### PR DESCRIPTION
As per comment in commit - currently SHASUMS are not discoverable without editing the download URL manually. 
