### PR TITLE
Fix a broken download link to the OSX client

### DIFF
--- a/_templates/download.html
+++ b/_templates/download.html
@@ -66,7 +66,7 @@ case 'ubuntu':
 break;
 case 'mac':
   but.getElementsByTagName('IMG')[0].src='/img/but_mac.svg';
-  but.href='/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-macosx.dmg';
+  but.href='/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-macosx-setup.dmg';
 break;
 }
 </script>


### PR DESCRIPTION
On https://bitcoin.org/en/download the OSX link is https://bitcoin.org/bin/0.9.1/bitcoin-0.9.1-macosx-setup.dmg but the big Download button points to https://bitcoin.org/bin/0.9.1/bitcoin-0.9.1-macosx.dmg which is a 404
