### PR TITLE
Add link to bitcoinpresscenter.org

### DIFF
--- a/en/bitcoin-for-press.html
+++ b/en/bitcoin-for-press.html
@@ -21,6 +21,8 @@ mode: wide
 
 </div>
 
+<p>Find more bitcoin press contacts at the independent <a href="http://bitcoinpresscenter.org">Bitcoin Press Center</a>.</p>
+
 <div>
 
 <div>


### PR DESCRIPTION
Please add a link to the independent site bitcoinpresscenter.org to the main press page of bitcoin.org. 

The bitcoinpresscenter.org provides much richer information about press contacts, a more fair randomized display order, nine languages and multilingual contact records and a comprehensive and very effective faceted search and navigation panel (left sidebar).

Alternatively, remove the Press page from bitcoin.org and allow a completely independent site to offer press contacts without implicit or explicit endorsement from bitcoin.org and in an inclusive way. 

Thank you for consideration
