### PR TITLE
update url for Electrum website

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -62,7 +62,7 @@ clients:
   - name: linux
   - name: win
 - name: Electrum
-  url: electrum-desktop.com
+  url: electrum.org
   image: electrum.png
   description: |
     Electrum's focus is speed, with low resource usage and


### PR DESCRIPTION
the Electrum website is now electrum.org
