### PR TITLE
Rename Bitcoin to Bitcoin-Qt in Version history

### DIFF
--- a/_posts/releases/2011-11-21-v0.5.0.md
+++ b/_posts/releases/2011-11-21-v0.5.0.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.5.0 released
+title: Bitcoin-Qt version 0.5.0 released
 category: releases
 version: 0.5.0
 ---
-Bitcoin version 0.5.0 is now available for download at:
+Bitcoin-Qt version 0.5.0 is now available for download at:
   <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.0/>
 
 The major change for this release is a completely new graphical

--- a/_posts/releases/2011-12-15-v0.5.1.md
+++ b/_posts/releases/2011-12-15-v0.5.1.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.5.1 released
+title: Bitcoin-Qt version 0.5.1 released
 category: releases
 version: 0.5.1
 ---
-Bitcoin version 0.5.1 is now available for download at:
+Bitcoin-Qt version 0.5.1 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.1/>
 
 This is a bugfix-only release.

--- a/_posts/releases/2012-01-09-v0.5.2.md
+++ b/_posts/releases/2012-01-09-v0.5.2.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.5.2 released
+title: Bitcoin-Qt version 0.5.2 released
 category: releases
 version: 0.5.2
 ---
-Bitcoin version 0.5.2 is now available for download at:
+Bitcoin-Qt version 0.5.2 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.2/>
 
 This is a bugfix-only release.

--- a/_posts/releases/2012-03-14-v0.5.3.md
+++ b/_posts/releases/2012-03-14-v0.5.3.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.5.3 released
+title: Bitcoin-Qt version 0.5.3 released
 category: releases
 version: 0.5.3
 ---
-Bitcoin version 0.5.3 is now available for download at:
+Bitcoin-Qt version 0.5.3 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.3/>
 
 This is a bugfix-only release based on 0.5.1.

--- a/_posts/releases/2012-03-16-v0.5.3.1.md
+++ b/_posts/releases/2012-03-16-v0.5.3.1.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.5.3.1 released
+title: Bitcoin-Qt version 0.5.3.1 released
 category: releases
 version: 0.5.3.1
 ---
-Bitcoin version 0.5.3.1 for Windows is now available for download at:
+Bitcoin-Qt version 0.5.3.1 for Windows is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.3/>
 
 This is a bugfix-only release based on 0.5.1.

--- a/_posts/releases/2012-03-30-v0.6.0.md
+++ b/_posts/releases/2012-03-30-v0.6.0.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.6.0 released
+title: Bitcoin-Qt version 0.6.0 released
 category: releases
 version: 0.6.0
 ---
-Bitcoin version 0.6.0 is now available for download at:
+Bitcoin-Qt version 0.6.0 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.0/>
 
 This release includes many bug fixes, performance improvements and new

--- a/_posts/releases/2012-05-04-v0.6.1.md
+++ b/_posts/releases/2012-05-04-v0.6.1.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.6.1 released
+title: Bitcoin-Qt version 0.6.1 released
 category: releases
 version: 0.6.1
 ---
-Bitcoin version 0.6.1 is now available for download at:
+Bitcoin-Qt version 0.6.1 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.1/>
 
 This is a bug-fix and code-cleanup release, with no major new features.

--- a/_posts/releases/2012-05-08-v0.6.2.md
+++ b/_posts/releases/2012-05-08-v0.6.2.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.6.2 released
+title: Bitcoin-Qt version 0.6.2 released
 category: releases
 version: 0.6.2
 ---
-Bitcoin version 0.6.2 is now available for download at:
+Bitcoin-Qt version 0.6.2 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.2/>
 
 This is a bug-fix release with no major new features.

--- a/_posts/releases/2012-06-25-v0.6.3.md
+++ b/_posts/releases/2012-06-25-v0.6.3.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.6.3 released
+title: Bitcoin-Qt version 0.6.3 released
 category: releases
 version: 0.6.3
 ---
-Bitcoin version 0.6.3 is now available for download at:
+Bitcoin-Qt version 0.6.3 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.3/>
 
 This is a bug-fix release with no new features.

--- a/_posts/releases/2012-09-17-v0.7.0.md
+++ b/_posts/releases/2012-09-17-v0.7.0.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.7.0 released
+title: Bitcoin-Qt version 0.7.0 released
 category: releases
 version: 0.7.0
 ---
-Bitcoin version 0.7.0 is now available for download at:
+Bitcoin-Qt version 0.7.0 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.0/>
 
 We recommend that everybody running prior versions of bitcoind/Bitcoin-Qt

--- a/_posts/releases/2012-10-19-v0.7.1.md
+++ b/_posts/releases/2012-10-19-v0.7.1.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.7.1 released
+title: Bitcoin-Qt version 0.7.1 released
 category: releases
 version: 0.7.1
 ---
-Bitcoin version 0.7.1 is now available for download at:
+Bitcoin-Qt version 0.7.1 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.1/>
 
 This is a minor bug-fix release.

--- a/_posts/releases/2012-12-14-v0.7.2.md
+++ b/_posts/releases/2012-12-14-v0.7.2.md
@@ -1,10 +1,10 @@
 ---
 layout: releases
-title: Bitcoin version 0.7.2 released
+title: Bitcoin-Qt version 0.7.2 released
 category: releases
 version: 0.7.2
 ---
-Bitcoin version 0.7.2 is now available for download at:
+Bitcoin-Qt version 0.7.2 is now available for download at:
 <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.2/>
 
 This is a minor bug-fix release.

--- a/_posts/releases/2013-02-19-v0.8.0.md
+++ b/_posts/releases/2013-02-19-v0.8.0.md
@@ -1,6 +1,6 @@
 ---
 layout: releases
-title: Bitcoin version 0.8.0 released
+title: Bitcoin-Qt version 0.8.0 released
 category: releases
 version: 0.8.0
 ---

--- a/_posts/releases/2013-03-18-v0.8.1.md
+++ b/_posts/releases/2013-03-18-v0.8.1.md
@@ -1,6 +1,6 @@
 ---
 layout: releases
-title: Bitcoin version 0.8.1 released
+title: Bitcoin-Qt version 0.8.1 released
 category: releases
 version: 0.8.1
 ---

--- a/en/version-history.html
+++ b/en/version-history.html
@@ -1,10 +1,10 @@
 ---
 layout: base-en
 id: version-history
-title: Version history
+title: Bitcoin-Qt version history
 ---
 <div class="versiontext">
-  <h1>Version history</h1>
+  <h1>Bitcoin-Qt version history</h1>
   <ul>
   {% for post in site.categories.releases %}
     <li>


### PR DESCRIPTION
Should we apply a consistent name for Bitcoin-Qt in version history?

Right now, "Bitcoin" is what is used except in the description of the latest releases. This would probably go in the same direction than many recent efforts to differentiate the software and the protocol.
