### PR TITLE
point to main otc chan

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@ ALERT:
                 <ul>
                   <li><strong>#bitcoin</strong> (General Bitcoin-related)</li>
                   <li><strong>#bitcoin-dev</strong> (Development and technical)</li>
-                  <li><strong>#bitcoin-otc-foyer</strong>  (Over The Counter exchange)</li>
+                  <li><strong>#bitcoin-otc</strong>  (Over The Counter exchange)</li>
                   <li><strong>#bitcoin-market</strong> (Live quotes from markets)</li>
                   <li><strong>#bitcoin-mining</strong> (GPU mining related)</li>
                 </ul>


### PR DESCRIPTION
since it is no longer +m, and -foyer is fairly quiet.
