### PR TITLE
Add links to the development mailing list and IRC, as well as a web-irc link

### DIFF
--- a/en/development.html
+++ b/en/development.html
@@ -25,7 +25,9 @@ title: Development - Bitcoin
 </ul>
 
 <h2>Get involved</h2>
-<p>Bitcoin development is open source and any developer can contribute to the project. Everything you need is in the <a href="https://github.com/bitcoin/bitcoin">Github repository</a>. Please make sure to read and follow the development process described in the README as well as to provide good quality code and respect all guidelines.</p>
+<p>Bitcoin development is open source and anyone can contribute to the project. Everything you need is in the <a href="https://github.com/bitcoin/bitcoin">Github repository</a>. Please make sure to read and follow the development process described in the README as well as to provide good quality code and respect all guidelines.</p>
+<p>Development discussion takes place on github and the <a href="http://sourceforge.net/mailarchive/forum.php?forum_name=bitcoin-development">bitcoin-development</a> mailing list at sourceforge. Less formal development discussion happens on irc.freenode.net #bitcoin-dev (&rarr;<a href="" onclick="document.getElementById('chatbox').innerHTML='<iframe src=\'http://webchat.freenode.net/?channels=bitcoin-dev\' width=800 height=600/>';return false;">web interface</a>; <a href="http://bitcoinstats.com/irc/bitcoin-dev/logs/">logs</a>).</p>
+<div id="chatbox" style="text-align:center;"></div>
 
 <section id="contributors">
   <h2>Contributors</h2>


### PR DESCRIPTION
This should improve the transparency of the development process some,
if it turns out that it's bringing too many overly-green people
we can redirect it to some more beginner oriented locations later.
