### PR TITLE
Added visual separator between wallet types on choose-your-wallet page

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -758,8 +758,13 @@ li p{
 	float:left;
 	width:255px;
 	text-align:left;
-	padding-left:40px;
+	padding-left:16px;
+	padding-right:15px;
 	position:relative;
+}
+.previewrow:nth-child(2){
+	border-left:1px solid #ccc;
+	border-right:1px solid #ccc;
 }
 .previewrow>h2{
 	font-size:115%;


### PR DESCRIPTION
It took me a minute to understand why blockchain.info's icon was on the "choose your wallet" page twice, and I also remember wondering whether it'd be clear to users that some downloads are not desktop applications. I only understood once I saw the text above the icons.

Since many people don't read the all the text on a page (especially a page leading to downloads, and I came here looking for the bitcoin-qt download), I think this visual hint, separating the different types with a gray line, makes it clearer that there is not only the choice of which wallet to use but also different types of wallets.

Screenshot of change (to compare with bitcoin.org/en/choose-your-wallet): http://i.imgur.com/PcCqIEO.png

I'm not that experienced with Github and how appropriate it is to do pull requests for such a small change, but I think it will help users so I'd like to contribute the change anyway. Thanks!
