### PR TITLE
Replace video on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ if(!langs[lang])lang='en';
 setTimeout(function(){window.location.href='/'+lang+'/';},200);
 </script>
 <p class="mainsummary">{% translate listintro %}</p>
-<div class="mainvideo"><iframe src="//www.youtube.com/embed/Um63OQz3bjo{% if page.lang != 'en' %}?cc_load_policy=1{% endif %}" frameborder="0" allowfullscreen></iframe></div>
+<div class="mainvideo"><iframe src="//www.youtube.com/embed/YEvDffKulgc{% if page.lang != 'en' %}?cc_load_policy=1{% endif %}" frameborder="0" allowfullscreen></iframe></div>
 <div class="mainlist">
   <div><div><img src="/img/main_ico_instant.svg" alt="Icon"><div>{% translate list1 %}</div></div></div>
   <div><div><img src="/img/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>


### PR DESCRIPTION
There is a proposal on [reddit](http://www.reddit.com/r/Bitcoin/comments/1rbbqk/til_why_newbies_still_download_the_bitcoinqt/cdlipbl) to change the video on the
homepage of bitcoin.org. This implements that proposal.

The rationale for this change is that the [existing video](http://www.youtube.com/watch?v=Um63OQz3bjo) 
goes into detail about mining, possibly misleading new users 
into thinking they can mine.

Possible reasons this new video is not appropriate:
1. It has an eBay logo at the end
2. It is very balanced, mentioning some negatives about bitcoin.
    Perhaps this is not appropriate on bitcoin.org
3. It says "bitcoins are fully anonymous" which may be
    misleading
