### PR TITLE
Add links to relevant local resources

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -9,6 +9,7 @@ id: community
 <div>
   <div>
     <h2><img src="/img/ico_invoice.svg" class="titleicon" alt="Icon">{% translate forums %}</h2>
+    {% if page.lang == 'bg' %}<p><a href="http://hash.bg/forum/">Hash.bg</a></p>{% endif %}
     {% if page.lang == 'es' %}<p><a href="http://www.forobtc.com/">Foro Bitcoin en Español</a></p>{% endif %}
     {% if page.lang == 'pl' %}<p><a href="https://forum.bitcoin.pl/">Polski portal bitcoin.pl</a></p>{% endif %}
     <p>{% translate bitcointalk %}</p>

--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -24,6 +24,9 @@ id: resources
 <div>
   <div>
     <h2><img src="/img/ico_spread.svg" class="titleicon" alt="Icon">{% translate news %}</h2>
+    {% if page.lang == 'bg' %}<p><a href="http://hash.bg/">Hash.bg</a></p>{% endif %}
+    {% if page.lang == 'fr' %}<p><a href="http://francebitcoin.com/">France Bitcoin</a></p>{% endif %}
+    {% if page.lang == 'ru' %}<p><a href="http://btcrussia.ru/">BTCRussia</a></p>{% endif %}
     <p><a href="http://www.coindesk.com/">CoinDesk</a></p>
     <p><a href="http://bitcoinmagazine.com/">Bitcoin Magazine</a></p>
     <p><a href="https://bitcointalk.org/index.php?board=77.0">Bitcoin Forum / Press</a></p>


### PR DESCRIPTION
Bitcoin.org contextually links to relevant local resources (news, IRC channels, forums, etc) for each language ( instead of just linking to English resources ).

This pull request adds links to three additional suggested resources. As far as I looked, their content seems good and useful.

bg: hash.bg
fr: francebitcoin.com
ru: btcrussia.ru
