### PR TITLE
Order vocabulary page with ICU to handle each language collation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 Installing dependencies on Ubuntu 12.10
 
-    sudo apt-get install jekyll node-less
+    sudo apt-get install jekyll node-less ruby1.9.1-dev
+    sudo gem install ffi-icu
 
 Installing dependencies on older Ubuntu and Debian distributions
 
     sudo apt-get install rubygems ruby1.9.1-dev build-essential
-    sudo gem install jekyll json less therubyracer
+    sudo gem install jekyll json less therubyracer ffi-icu
 
 # Usage
 

--- a/_plugins/alphab_for.rb
+++ b/_plugins/alphab_for.rb
@@ -1,0 +1,75 @@
+require 'yaml'
+require 'ffi-icu'
+
+#alphab_for allows to loop in an array sorted by the translated value of
+#each key using appropriate collation for the current language. Example :
+#{% alphab_for v in page.voc %}
+#  ..
+#{% endalphab_for %}
+
+module Jekyll
+  module AlphabForImpl
+    def render(context)
+      #load translations files
+      site = context.registers[:site].config
+      if !site.has_key?("loc")
+        site['loc'] = {}
+        site['langs'].each do |key,value|
+          site['loc'][key] = YAML.load_file('_translations/'+key+'.yml')[key]
+        end
+      end
+      #load collection and context variables
+      sorted_collection = collection_to_sort context
+      return if sorted_collection.empty?
+      lang = Liquid::Template.parse('{{page.lang}}').render context
+      page = Liquid::Template.parse('{{page.id}}').render context
+      #build translated array and associative hash
+      translated = []
+      assoc = {}
+      for key in sorted_collection do
+        next if !site['loc'][lang].has_key?(page) || !site['loc'][lang][page].has_key?(key) || site['loc'][lang][page][key].nil?
+        t = site['loc'][lang][page][key]
+        translated.push(t)
+        assoc[key] = t
+      end
+      #sort translated array using appropriate collation
+      translated = ICU::Collation.collate(lang, translated)
+      #recreate collection with new ordering
+      sorted_collection = []
+      for va in translated do
+        val = assoc.select{|k,v| v == va}
+        #compatibility with old ruby versions that return an Array
+        if val.is_a?(Array)
+          val = { val[0][0] => va }
+        end
+        val = val.keys[0]
+        sorted_collection.push(val)
+      end
+      #return modified array
+      original_name = @collection_name
+      result = nil
+      context.stack do
+        sorted_collection_name = "#{@collection_name}_sorted".sub('.', '_')
+        context[sorted_collection_name] = sorted_collection
+        @collection_name = sorted_collection_name
+        result = super
+        @collection_name = original_name
+      end
+      result
+    end
+  end
+ 
+  class AlphabForTag < Liquid::For
+    include AlphabForImpl
+ 
+    def collection_to_sort(context)
+      return context[@collection_name].dup
+    end
+ 
+    def end_tag
+      'endalphab_for'
+    end
+  end
+end
+ 
+Liquid::Template.register_tag('alphab_for', Jekyll::AlphabForTag)

--- a/_templates/vocabulary.html
+++ b/_templates/vocabulary.html
@@ -2,138 +2,34 @@
 layout: base
 id: vocabulary
 
-order:
-  de:
-  - id: address
-  - id: confirmation
-  - id: blockchain
-  - id: block
-  - id: btc
-  - id: doublespend
-  - id: hashrate
-  - id: cryptography
-  - id: mining
-  - id: p2p
-  - id: privatekey
-  - id: signature
-  - id: wallet
-  en:
-  - id: address
-  - id: bitcoin
-  - id: blockchain
-  - id: block
-  - id: btc
-  - id: confirmation
-  - id: cryptography
-  - id: doublespend
-  - id: hashrate
-  - id: mining
-  - id: p2p
-  - id: privatekey
-  - id: signature
-  - id: wallet
-  es:
-  - id: block
-  - id: btc
-  - id: blockchain
-  - id: confirmation
-  - id: cryptography
-  - id: address
-  - id: doublespend
-  - id: signature
-  - id: privatekey
-  - id: mining
-  - id: wallet
-  - id: p2p
-  - id: hashrate
-  fr:
-  - id: address
-  - id: bitcoin
-  - id: block
-  - id: btc
-  - id: blockchain
-  - id: confirmation
-  - id: privatekey
-  - id: cryptography
-  - id: doublespend
-  - id: mining
-  - id: p2p
-  - id: wallet
-  - id: signature
-  - id: hashrate
-  it:
-  - id: block
-  - id: blockchain
-  - id: btc
-  - id: privatekey
-  - id: confirmation
-  - id: cryptography
-  - id: doublespend
-  - id: signature
-  - id: hashrate
-  - id: address
-  - id: mining
-  - id: p2p
-  - id: wallet
-  nl:
-  - id: confirmation
-  - id: address
-  - id: blockchain
-  - id: block
-  - id: btc
-  - id: cryptography
-  - id: mining
-  - id: signature
-  - id: doublespend
-  - id: privatekey
-  - id: hashrate
-  - id: p2p
-  - id: wallet
-  pl:
-  - id: address
-  - id: bitcoin
-  - id: block
-  - id: btc
-  - id: privatekey
-  - id: cryptography
-  - id: blockchain
-  - id: p2p
-  - id: signature
-  - id: doublespend
-  - id: wallet
-  - id: confirmation
-  - id: hashrate
-  - id: mining
-  tr:
-  - id: address
-  - id: bitcoin
-  - id: blockchain
-  - id: block
-  - id: btc
-  - id: doublespend
-  - id: wallet
-  - id: privatekey
-  - id: hashrate
-  - id: signature
-  - id: cryptography
-  - id: mining
-  - id: confirmation
-  - id: p2p
+voc:
+  - address
+  - bitcoin
+  - blockchain
+  - block
+  - btc
+  - confirmation
+  - cryptography
+  - doublespend
+  - hashrate
+  - mining
+  - p2p
+  - privatekey
+  - signature
+  - wallet
 
 ---
 <h1>{% translate pagetitle %}</h1>
 <p>{% translate summary %}</p>
 <h2>{% translate table %}</h2>
 
-{% if page.order[page.lang] %}{%assign voc=page.order[page.lang]%}{%else%}{%assign voc=page.order.en%}{%endif%}
-
 <div class="index">
-{% for v in voc %}
-<a href="#{% translate {{v.id}} anchor.vocabulary %}">{% translate {{v.id}} %}</a>
-{%endfor%}
+{% alphab_for v in page.voc %}
+<a href="#{% translate {{v}} anchor.vocabulary %}">{% translate {{v}} %}</a>
+{% endalphab_for %}
 </div>
 
-{% for v in voc %}
-<h2><a name="{% translate {{v.id}} anchor.vocabulary %}">{% translate {{v.id}} %}</a></h2>
-<p>{% translate {{v.id}}txt %}</p>
-{% endfor %}
+{% alphab_for v in page.voc %}
+<h2><a name="{% translate {{v}} anchor.vocabulary %}">{% translate {{v}} %}</a></h2>
+<p>{% translate {{v}}txt %}</p>
+{% endalphab_for %}


### PR DESCRIPTION
This pull request allows alphabetical sorting to be handled automatically for each language using the ICU standard instead of using pre-ordered arrays.

This makes it much easier to manage the vocabulary page when adding / changing things in the table of content.

Using this feature adds a dependency on ffi-icu ruby gem.
