### PR TITLE
Drop text about mobiles in "Secure your wallet"

### DIFF
--- a/_templates/secure-your-wallet.html
+++ b/_templates/secure-your-wallet.html
@@ -72,8 +72,5 @@ ButterflyLabs BitSafe
 <h2>{% translate offlinemulti %}</h2>
 <p>{% translate offlinemultitxt %}</p>
 
-<h2>{% translate offlinemobile %}</h2>
-<p>{% translate offlinemobiletxt %}</p>
-
 <h2>{% translate offlinetestament %}</h2>
 <p>{% translate offlinetestamenttxt %}</p>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -286,7 +286,7 @@ en:
     backupregular: "Make regular backups"
     backupregulartxt: "You need to backup your wallet on a regular basis to make sure that all recent Bitcoin change addresses and all new Bitcoin addresses you created are included in your backup. However, all applications will be soon using wallets that only need to be backed up once."
     encrypt: "Encrypt your wallet"
-    encrypttxt: "Encrypting your wallet allows you to set a password for anyone trying to withdraw any funds. This helps protect against thieves, though it cannot protect against keylogging hardware or software."
+    encrypttxt: "Encrypting your wallet or your smartphone allows you to set a password for anyone trying to withdraw any funds. This helps protect against thieves, though it cannot protect against keylogging hardware or software."
     encryptforget: "Never forget your password"
     encryptforgettxt: "You should make sure you never forget the password or your funds will be permanently lost. Unlike your bank, there are no password recovery options with Bitcoin. In fact, you should be able to remember your password even after many years without using it. In doubt, you might want to keep a paper copy of your password in a safe place like a vault."
     encryptstrong: "Use a strong password"
@@ -304,8 +304,6 @@ en:
     hardwarewalletsoon: "As of today, no hardware wallet has entered in production but they are coming soon:"
     offlinemulti: "Multi-signature to protect against theft"
     offlinemultitxt: "Bitcoin includes a multi-signature feature that allows a transaction to require the signature of more than one private key to be spent. It is however only usable for technical users but a greater availability for this feature can be expected in the future. Multi-signature can allow an organization to give access to its treasury to its members while only allowing a withdrawal if 3 of 5 members sign the transaction. It can also allow future online wallets to share a multi-signature address with their users, so that a thief would need to compromise both your computer and the online wallet servers in order to steal your funds."
-    offlinemobile: "Small amounts on your mobile"
-    offlinemobiletxt: "A Bitcoin wallet on your phone is like a wallet with cash. If you wouldn't keep a thousand dollar in your pocket, you might want to have the same consideration for your Bitcoin wallet. You can easily add more funds at any time on your mobile. This way, you can combine security with ease of use."
     offlinetestament: "Think about your testament"
     offlinetestamenttxt: "Your bitcoins can be lost forever if you don't have a backup plan for your peers and family. If the location of your wallets or your passwords are not known by anyone when you are gone, there is no hope that your funds will ever be recovered. Taking a bit of time on these matters can make a huge difference."
   support-bitcoin:


### PR DESCRIPTION
As it seems that OS level encryption is an available feature in most today's smartphones, I think it's better to mention it explicitely and drop special text "keep small amounts on mobiles". This text was used mainly because mobile encryption wasn't built in wallet apps themselves. Current texts about backup, encryption and offline wallets already cover it all without thinking too much for the user IMO.
