### PR TITLE
Manage gems + Ruby at current stable version(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _site/
 Icon?
 ehthumbs.db
 Thumbs.db
+.bundle
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+ruby '2.0.0'
+
+group :development do
+  gem 'ffi-icu'
+  gem 'jekyll'
+  gem 'json'
+  gem 'less'
+  gem 'kramdown'
+  gem 'RedCloth'
+  gem 'therubyracer' # required by less
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,66 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    RedCloth (4.2.9)
+    classifier (1.3.3)
+      fast-stemmer (>= 1.0.0)
+    colorator (0.1)
+    commander (4.1.5)
+      highline (~> 1.6.11)
+    commonjs (0.2.7)
+    fast-stemmer (1.0.2)
+    ffi (1.9.3)
+    ffi-icu (0.1.2)
+      ffi (~> 1.0, >= 1.0.9)
+    highline (1.6.20)
+    jekyll (1.3.0)
+      classifier (~> 1.3)
+      colorator (~> 0.1)
+      commander (~> 4.1.3)
+      liquid (~> 2.5.2)
+      listen (~> 1.3)
+      maruku (~> 0.6.0)
+      pygments.rb (~> 0.5.0)
+      redcarpet (~> 2.3.0)
+      safe_yaml (~> 0.9.7)
+    json (1.8.1)
+    kramdown (1.3.3)
+    less (2.4.0)
+      commonjs (~> 0.2.7)
+    libv8 (3.16.14.3)
+    liquid (2.5.4)
+    listen (1.3.1)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      rb-kqueue (>= 0.2)
+    maruku (0.6.1)
+      syntax (>= 1.0.0)
+    posix-spawn (0.3.6)
+    pygments.rb (0.5.4)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
+    rb-fsevent (0.9.3)
+    rb-inotify (0.9.2)
+      ffi (>= 0.5.0)
+    rb-kqueue (0.2.0)
+      ffi (>= 0.5.0)
+    redcarpet (2.3.0)
+    ref (1.0.5)
+    safe_yaml (0.9.7)
+    syntax (1.0.0)
+    therubyracer (0.12.1)
+      libv8 (~> 3.16.14.0)
+      ref
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  RedCloth
+  ffi-icu
+  jekyll
+  json
+  kramdown
+  less
+  therubyracer

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-## How to participate
+## How To Participate
 
-You can report any problem or help to improve bitcoin.org by opening an issue or a [pull request](#working-with-github) on [GitHub](https://github.com/bitcoin/bitcoin.org). You can also help [translating bitcoin.org](#translation) on [Transifex](https://www.transifex.com/projects/p/bitcoinorg/).
+You can report problems or help improve bitcoin.org by opening an issue or a [pull request](#working-with-github) on [GitHub](https://github.com/bitcoin/bitcoin.org). You can also help by [translating](#translation) bitcoin.org's text on [Transifex](https://www.transifex.com/projects/p/bitcoinorg/).
 
-### Working with GitHub
+### Working With GitHub
 
 GitHub allows you to make changes to a project using git, and later submit them in a "pull request" so they can be reviewed and discussed. Many online how-tos exist so you can learn git, [here's a good one](https://www.atlassian.com/git/tutorial/git-basics).
 
-In order to use GitHub, you need to [sign up](http://github.com/signup) and [set up git](https://help.github.com/articles/set-up-git). You will also need to click the **Fork** button on the bitcoin.org [GitHub page](https://github.com/bitcoin/bitcoin.org) and clone your GitHub repository into a local directory using the following command lines:
+In order to use GitHub, you need to [sign up](http://github.com/signup) and [set up git](https://help.github.com/articles/set-up-git). You will also need to click the **Fork** button on the bitcoin.org [GitHub page](https://github.com/bitcoin/bitcoin.org) and clone your GitHub repository into a local directory with the following command lines:
 
 ```
 git clone (url provided by GitHub on your fork's page) bitcoin.org
@@ -28,7 +28,7 @@ When submitting a pull request, please take required time to discuss your change
 
 **How to make additional changes in a pull request**
 
-You simply need to push additionnal commits on the appropriate branch of your GitHub repository. That's basically the same steps as above, except you don't need to re-create the branch and the pull request.
+You simply need to push additional commits on the appropriate branch of your GitHub repository. That's basically the same steps as above, except you don't need to re-create the branch and the pull request.
 
 **How to reset and update your master branch with latest upstream changes**
 
@@ -39,44 +39,85 @@ You simply need to push additionnal commits on the appropriate branch of your Gi
 
 ### Previewing
 
-**Easy preview**: Simple text changes can be previewed live on bitcoin.org. You only need to click anywhere on the page and hold your mouse button for one second. You'll then be able to edit the page just like a document. Changes will be lost as soon as the page is refreshed.
+#### Preview Small Text Changes
 
-**Real preview**: Install [dependencies](#requirements), run jekyll (or "jekyll build" on older setups), and copy the output files from _site/ to the root of your web server. If you have no web server, run jekyll --server (or "jekyll serve" on older setups). This server requires you to add a trailing ".html" by hand in your browser address bar.
+Simple text changes can be previewed live on bitcoin.org. You only need to click anywhere on the page and hold your mouse button for one second. You'll then be able to edit the page just like a document. Changes will be lost as soon as the page is refreshed.
 
-### Requirements
+#### Build Site With Jekyll From Bundler
 
-Installing dependencies on Ubuntu 12.10
+Make sure you have ruby 2.0. If you don't, we recommend
+[installing it with RVM](https://www.digitalocean.com/community/articles/how-to-install-ruby-on-rails-on-ubuntu-14-04-using-rvm),
+which can usually be done by running the following three commands:
+
+    \curl -sSL https://get.rvm.io | bash -s stable
+    source ~/.rvm/scripts/rvm
+    rvm install ruby-2.0.0
+
+Next, you need to install bundler, and let it install all gems you need
+to build the site. You must run the last command from within your local
+bitcoin.org repository:
+
+    gem install bundler
+    bundle install
+
+Finally, you can build the website in _site/:
+
+    bundle exec jekyll build
+
+You can then copy the output files from _site/ to the root of your web server.
+If you have no web server, run `bundle exec jekyll serve` and visit
+http://127.0.0.1:4000/. This server requires you to add a trailing ".html"
+by hand in your browser address bar.
+
+#### Build Site With Jekyll From APT
+
+The instructions in the section above will ensure that you use the same
+versions of the same software we use to build the website, but you can
+also install dependencies from your Linux distribution. For example:
+
+Installing dependencies on Ubuntu 12.10:
 
     sudo apt-get install jekyll node-less ruby1.9.1-dev libicu-dev
     sudo gem install ffi-icu
 
-Installing dependencies on older Ubuntu and Debian distributions
+Installing dependencies on older Ubuntu and Debian distributions:
 
     sudo apt-get install rubygems ruby1.9.1-dev build-essential libicu-dev
     sudo gem install jekyll json less therubyracer ffi-icu
 
+Finally build the website in _site/:
+
+    jekyll
+
+...Or `jekyll build` on recent versions. You can then copy the output files
+from _site/ to the root of your web server. If you have no web server, run
+`jekyll --server` (or `jekyll serve` on recent versions) and visit
+http://127.0.0.1:4000/. This server requires you to add a trailing ".html"
+by hand in your browser address bar.
+
 ## Translation
 
-### How to translate
+### How To Translate
 
 You can join a translation team on [Transifex](https://www.transifex.com/projects/p/bitcoinorg/) and start translating or improving existing translations. Latest live previews and communications can be found on [this thread](https://bitcointalk.org/index.php?topic=349633.0).
 
 * You must be a native speaker for the language you choose to translate.
 * Please be careful to preserve the original meaning of each text.
 * Sentences and popular expressions should sound native in your language.
+* You can check the result on live previews and [test small changes](#preview-small-text-changes).
 * Translations need to be reviewed by a reviewer or coordinator before publication.
 * Once reviewed, translations can be [submitted](#import-translations) in a pull request on GitHub.
 * **In doubt, please open a discussion on Transifex with coordinators. That'll be much appreciated.**
 
-### Import translations
+### Import Translations
 
 **Update translations**: You can update the relevant language file in \_translations/ and from the root of the git repository run ./\_contrib/updatetx.rb to update layouts and templates for this language. You should also make sure that no url has been changed by translators. If any page needs to be moved, please add [redirections](#redirections).
 
 **Add a new language**: You can put the language file from Transifex in \_translations and add the language in \_config.yml in the right display order for the language bar. Make sure to review all pages and check all links.
 
-### Update english strings
+### Update English Strings
 
-Any change in the english texts can be done through a pull request on GitHub. If your changes affect the html layout of a page, you should apply fallback html code for other languages until they are updated.
+Any change in the English text can be done through a pull request on GitHub. If your changes affect the HTML layout of a page, you should apply fallback HTML code for other languages until they are updated.
 
     {% case page.lang %}
     {% when 'fr' %}
@@ -171,7 +212,7 @@ Redirections can be defined in ```_config.yml```.
   /news: /en/version-history
 ```
 
-### Aliases for contributors
+### Aliases For Contributors
 
 Aliases for contributors are defined in ```_config.yml```.
 

--- a/_config.yml
+++ b/_config.yml
@@ -109,14 +109,15 @@ aliases:
   tcatm: Nils Schneider
 
 safe:        false
-auto:        false
-server:      false
 server_port: 4000
 base-url:    /
 
 source:      .
 destination: ./_site
 plugins:     ./_plugins
+exclude:
+    - Gemfile
+    - Gemfile.lock
 
 future:      true
 lsi:         false


### PR DESCRIPTION
The current stable version of Ruby is **[2.0](https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/)**. Bitcoin.org's version, 1.9.1, has been [end-of-life'd](http://bugs.ruby-lang.org/projects/ruby/wiki/ReleaseEngineering) and is not supported.

Most popular ruby projects have also adopted [Bundler](http://bundler.io/) to simplify managing their gem dependencies. Bundler lets developers have more than one version of a gem (or of Ruby itself) on their machines without conflict.

This pull request updates bitcoin.org to Ruby 2.0.0 and encapsulates all Ruby dependencies in a `Gemfile` so that one command (`bundle install`) now downloads and install all required gems. Other than making it easier for developers to contribute, there are no changes. Any curmudgeonly developers who do _not_ wish to run modern Ruby can simply ignore the Gemfile and everything will work the same (though you really _should_ update :).

README has also been updated to reflect the change.
