### PR TITLE
Update title for Google search results

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: base-en
 id: index
-title: Bitcoin - Open-source P2P Digital Currency
+title: Bitcoin - Open source P2P Digital Currency
 ---
 <script>
 //Auto redirect to the appropriate language


### PR DESCRIPTION
Changed title from just "Bitcoin" to "Bitcoin - Open-source P2P Digital Currency" in the layout config so people know exactly what Bitcoin is when they see bitcoin.org on Google's search results.
