### PR TITLE
Correctly associate quote.

### DIFF
--- a/en/press.html
+++ b/en/press.html
@@ -273,7 +273,7 @@ dialogs:
 <div>
 <p><span>{{ page.dialogs.quotechrisdixon }}</span><span>Chris Dixon, Technology Investor</span></p>
 <p><span>{{ page.dialogs.quotewencescasares }}</span><span>Wences Casares, Technology Entrepreneur</span></p>
-<p><span>{{ page.dialogs.quotetonygallippi }}</span><span>Tony Gallippi, BitInstant CEO</span></p>
+<p><span>{{ page.dialogs.quotetonygallippi }}</span><span>Tony Gallippi, BitPay CEO</span></p>
 <p><span>{{ page.dialogs.quotedankaminsky }}</span><span>Dan Kaminsky, Security Researcher</span></p>
 <p><span>{{ page.dialogs.quotejeremyliew }}</span><span>Jeremy Liew, Lightspeed Venture Partners</span></p>
 <p><span>{{ page.dialogs.quotejohndonohoe }}</span>John Donohoe, Ebay CEO<span></span></p>


### PR DESCRIPTION
One of the attributions in the quotes section was incorrectly associated.
