### PR TITLE
Enable Google Analytics temporarily

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -35,6 +35,17 @@ if(typeof(legacyIE)==='undefined'){
 }
 </script>
 {% endif %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-46627233-1', 'bitcoin.org');
+  ga('set', 'anonymizeIp', true);
+  ga('send', 'pageview');
+
+</script>
 <link rel="shortcut icon" href="/favicon.png">
 <link rel="apple-touch-icon-precomposed" href="/img/logo_ios.png"/>
 </head>


### PR DESCRIPTION
I suggest we temporarily enable Google Analytics so we can have an accurate estimation of the traffic and be able to choose a dedicated server accordingly.

I planned to keep Analytics enabled for a week, and remove it afterwhile once we have enough data, with respect to previous discussions on this matter.

A fairly good dedicated server didn't survive to bitcoin.org traffic today so it seems like most estimations underestimate the real load.
