### PR TITLE
Add Event, WIRED Money in London, England.

### DIFF
--- a/_events/2014-07-01-wired-money.md
+++ b/_events/2014-07-01-wired-money.md
@@ -1,0 +1,9 @@
+---
+date: 2014-07-01
+title: "WIRED Money"
+venue: "Level39"
+address: "One Canada Square"
+city: "London"
+country: "England"
+link: "http://www.wiredevent.co.uk/wired-money-2014"
+---


### PR DESCRIPTION
This event is being organized by WIRED magazine (http://www.wired.co.uk/).
