### PR TITLE
Improve text about anonymity

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -79,8 +79,8 @@ en:
     securetext: "Bitcoin transactions are secured by military grade cryptography. Nobody can make a payment on your behalf or charge you money without having a copy of your wallet. So as long as you take the required steps to <a href=\"#secure-your-wallet#\">protect your wallet</a>, Bitcoin provides a nice level of protection against many types of fraud."
     lowfee: "Almost free to use"
     lowfeetext: "Bitcoin allows you to send and receive payments at very low cost. Except for special cases like micro-payments, there is no enforced fee. It is however recommended to pay a higher voluntary fee for faster confirmation of your transaction and to remunerate the people who operate the Bitcoin network." 
-    anonymous: "Pseudo-anonymous online payments"
-    anonymoustext: "Anonymous payments are a part of our everyday lives - most real life purchases are done without the requirement to provide proper identification. Bitcoin now introduces the same freedom to the online world. It allows you to buy services or make donations without the hassle of being passed under x-ray. However, you should note that <a href=\"#you-need-to-know#\"><b>full anonymity requires special efforts</b></a>."
+    anonymous: "Protect your identity"
+    anonymoustext: "With Bitcoin, there is no credit card number that some malicious actor can collect in order to impersonate you. In fact, it is even possible to send a payment without revealing your identity, just like with real money. You should however take note that some effort can be required to <a href=\"#you-need-to-know#\">protect your privacy</a>."
   community:
     title: "Community - Bitcoin"
     pagetitle: "Bitcoin communities"


### PR DESCRIPTION
The accuracy of the current text about pseudo-anonymity on the "Bitcoin for individuals" page is fragile as anonymity is a complex subject. This replacing text aims to improve this by focusing more on identity theft and anonymous tip / donations. And by not saying "not being passed under x-rays" and "pseudo-anonymous".
