### PR TITLE
Display SVG graphics properly when serving files with WEBrick

### DIFF
--- a/_plugins/svg.rb
+++ b/_plugins/svg.rb
@@ -1,0 +1,4 @@
+require 'webrick'
+include WEBrick
+
+WEBrick::HTTPUtils::DefaultMimeTypes.store 'svg', 'image/svg+xml'


### PR DESCRIPTION
I wanted to make some changes to the site, but letting Jekyll serve the files locally through WEBrick displays broken images. SVGs are not given the correct content-type.

Jekyll's fix seems to be in the next release. This will be a temporary fix.

Hopefully others won't run into the same issue.
