### PR TITLE
add secure-your-wallet page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,8 @@ section:
     en: resources
     fr: ressources
     es: recursos
+  secure-your-wallet:
+    en: secure-your-wallet
   support-bitcoin:
     en: support-bitcoin
     fr: supporter-bitcoin

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -26,7 +26,7 @@ h2{
 }
 h3{
 	color:#383838;
-	font-size:100%;
+	font-size:110%;
 }
 h1 img,h2 img,h3 img{
 	vertical-align:middle;
@@ -400,6 +400,16 @@ li{
 .box{
 	border:2px dashed #4892b2;
 	padding:0px 20px 0px 20px;
+}
+.boxexpand{
+	height:56px;
+	overflow:hidden;
+	transition:height 400ms ease-out;
+	-moz-transition:height 400ms ease-out;
+	-webkit-transition:height 400ms ease-out;
+}
+.boxexpand h3>a:link,.boxexpand h3>a:visited,.boxexpand h3>a:active{
+	text-decoration:none;
 }
 
 .titlelight{

--- a/en/bitcoin-for-individuals.html
+++ b/en/bitcoin-for-individuals.html
@@ -16,7 +16,7 @@ title: Bitcoin for Individuals - Bitcoin
 <p>Just like with email, you don't need to force your family to use the same software or the same service providers. Just let them stick to their own favorites. No problem there, they are all compatible as they use the same open technology. The Bitcoin network never sleeps, even on holidays!</p>
 
 <h2><img src="/img/ico_lock.svg" alt="Secure" />Secure transactions</h2>
-<p>Bitcoin transactions are secured by military grade cryptography. Nobody can make a payment on your behalf or charge you money without having a copy of your wallet. So as long as you take required steps to <a href="/en/you-need-to-know">protect your wallet</a>, Bitcoin provides a nice level of protection against many types of fraud.</p>
+<p>Bitcoin transactions are secured by military grade cryptography. Nobody can make a payment on your behalf or charge you money without having a copy of your wallet. So as long as you take required steps to <a href="/en/secure-your-wallet">protect your wallet</a>, Bitcoin provides a nice level of protection against many types of fraud.</p>
 
 <h2><img src="/img/ico_lowfee.svg" alt="Free" />Almost free to use</h2>
 <p>Bitcoin allows to send and receive payments for free. Except for special cases like very tiny micro-payments, there is no enforced fee. You can however choose to pay a small voluntary fee to increase your transaction priority and to remunerate people who operate the Bitcoin network.</p>

--- a/en/bitcoin-for-press.html
+++ b/en/bitcoin-for-press.html
@@ -145,7 +145,7 @@ mode: wide
 <div>
   <a href="#" onclick="faqshow(event);">Is Bitcoin secure?</a>
   <div>
-  <p>The Bitcoin technology - the protocol and the cryptography - has a strong security track record.  Bitcoin’s vulnerability is in user error.  Bitcoin wallet files that store the necessary private keys can be accidentally deleted, lost, stolen or compromised. Consequently, users need to employ security practices to protect their money or use service providers that offer good levels of security and insurance. As Bitcoin has grown in adoption, more service providers have appeared to make it easier, safer, and more convenient to use and safely secure bitcoins. Bitcoins are not covered by insurance schemes or depositor insurance like the FDIC, but could be with a service provider that offered that service.</p>
+  <p>The Bitcoin technology - the protocol and the cryptography - has a strong security track record.  Bitcoin’s vulnerability is in user error.  Bitcoin wallet files that store the necessary private keys can be accidentally deleted, lost, stolen or compromised. Consequently, users need to employ <a href="/en/secure-your-wallet">security practices</a> to protect their money or use service providers that offer good levels of security and insurance. As Bitcoin has grown in adoption, more service providers have appeared to make it easier, safer, and more convenient to use and safely secure bitcoins. Bitcoins are not covered by insurance schemes or depositor insurance like the FDIC, but could be with a service provider that offered that service.</p>
   </div>
 </div>
 <div>

--- a/en/secure-your-wallet.html
+++ b/en/secure-your-wallet.html
@@ -1,0 +1,77 @@
+---
+layout: base-en
+id: secure-your-wallet
+title: Securing your wallet - Bitcoin
+---
+<h1>Securing your wallet</h1>
+<p>Like in real life, your wallet must be secured. Bitcoin allows to transfer value worldwide easier than ever. Such great features also come with great security concerns. At the same time, Bitcoin can provide very high levels of security if used correctly. <b>Always remember that it is your responsibility to adopt good practices in order to protect your money</b>. Here are some things you should consider.</p>
+
+<h2>Be careful with online wallets</h2>
+<p>Online wallets look like online banks. You are trusting someone to store and protect your bitcoins while you have to remember your password. However, you should always choose such services carefully. As of today, no online wallet provides enough insurance and security to be used to store value like a bank. Using security features like two-factor authentication can also increase the security of your acccounts.</p>
+
+<h2>Backup your wallet</h2>
+<p>Bitcoin services and software allow you to backup your wallet. Stored in a safe place, a backup can protect you against computer failures and many human mistakes.
+
+<div class="box">
+
+<h3>Backup your entire wallet</h3>
+<p>Your wallet contains many private keys that receive the change of your transactions in order to protect your privacy. If you only have a backup of your visible private keys, you might not be able to recover a great part of your funds with your backup.</p>
+
+<h3>Encrypt online backups</h3>
+<p>Any backup that is stored online is highly vulnerable to theft. Even a computer that is connected to the Internet is vulnerable to malicious software. As such, encrypting any backup that is exposed to the network is a good security practice.</p>
+
+<h3>Use many secure locations</h3>
+<p>Single points of failure are bad for security. If your backup is not dependent of a single location, it is less likely that any bad event will prevent you to recover your wallet. You might also want to consider using different medias like USB keys, papers and CDs.</p>
+
+<h3>Make regular backups</h3>
+<p>You need to backup your wallet on a regular basis to make sure that all recent Bitcoin change addresses and all new Bitcoin addresses you created are included in your backup. However, all applications will be soon using wallets that only need to be backed up once.</p>
+
+</div>
+
+<h2>Encrypt your wallet</h2>
+<p>Encrypting your wallet allows you to set a password for anyone trying to withdraw any funds. This helps protect against thieves, though it cannot protect against keylogging hardware or software.</p>
+
+<div class="box">
+
+<h3>Never forget your password</h3>
+<p>You should make sure you never forget the password or your funds will be permanently lost. Unlike your bank, there are no password recovery options with Bitcoin. In fact, you should be able to remember your password even after many years without using it. In doubt, you might want to keep a paper copy of your password in a safe place like a vault.</p>
+
+<h3>Use a strong password</h3>
+<p>Any password that contains only letters or recognizable words can be considered very weak and easy to break. A strong password must contain letters, numbers, punctuation marks and must be at least 16 characters long. Still, this should not prevent you to remember your password.</p>
+
+</div>
+
+<h2>Offline wallet for savings</h2>
+<p>An offline wallet, also known as cold storage, provides the highest level of security for savings. It involves storing a wallet in a secured place that is not connected to the network. When done properly, it can offer a very good protection against computer vulnerabilities. It is however very important to test this type of setup before you start to use it with serious transactions. Using an offline wallets in conjunction with backups and encryption is also a good practice. Here is an overview of some approaches.</p>
+
+<div class="box boxexpand">
+<h3><a href="#" onclick="boxshow(event);">Offline transaction signing</a></h3>
+<p>This approach involves having two computers sharing some parts of the same wallet. The first one must be disconnected from any network. It is the only one that holds the entire wallet and is able to sign transactions. The second computer is connected to the network and only have a watching wallet that can only create unsigned transactions. This way, you can securely issue new transactions with the following steps.</p>
+<ol>
+  <li>Create a new transaction on the online computer and save it on an USB key.</li>
+  <li>Sign the transaction with the offline computer.</li>
+  <li>Send the signed transaction with the online computer.</li>
+</ol>
+<p>Because the computer that is connected to the network cannot sign transactions, it cannot be used to withdraw any funds if it is compromised. <a href="https://bitcoinarmory.com/using-offline-wallets-in-armory/">Armory</a> can be used to do offline transaction signature.</p>
+</div>
+
+<br>
+<div class="box boxexpand">
+<h3><a href="#" onclick="boxshow(event);">Temporary environment</a></h3>
+<p>This approach involves loading a wallet inside a temporary environment. For example, it is possible to boot on a Linux live CD, load a light SPV wallet software with its configuration from an USB key and issue a transaction. When a computer is booted from a trusted read-only environment that is only loaded in memory, malicious code is kept away and no trace of your wallet is left on the hard drive. You should however be very careful with the following points.</p>
+<p><b>Losing funds</b></p>
+<p>A temporary environment is the perfect place to lose funds forever. If your wallet is not correctly loaded from an external permanent storage like an USB key, any changes made in your wallet will be lost permanently. Including the new Bitcoin adresses that might have been created during the temporary session to receive the change of your last transactions.</p>
+<p><b>Password mismatch</b></p>
+<p>Booting in a temporary environment might possibly assign a different layout to your keyboard which will later produce different characters then expected. When using encryption, this can cause password mismatches. You might want to type your password on the screen to prevent problems.</p>
+<p><b>Leaving no trace</b></p>
+<p>As long as a storage media like a hard drive is connected to the computer, there is a small risk that some traces of your private keys can remain. You might want to disconnect any hard drive or disable all swap partitions before loading your wallet.</p>
+</div>
+
+<h2>Multi-signature to protect against theft</h2>
+<p>Bitcoin includes a multi-signature feature that allows a transaction to require the signature of more than one private key to be spent. It is however only usable for technical users but a greater availability for this feature can be expected in the future. Multi-signature can allow an organization to give access to its treasury to its members while only allowing a withdrawal if 3 of 5 members sign the transaction. It can also allow future online wallets to share a multi-signature address with their users, so that a thief would need to compromise both your computer and the online wallet servers in order to steal your funds.</p>
+
+<h2>Small amounts on your mobile</h2>
+<p>A Bitcoin wallet on your phone is like a wallet with cash. If you wouldn't keep a thousand dollar in your pocket, you might want to have the same consideration for your Bitcoin wallet. You can easily add more funds at any time on your mobile. This way, you can combine security with ease of use.</p>
+
+<h2>Think about your testament</h2>
+<p>Your bitcoins can be lost forever if you don't have a backup plan for your peers and family. If the location of your wallets or your passwords are not known by anyone when you are gone, there is no hope that your funds will ever be recovered. Taking a bit of time on these matters can make a huge difference.</p>

--- a/en/you-need-to-know.html
+++ b/en/you-need-to-know.html
@@ -7,21 +7,7 @@ title: Some things you need to know - Bitcoin
 <p>If you are about to explore Bitcoin, there are a few things you should know. Bitcoin does not let you send emails or take pictures; it lets you exchange money and value. As such, Bitcoin must be treated with the same care as your regular wallet, or even more in some cases!</p>
 
 <h2><img src="/img/ico_key.svg" alt="Security" />Securing your wallet</h2>
-<p>Like in real life, your wallet must be secured. Always remember that it is your responsibility to adopt good practices in order to protect your money. Here are some options you should consider.</p>
-
-<div class="box">
-<h3>Backup your wallet</h3>
-<p>Bitcoin services and softwares allow you to backup your wallet, which can be printed on paper or saved to a USB drive. Stored in a safe place, a backup can protect you against computer failure and many human mistakes.</p>
-
-<h3>Encrypt your wallet</h3>
-<p>Encrypting your wallet allows you to set a password for anyone trying to withdraw any funds. This helps protect against thieves and hackers, though it cannot protect against keylogging hardware or software. However, you should make sure you never forget the password or your funds will be permanently lost. Unlike your bank, there are no password recovery options with Bitcoin!</p>
-
-<h3>Be careful with online wallets</h3>
-<p>Using an online wallet is pretty much like using an online bank. You are trusting someone else to protect your money while you have to remember and protect your password. You should always choose such services carefully. As of today, no online wallet provides enough insurance and security to be used to store value like a bank.</p>
-
-<h3>Use an offline backup for savings</h3>
-<p>An offline backup of a wallet provides the highest level of security for savings. It involves storing a wallet only on paper and on usb keys in different secured locations that are not connected to the network. This is a good protection against computer failures, computer vulnerabilities, theft and human mistakes. As of today, this approach still requires some technical knowledge to be done correctly.</p>
-</div>
+<p>Like in real life, your wallet must be secured. Bitcoin allows to transfer value worldwide easier than ever. Such great features also come with great security concerns. At the same time, Bitcoin can provide very high levels of security if used correctly. Always remember that it is your responsibility to adopt good practices in order to protect your money. <a href="/en/secure-your-wallet"><b>Read more about securing your wallet</b></a>.</p>
 
 <h2><img src="/img/ico_market.svg" alt="Volatile" />Bitcoin price is volatile</h2>
 <p>The price of a bitcoin can unpredictably increase or decrease over a short period of time due to its young economy, novel nature, and sometimes illiquid markets. Consequently, keeping your savings in bitcoin is not recommended. Bitcoin should be considered as a high risk asset, and you should never store money that you cannot afford to lose with Bitcoin. If you receive payments with Bitcoin, many service providers allow you to convert them instantly to your local currency.</p>

--- a/js/main.js
+++ b/js/main.js
@@ -76,7 +76,6 @@ for(var i=0,nd=document.getElementsByTagName('*'),n=nd.length;i<n;i++){
 
 
 function mobileshow(e){
-cancelEvent(e);
 var mm=document.getElementById('menu');
 var mf=document.getElementById('menufor');
 var ml=document.getElementById('langselect');
@@ -84,7 +83,22 @@ var t=document.getElementById('menumobile');
 if(mf.style.display=='block'){mf.style.display='';mm.style.display='';ml.style.display='';}
 else{mf.style.display='block';mm.style.display='block';ml.style.display='inline-block';}
 t.parentNode.removeChild(t);
-return false;
+cancelEvent(e);
+}
+
+
+function boxshow(e){
+var p=t=getEventTarget(e);
+while(p.nodeName!='DIV')p=p.parentNode;
+var pp=p.cloneNode(true);
+pp.style.visibility='hidden';
+pp.style.height='auto';
+p.parentNode.appendChild(pp);
+var nhe=getHeight(pp);
+pp.parentNode.removeChild(pp);
+p.style.height=nhe+'px';
+t.removeAttribute('href');
+cancelEvent(e);
 }
 
 


### PR DESCRIPTION
In the same spirit then the "You need to know" page, I produced a "secure your wallet" page in order to give more serious advices and help users to adopt good security practices. In the hope that this can contribute in reducing unsecure setups and loss of funds over time.

This page is replacing (and recycling) the little box in the "you need to know" page and is adding the following content :
- More advices and warnings concerning backups.
- More advices and warnings concerning encryption.
- Concrete and prudent introduction to offline wallets.
- Introduction to offline transaction signature with Armory
- Explanations and warnings about using a wallet in a temporary environment
- Better explanation about the change addresses, private keys and deterministic wallets in relation with backups.
- Introduction about multi-signature against theft.
- Quick advice about mobiles that are easy to steal.
- Improved general redaction

Result can be seen live there :
http://bitcoinsecwallet.zapto.org/en/you-need-to-know
http://bitcoinsecwallet.zapto.org/en/secure-your-wallet

The content of this page is sensitive and I took a lot of time to proof-read it. But I think it requires many ACK from developers before we choose to merge it.
