### PR TITLE
Remove duplicate web wallets services under mobile wallets

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -70,32 +70,6 @@ id: choose-your-wallet
   <a href="#" onclick="return false;"><img src="/img/clients/lo-blockchain.png" alt="blockchain.info" /></a>
 </div>
 {% endcase %}
-<div data-id="coinbase-mobile">
-  <div class="walletwarning">
-    <div>
-      <h2>{% translate walletwebwarning %}</h2>
-      <span></span>
-      <p>{% translate walletwebwarningtxt %}</p>
-      <p><a href="#" onclick="walletShow(event);">{% translate walletwebwarningok %}</a></p>
-    </div>
-  </div>
-  <a href="#" onclick="return false;"><img src="/img/clients/lo-coinbase.png" alt="coinbase" /></a>
-</div>
-{% case page.lang %}
-{% when 'ar' or 'bg' or 'de' or 'es' or 'fa' or 'fr' or 'id' or 'it' or 'nl' or 'pl' or 'ru' or 'tr' or 'zh_CN' or 'zh_TW' %}
-{% else %}
-<div data-id="coinkite-mobile">
-  <div class="walletwarning">
-    <div>
-      <h2>{% translate walletwebwarning %}</h2>
-      <span></span>
-      <p>{% translate walletwebwarningtxt %}</p>
-      <p><a href="#" onclick="walletShow(event);">{% translate walletwebwarningok %}</a></p>
-    </div>
-  </div>
-  <a href="#" onclick="return false;"><img src="/img/clients/lo-coinkite.png" alt="coinkite" /></a>
-</div>
-{% endcase %}
 
 <h2><img class="titleicon" src="/img/ico_desktop.svg" alt="Desktop wallets" />{% translate walletdesk %}</h2>
 <p>{% translate walletdesktxt %}</p>
@@ -340,36 +314,6 @@ id: choose-your-wallet
   <a href="#" onclick="return false;"><img src="/img/clients/lo-blockchain.png" alt="blockchain.info" /></a>
 </div>
 {% endcase %}
-<div data-id="coinbase-mobile">
-  <div class="walletwarning">
-    <div class="b1"></div>
-    <div class="b2">
-      <h2>{% translate walletwebwarning %}</h2>
-      <span></span>
-      <p class="hyphenate">{% translate walletwebwarningtxt %}</p>
-      <p><a href="#" onclick="walletShow(event);">{% translate walletwebwarningok %}</a></p>
-    </div>
-    <div class="b3"></div>
-  </div>
-  <a href="#" onclick="return false;"><img src="/img/clients/lo-coinbase.png" alt="coinbase" /></a>
-</div>
-{% case page.lang %}
-{% when 'ar' or 'bg' or 'de' or 'es' or 'fa' or 'fr' or 'id' or 'it' or 'nl' or 'pl' or 'ru' or 'tr' or 'zh_CN' or 'zh_TW' %}
-{% else %}
-<div data-id="coinkite-mobile">
-  <div class="walletwarning">
-    <div class="b1"></div>
-    <div class="b2">
-      <h2>{% translate walletwebwarning %}</h2>
-      <span></span>
-      <p class="hyphenate">{% translate walletwebwarningtxt %}</p>
-      <p><a href="#" onclick="walletShow(event);">{% translate walletwebwarningok %}</a></p>
-    </div>
-    <div class="b3"></div>
-  </div>
-  <a href="#" onclick="return false;"><img src="/img/clients/lo-coinkite.png" alt="coinkite" /></a>
-</div>
-{% endcase %}
 </div>
 
 <div class="previewrow">
@@ -495,33 +439,7 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-coinbase.png" alt="coinbase" />Coinbase</a>
 </div>
-<div id="coinbase-mobile">
-  <div>
-    <div class="b1"></div>
-    <div class="b2">
-      <h2>Coinbase</h2>
-      <span></span>
-      <p class="hyphenate">{% translate walletcoinbase %}</p>
-      <p><a href="https://play.google.com/store/apps/details?id=com.coinbase.android">{% translate walletvisit %}</a></p>
-    </div>
-    <div class="b3"></div>
-  </div>
-  <a href="#" onclick="return false;"><img src="/img/clients/lo-coinbase.png" alt="coinbase" />Coinbase</a>
-</div>
 <div id="coinkite">
-  <div>
-    <div class="b1"></div>
-    <div class="b2">
-      <h2>Coinkite</h2>
-      <span></span>
-      <p class="hyphenate">{% translate walletcoinkite %}</p>
-      <p><a href="https://coinkite.com/">{% translate walletvisit %}</a></p>
-    </div>
-    <div class="b3"></div>
-  </div>
-  <a href="#" onclick="return false;"><img src="/img/clients/lo-coinkite.png" alt="coinkite" />Coinkite</a>
-</div>
-<div id="coinkite-mobile">
   <div>
     <div class="b1"></div>
     <div class="b2">

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -109,7 +109,7 @@ en:
     walletmobi: "Mobile wallets"
     walletmobitxt: "Mobile wallets allow you to bring Bitcoin with you in your pocket. You can exchange coins easily and pay in physical stores by scanning a QR code or using NFC \"tap to pay\"."
     walletweb: "Web wallets"
-    walletwebtxt: "Web wallets allow you to use Bitcoin anywhere with less effort to protect your wallet. However, you must choose your web wallet with care as they host your bitcoins."
+    walletwebtxt: "Web wallets allow you to use Bitcoin on any browser or mobile and often offer additional services. However, you must choose your web wallet with care as they host your bitcoins."
     walletbitcoinqt: "Bitcoin-Qt is a full Bitcoin client and builds the backbone of the network. It offers the highest levels of security, privacy, and stability. However, it has fewer features and it takes a lot of space and memory."
     walletmultibit: "MultiBit is a lightweight client that focuses on being fast and easy to use. It synchronizes with the network and is ready to use in minutes. MultiBit also supports many languages. It is a good choice for non-technical users."
     walletarmory: "Armory is an advanced Bitcoin client that expands its features for Bitcoin power users. It offers many backup and encryption features, and it allows secure cold-storage on offline computers."


### PR DESCRIPTION
Live preview: (Merged)

I think duplicate listing is confusing and should be reduced. All web wallets work on "Desktop" and "Mobiles" but it doesn't make sense to list them in all sub-categories.

I suggest that only minimally standalone apps ( able to store / backup private keys and sign transactions locally ) should be displayed under Desktop and Mobiles sections. This pull req also updates the Web wallets text to mention that they work on browsers and mobiles.
