### PR TITLE
The Bitcoin.org Page Description on Google Search Results

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Bitcoin - {{ page.title }}</title>
-    <meta name="description" content="The original site offering documentation, forums and the original open-source Bitcoin software." />
+    <meta name="description" content="The original site offering documentation and open-source Bitcoin software." />
     <meta name="author" content="" />
     <meta name="robots" content="noodp" />
 


### PR DESCRIPTION
In addition to correcting the minor formatting issue in the header, I added &lt;meta name="robots" content="noodp" /&gt; to the page layout so the Google description for the Bitcoin.org result is taken directly from the page instead of using outdated ODP data.

http://www.google.com/search?q=bitcoin&ie=utf-8&oe=utf-8

This will appease people who are complaining about the current outdated page description that uses the word "official". 
