### PR TITLE
Add missing wallets names, and changed order of wallets

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -99,17 +99,6 @@ id: choose-your-wallet
 <div>
   <div>
     <div>
-      <h2>Bitcoin-Qt</h2>
-      <span><img src="/img/dow-win.png" alt="Windows" title="Windows" /><img src="/img/dow-linux.png" alt="Linux" title="Linux" /><img src="/img/dow-osx-uni.png" alt="Mac OS X" title="Mac OS X" /></span>
-      <p>{% translate walletbitcoinqt %}</p>
-      <p>{% translate walletdownload %}</p>
-    </div>
-  </div>
-  <a href="#" onclick="return false;"><img src="/img/clients/lo-bitcoin.png" alt="bitcoin-qt" />Bitcoin-Qt</a>
-</div>
-<div>
-  <div>
-    <div>
       <h2>MultiBit</h2>
       <span><img src="/img/dow-win.png" alt="Windows" title="Windows" /><img src="/img/dow-linux.png" alt="Linux" title="Linux" /><img src="/img/dow-osx-uni.png" alt="Mac OS X" title="Mac OS X" /></span>
       <p>{% translate walletmultibit %}</p>
@@ -117,6 +106,17 @@ id: choose-your-wallet
     </div>
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-multibit.png" alt="multibit" />MultiBit</a>
+</div>
+<div>
+  <div>
+    <div>
+      <h2>Bitcoin-Qt</h2>
+      <span><img src="/img/dow-win.png" alt="Windows" title="Windows" /><img src="/img/dow-linux.png" alt="Linux" title="Linux" /><img src="/img/dow-osx-uni.png" alt="Mac OS X" title="Mac OS X" /></span>
+      <p>{% translate walletbitcoinqt %}</p>
+      <p>{% translate walletdownload %}</p>
+    </div>
+  </div>
+  <a href="#" onclick="return false;"><img src="/img/clients/lo-bitcoin.png" alt="bitcoin-qt" />Bitcoin-Qt</a>
 </div>
 <div>
   <div>
@@ -236,19 +236,6 @@ id: choose-your-wallet
   <div>
     <div class="b1"></div>
     <div class="b2">
-      <h2>Bitcoin-Qt</h2>
-      <span><img src="/img/dow-win.png" alt="Windows" title="Windows" /><img src="/img/dow-linux.png" alt="Linux" title="Linux" /><img src="/img/dow-osx-uni.png" alt="Mac OS X" title="Mac OS X" /></span>
-      <p class="hyphenate">{% translate walletbitcoinqt %}</p>
-      <p>{% translate walletdownload %}</p>
-    </div>
-    <div class="b3"></div>
-  </div>
-  <a href="#" onclick="return false;"><img src="/img/clients/lo-bitcoin.png" alt="bitcoin-qt" />Bitcoin-Qt</a>
-</div>
-<div>
-  <div>
-    <div class="b1"></div>
-    <div class="b2">
       <h2>MultiBit</h2>
       <span><img src="/img/dow-win.png" alt="Windows" title="Windows" /><img src="/img/dow-linux.png" alt="Linux" title="Linux" /><img src="/img/dow-osx-uni.png" alt="Mac OS X" title="Mac OS X" /></span>
       <p class="hyphenate">{% translate walletmultibit %}</p>
@@ -257,6 +244,19 @@ id: choose-your-wallet
     <div class="b3"></div>
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-multibit.png" alt="multibit" />MultiBit</a>
+</div>
+<div>
+  <div>
+    <div class="b1"></div>
+    <div class="b2">
+      <h2>Bitcoin-Qt</h2>
+      <span><img src="/img/dow-win.png" alt="Windows" title="Windows" /><img src="/img/dow-linux.png" alt="Linux" title="Linux" /><img src="/img/dow-osx-uni.png" alt="Mac OS X" title="Mac OS X" /></span>
+      <p class="hyphenate">{% translate walletbitcoinqt %}</p>
+      <p>{% translate walletdownload %}</p>
+    </div>
+    <div class="b3"></div>
+  </div>
+  <a href="#" onclick="return false;"><img src="/img/clients/lo-bitcoin.png" alt="bitcoin-qt" />Bitcoin-Qt</a>
 </div>
 <div>
   <div>


### PR DESCRIPTION
I noticed that the names of the wallets at the bottom of the page "choose your wallet" were missing. I have added them.

I also changed the order of the wallets in order to reflect better that the default choice for beginners is MultiBit rather than BitcoinQt. It is also more consistent with the upper part of the page. 
