### PR TITLE
Create 2014-01-25-NABC.md

### DIFF
--- a/_events/2014-01-25-NABC.md
+++ b/_events/2014-01-25-NABC.md
@@ -1,0 +1,6 @@
+---
+title: "North American Bitcoin Conference"
+city: "Miami Beach, Florida"
+country: "United States"
+link: "http://www.btcmiami.com/"
+---


### PR DESCRIPTION
Please add the North American Bitcoin Conference to the listing in the event page. The dates are January 25 - 26, 2014, it is happening at the Miami Beach Convention Centre, with major sponsors being BitPay and Doubledutch. 

Speakers at this event will be core developers, lawyers, bankers, and bitcoin entrepreneurs, covering topics from fiat money, to regulation, to startups and community engagement.

Covered here: http://bitcoinmagazine.com/8231/north-american-bitcoin-conference-set-to-shake-up-miami/
