### PR TITLE
Add complete release notes

### DIFF
--- a/_releases/2012-03-30-v0.6.0.md
+++ b/_releases/2012-03-30-v0.6.0.md
@@ -2,11 +2,177 @@
 title: Bitcoin-Qt version 0.6.0 released
 ---
 Bitcoin-Qt version 0.6.0 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.0/>
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.0/>
 
-This release includes many bug fixes, performance improvements and new
-features over version 0.5.0, and we recommend that everybody upgrade.
+This release includes more than 20 language localizations.
+More translations are welcome; join the
+project at Transifex to help:
+  <https://www.transifex.net/projects/p/bitcoin/>
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
 
+Project source code is hosted at github; we are no longer
+distributing .tar.gz files here, you can get them
+directly from github:
+ <https://github.com/bitcoin/bitcoin/tarball/v0.6.0>  # .tar.gz
+ <https://github.com/bitcoin/bitcoin/zipball/v0.6.0>  # .zip
+
+For Ubuntu users, there is a ppa maintained by Matt Corallo which
+you can add to your system so that it will automatically keep
+bitcoin up-to-date.  Just type
+ sudo apt-add-repository ppa:bitcoin/bitcoin
+in your terminal, then install the bitcoin-qt package.
+
+
+KNOWN ISSUES
+------------
+
+Shutting down while synchronizing with the network
+(downloading the blockchain) can take more than a minute,
+because database writes are queued to speed up download
+time.
+
+
+NEW FEATURES SINCE BITCOIN VERSION 0.5
+--------------------------------------
+
+Initial network synchronization should be much faster
+(one or two hours on a typical machine instead of ten or more
+hours).
+
+Backup Wallet menu option.
+
+Bitcoin-Qt can display and save QR codes for sending
+and receiving addresses.
+
+New context menu on addresses to copy/edit/delete them.
+
+New Sign Message dialog that allows you to prove that you
+own a bitcoin address by creating a digital
+signature.
+
+New wallets created with this version will
+use 33-byte 'compressed' public keys instead of
+65-byte public keys, resulting in smaller
+transactions and less traffic on the bitcoin
+network. The shorter keys are already supported
+by the network but wallet.dat files containing
+short keys are not compatible with earlier
+versions of Bitcoin-Qt/bitcoind.
+
+New command-line argument -blocknotify=<command>
+that will spawn a shell process to run <command> 
+when a new block is accepted.
+
+New command-line argument -splash=0 to disable
+Bitcoin-Qt's initial splash screen
+
+validateaddress JSON-RPC api command output includes
+two new fields for addresses in the wallet:
+ pubkey : hexadecimal public key
+ iscompressed : true if pubkey is a short 33-byte key
+
+New JSON-RPC api commands for dumping/importing
+private keys from the wallet (dumprivkey, importprivkey).
+
+New JSON-RPC api command for getting information about
+blocks (getblock, getblockhash).
+
+New JSON-RPC api command (getmininginfo) for getting
+extra information related to mining. The getinfo
+JSON-RPC command no longer includes mining-related
+information (generate/genproclimit/hashespersec).
+
+
+
+NOTABLE CHANGES
+---------------
+
+BIP30 implemented (security fix for an attack involving
+duplicate "coinbase transactions").
+
+The -nolisten, -noupnp and -nodnsseed command-line
+options were renamed to -listen, -upnp and -dnsseed,
+with a default value of 1. The old names are still
+supported for compatibility (so specifying -nolisten
+is automatically interpreted as -listen=0; every
+boolean argument can now be specified as either
+-foo or -nofoo).
+
+The -noirc command-line options was renamed to
+-irc, with a default value of 0. Run -irc=1 to
+get the old behavior.
+
+Three fill-up-available-memory denial-of-service
+attacks were fixed.
+
+NOT YET IMPLEMENTED FEATURES
+----------------------------
+
+Support for clicking on bitcoin: URIs and
+opening/launching Bitcoin-Qt is available only on Linux,
+and only if you configure your desktop to launch
+Bitcoin-Qt. All platforms support dragging and dropping
+bitcoin: URIs onto the Bitcoin-Qt window to start
+payment.
+
+
+PRELIMINARY SUPPORT FOR MULTISIGNATURE TRANSACTIONS
+---------------------------------------------------
+
+This release has preliminary support for multisignature
+transactions-- transactions that require authorization
+from more than one person or device before they
+will be accepted by the bitcoin network.
+
+Prior to this release, multisignature transactions
+were considered 'non-standard' and were ignored;
+with this release multisignature transactions are
+considered standard and will start to be relayed
+and accepted into blocks.
+
+It is expected that future releases of Bitcoin-Qt
+will support the creation of multisignature transactions,
+once enough of the network has upgraded so relaying
+and validating them is robust.
+
+For this release, creation and testing of multisignature
+transactions is limited to the bitcoin test network using
+the "addmultisigaddress" JSON-RPC api call.
+
+Short multisignature address support is included in this
+release, as specified in BIP 13 and BIP 16.
+
+
+Thanks to everybody who contributed to this release:
+
+- Alex B
+- Alistair Buxton
+- Chris Moore
+- Clark Gaebel
+- Daniel Folkinshteyn
+- Dylan Noblesmith
+- Forrest Voight
+- Gavin Andresen
+- Gregory Maxwell
+- Janne Pulkkinen
+- Joel Kaartinen
+- Lars Rasmusson
+- Luke Dashjr
+- Matt Corallo
+- Michael Ford
+- Michael Hendricks
+- Nick Bosma
+- Nils Schneider
+- Philip Kaufmann
+- Pierre Pronchery
+- Pieter Wuille
+- Rune K Svendsen
+- Wladimir J. van der Laan
+- coderrr
+- p2k
+- sje397
+
+Special thanks to Sergio Lerner and Matt Corallo for bringing
+potential denial-of-service attacks to our attention.

--- a/_releases/2012-05-04-v0.6.1.md
+++ b/_releases/2012-05-04-v0.6.1.md
@@ -2,10 +2,67 @@
 title: Bitcoin-Qt version 0.6.1 released
 ---
 Bitcoin-Qt version 0.6.1 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.1/>
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.1/>
 
 This is a bug-fix and code-cleanup release, with no major new features.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+NOTABLE CHANGES
+===============
 
+Much faster shutdowns. However, the blkindex.dat file is no longer
+portable to different data directories by default. If you need a
+portable blkindex.dat file then run with the new -detachdb=1 option
+or the "Detach databases at shutdown" GUI preference.
+
+Mac and Windows binaries are compiled against OpenSSL 1.0.1b (Linux
+binaries are dynamically linked to the version of OpenSSL on the system).
+
+
+CHANGE SUMMARY
+==============
+
+Use 'git shortlog --no-merges v0.6.0..' for a summary of this release.
+
+Source codebase changes:
+- Many source code cleanups and warnings fixes.  Close to building with -Wall
+- Locking overhaul, and several minor locking fixes
+- Several source code portability fixes, e.g. FreeBSD
+
+JSON-RPC interface changes:
+- addmultisigaddress enabled for mainnet (previously only enabled for testnet)
+
+Network protocol changes:
+- protocol version 60001
+- added nonce value to "ping" message (BIP 31)
+- added new "pong" message (BIP 31)
+
+Backend storage changes:
+- Less redundant database flushing, especially during initial block download
+- Shutdown improvements (see above)
+
+Qt user interface:
+- minor URI handling improvements
+- progressbar improvements
+- error handling improvements (show message box rather than console exception,
+  etc.)
+- by popular request, make 4th bar of connection icon green
+
+
+
+Thanks to everybody who contributed to this release:
+
+- Chris Moore
+- Dwayne C. Litzenberger
+- Gavin Andresen
+- Jeff Garzik
+- Luke Dashjr
+- Matt Corallo
+- Philip Kaufmann
+- Pieter Wuille
+- R E Broadley
+- Timothy Redaelli
+- Wladimir J. van der Laan
+- cardpuncher
+- freewil
+- graingert
+- sje397

--- a/_releases/2012-05-08-v0.6.2.md
+++ b/_releases/2012-05-08-v0.6.2.md
@@ -2,10 +2,70 @@
 title: Bitcoin-Qt version 0.6.2 released
 ---
 Bitcoin-Qt version 0.6.2 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.2/>
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.2/>
 
-This is a bug-fix release with no major new features.
+This is a bug-fix and code-cleanup release, with no major new features.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+NOTABLE CHANGES
+===============
 
+Much faster shutdowns. However, the blkindex.dat file is no longer
+portable to different data directories by default. If you need a
+portable blkindex.dat file then run with the new -detachdb=1 option
+or the "Detach databases at shutdown" GUI preference.
+
+Fixed <https://github.com/bitcoin/bitcoin/issues/1065>, a bug that
+could cause long-running nodes to crash.
+
+Mac and Windows binaries are compiled against OpenSSL 1.0.1b (Linux
+binaries are dynamically linked to the version of OpenSSL on the system).
+
+
+CHANGE SUMMARY
+==============
+
+Use 'git shortlog --no-merges v0.6.0..' for a summary of this release.
+
+Source codebase changes:
+- Many source code cleanups and warnings fixes.  Close to building with -Wall
+- Locking overhaul, and several minor locking fixes
+- Several source code portability fixes, e.g. FreeBSD
+
+JSON-RPC interface changes:
+- addmultisigaddress enabled for mainnet (previously only enabled for testnet)
+
+Network protocol changes:
+- protocol version 60001
+- added nonce value to "ping" message (BIP 31)
+- added new "pong" message (BIP 31)
+
+Backend storage changes:
+- Less redundant database flushing, especially during initial block download
+- Shutdown improvements (see above)
+
+Qt user interface:
+- minor URI handling improvements
+- progressbar improvements
+- error handling improvements (show message box rather than console exception,
+  etc.)
+- by popular request, make 4th bar of connection icon green
+
+
+
+Thanks to everybody who contributed to this release:
+
+- Chris Moore
+- Dwayne C. Litzenberger
+- Gavin Andresen
+- Jeff Garzik
+- Luke Dashjr
+- Matt Corallo
+- Philip Kaufmann
+- Pieter Wuille
+- R E Broadley
+- Timothy Redaelli
+- Wladimir J. van der Laan
+- cardpuncher
+- freewil
+- graingert
+- sje397

--- a/_releases/2012-06-25-v0.6.3.md
+++ b/_releases/2012-06-25-v0.6.3.md
@@ -2,10 +2,48 @@
 title: Bitcoin-Qt version 0.6.3 released
 ---
 Bitcoin-Qt version 0.6.3 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.3/>
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.3/>
 
-This is a bug-fix release with no new features.
+This is a bug-fix release, with no new features.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+CHANGE SUMMARY
+==============
 
+Fixed a serious denial-of-service attack that could cause the
+bitcoin process to become unresponsive. Thanks to Sergio Lerner
+for finding and responsibly reporting the problem. (CVE-2012-3789)
+
+Optimized the process of checking transaction signatures, to
+speed up processing of new block messages and make propagating
+blocks across the network faster.
+
+Fixed an obscure bug that could cause the bitcoin process to get
+stuck on an invalid block-chain, if the invalid chain was
+hundreds of blocks long.
+
+Bitcoin-Qt no longer automatically selects the first address
+in the address book (Issue #1384).
+
+Fixed minimize-to-dock behavior of Bitcon-Qt on the Mac.
+
+Added a block checkpoint at block 185,333 to speed up initial
+blockchain download.
+
+
+Thanks to everybody who contributed to this release:
+====================================================
+
+- Chris Moore
+- Christian von Roques
+- Fordy
+- Gavin Andresen
+- Jeff Garzik
+- Luke Dashjr
+- Matt Corallo
+- Michael Hendricks
+- Peter Todd
+- Philip Kaufmann
+- Pieter Wuille
+- R E Broadley
+- Sergio Lerner
+- Wladimir J. van der Laan

--- a/_releases/2012-09-17-v0.7.0.md
+++ b/_releases/2012-09-17-v0.7.0.md
@@ -2,11 +2,133 @@
 title: Bitcoin-Qt version 0.7.0 released
 ---
 Bitcoin-Qt version 0.7.0 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.0/>
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.0/>
 
 We recommend that everybody running prior versions of bitcoind/Bitcoin-Qt
-upgrade to this release.
+upgrade to this release, except for users running Mac OSX 10.5.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
 
+Project source code is hosted at github; you can get
+source-only tarballs/zipballs directly from there:
+  <https://github.com/bitcoin/bitcoin/tarball/v0.7.0>  # .tar.gz
+  <https://github.com/bitcoin/bitcoin/zipball/v0.7.0>  # .zip
+
+Ubuntu Linux users can use the "Personal Package Archive" (PPA)
+maintained by Matt Corallo to automatically keep 
+bitcoin up-to-date.  Just type
+  sudo apt-add-repository ppa:bitcoin/bitcoin
+  sudo apt-get update
+in your terminal, then install the bitcoin-qt package:
+  sudo apt-get install bitcoin-qt
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you were running on Linux with a version that might have been compiled
+with a different version of Berkeley DB (for example, if you were using the
+PPA and are switching to the binary release), then run the old version again
+with the -detachdb argument and shut it down; if you do not, then the new
+version will not be able to read the database files and will exit with an error.
+
+Incompatible Changes
+--------------------
+* Replaced the 'getmemorypool' RPC command with 'getblocktemplate/submitblock'
+  and 'getrawmempool' commands.
+* Remove deprecated RPC 'getblocknumber'
+
+Bitcoin Improvement Proposals implemented
+-----------------------------------------
+BIP 22 - 'getblocktemplate', 'submitblock' RPCs
+BIP 34 - block version 2, height in coinbase
+BIP 35 - 'mempool' message, extended 'getdata' message behavior
+
+
+Core bitcoin handling and blockchain database
+---------------------------------------------
+* Reduced CPU usage, by eliminating some redundant hash calculations
+* Cache signature verifications, to eliminate redundant signature checks
+* Transactions with zero-value outputs are considered non-standard
+* Mining: when creating new blocks, sort 'paid' area by fee-per-kb
+* Database: better validation of on-disk stored data
+* Database: minor optimizations and reliability improvements
+* -loadblock=FILE will import an external block file
+* Additional DoS (denial-of-service) prevention measures
+* New blockchain checkpoint at block 193,000
+
+
+JSON-RPC API
+------------
+* Internal HTTP server is now thread-per-connection, rather than
+  a single-threaded queue that would stall on network I/O.
+* Internal HTTP server supports HTTP/1.1, pipelined requests and
+  connection keep-alive.
+* Support JSON-RPC 2.0 batches, to encapsulate multiple JSON-RPC requests
+  within a single HTTP request.
+* IPv6 support
+* Added raw transaction API.  See https://gist.github.com/2839617
+* Added 'getrawmempool', to list contents of TX memory pool
+* Added 'getpeerinfo', to list data about each connected network peer
+* Added 'listaddressgroupings' for better coin control
+* Rework getblock call.
+* Remove deprecated RPC 'getblocknumber'
+* Remove superceded RPC 'getmemorypool' (see BIP 22, above)
+* listtransactions output now displays "smart" times for transactions,
+  and 'blocktime' and 'timereceived' fields were added
+
+
+P2P networking
+--------------
+* IPv6 support
+* Tor hidden service support (see doc/Tor.txt)
+* Attempts to fix "stuck blockchain download" problems
+* Replace BDB database "addr.dat" with internally-managed "peers.dat"
+  file containing peer address data.
+* Lower default send buffer from 10MB to 1MB
+* proxy: SOCKS5 by default
+* Support connecting by hostnames passed to proxy
+* Add -seednode connections, and use this instead of DNS seeds when proxied
+* Added -externalip and -discover
+* Add -onlynet to connect only to a given network (IPv4, IPv6, or Tor)
+* Separate listening sockets, -bind=<addr>
+
+
+Qt GUI
+------
+* Add UI RPC console / debug window
+* Re-Enable URI handling on Windows, add safety checks and tray-notifications
+* Harmonize the use of ellipsis ("...") to be used in menus, but not on buttons
+* Add 2 labels to the overviewpage that display Wallet and Transaction status (obsolete or current)
+* Extend the optionsdialog (e.g. language selection) and re-work it to a tabbed UI
+* Merge sign/verify message into a single window with tabbed UI
+* Ensure a changed bitcoin unit immediately updates all GUI elements that use units
+* Update QR Code dialog
+* Improve error reporting at startup
+* Fine-grained UI updates for a much smoother UI during block downloads
+* Remove autocorrection of 0/i in addresses in UI
+* Reorganize tray icon menu into more logical order
+* Persistently poll for balance change when number of blocks changed
+* Much better translations
+* Override progress bar design on platforms with segmented progress bars to assist with readability
+* Added 'immature balance' display on the overview page
+* (Windows only): enable ASLR and DEP for bitcoin-qt.exe
+* (Windows only): add meta-data to bitcoin-qt.exe (e.g. description)
+
+Internal codebase
+-----------------
+* Additional unit tests
+* Compile warning fixes
+
+
+Miscellaneous
+-------------
+* Reopen debug.log upon SIGHUP
+* Bash programmable completion for bitcoind(1)
+* On supported OS's, each thread is given a useful name

--- a/_releases/2012-10-19-v0.7.1.md
+++ b/_releases/2012-10-19-v0.7.1.md
@@ -1,11 +1,113 @@
 ---
 title: Bitcoin-Qt version 0.7.1 released
 ---
-Bitcoin-Qt version 0.7.1 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.1/>
+Bitcoin-Qt version 0.7.1 is now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.1/>
 
-This is a minor bug-fix release.
+This is a bug-fix minor release.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
 
+Project source code is hosted at github; you can get
+source-only tarballs/zipballs directly from there:
+  <https://github.com/bitcoin/bitcoin/tarball/v0.7.1>  # .tar.gz
+  <https://github.com/bitcoin/bitcoin/zipball/v0.7.1>  # .zip
+
+Ubuntu Linux users can use the "Personal Package Archive" (PPA)
+maintained by Matt Corallo to automatically keep 
+up-to-date.  Just type:
+  sudo apt-add-repository ppa:bitcoin/bitcoin
+  sudo apt-get update
+in your terminal, then install the bitcoin-qt package:
+  sudo apt-get install bitcoin-qt
+
+KNOWN ISSUES
+------------
+
+Mac OSX 10.5 is no longer supported.
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you were running on Linux with a version that might have been compiled
+with a different version of Berkeley DB (for example, if you were using an
+Ubuntu PPA version), then run the old version again with the -detachdb
+argument and shut it down; if you do not, then the new version will not
+be able to read the database files and will exit with an error.
+
+Explanation of -detachdb (and the new "stop true" RPC command):
+The Berkeley DB database library stores data in both ".dat" and
+"log" files, so the database is always in a consistent state,
+even in case of power failure or other sudden shutdown. The
+format of the ".dat" files is portable between different
+versions of Berkeley DB, but the "log" files are not-- even minor
+version differences may have incompatible "log" files. The
+-detachdb option moves any pending changes from the "log" files
+to the "blkindex.dat" file for maximum compatibility, but makes
+shutdown much slower. Note that the "wallet.dat" file is always
+detached, and versions prior to 0.6.0 detached all databases
+at shutdown.
+
+New features
+------------
+
+* Added a boolean argument to the RPC 'stop' command, if true sets
+  -detachdb to create standalone database .dat files before shutting down.
+
+* -salvagewallet command-line option, which moves any existing wallet.dat
+  to wallet.{timestamp}.dat and then attempts to salvage public/private
+  keys and master encryption keys (if the wallet is encrypted) into
+  a new wallet.dat. This should only be used if your wallet becomes
+  corrupted, and is not intended to replace regular wallet backups.
+
+* Import $DataDir/bootstrap.dat automatically, if it exists.
+
+Dependency changes
+------------------
+
+* Qt 4.8.2 for Windows builds
+
+* openssl 1.0.1c
+
+Bug fixes
+---------
+
+* Clicking on a bitcoin: URI on Windows should now launch Bitcoin-Qt properly.
+
+* When running -testnet, use RPC port 18332 by default.
+
+* Better detection and handling of corrupt wallet.dat and blkindex.dat files.
+  Previous versions would crash with a DB_RUNRECOVERY exception, this
+  version detects most problems and tells you how to recover if it
+  cannot recover itself.
+
+* Fixed an uninitialized variable bug that could cause transactions to
+  be reported out of order.
+
+* Fixed a bug that could cause occasional crashes on exit.
+
+* Warn the user that they need to create fresh wallet backups after they
+  encrypt their wallet.
+
+----------------------------------------------------
+Thanks to everybody who contributed to this release:
+
+- Gavin Andresen
+- Jeff Garzik
+- Luke Dashjr
+- Mark Friedenbach
+- Matt Corallo
+- Philip Kaufmann
+- Pieter Wuille
+- Rune K. Svendsen
+- Virgil Dupras
+- Wladimir J. van der Laan
+- fanquake
+- kjj2
+- xanatos

--- a/_releases/2012-12-14-v0.7.2.md
+++ b/_releases/2012-12-14-v0.7.2.md
@@ -1,11 +1,72 @@
 ---
 title: Bitcoin-Qt version 0.7.2 released
 ---
-Bitcoin-Qt version 0.7.2 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.2/>
+Bitcoin-Qt version 0.7.2 is now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.2>
 
-This is a minor bug-fix release.
+This is a bug-fix minor release.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you were running on Linux with a version that might have been compiled
+with a different version of Berkeley DB (for example, if you were using an
+Ubuntu PPA version), then run the old version again with the -detachdb
+argument and shut it down; if you do not, then the new version will not
+be able to read the database files and will exit with an error.
+
+Explanation of -detachdb (and the new "stop true" RPC command):
+The Berkeley DB database library stores data in both ".dat" and
+"log" files, so the database is always in a consistent state,
+even in case of power failure or other sudden shutdown. The
+format of the ".dat" files is portable between different
+versions of Berkeley DB, but the "log" files are not-- even minor
+version differences may have incompatible "log" files. The
+-detachdb option moves any pending changes from the "log" files
+to the "blkindex.dat" file for maximum compatibility, but makes
+shutdown much slower. Note that the "wallet.dat" file is always
+detached, and versions prior to 0.6.0 detached all databases
+at shutdown.
+
+Bug fixes
+---------
+
+* Prevent RPC 'move' from deadlocking. This was caused by trying to lock the
+  database twice.
+
+* Fix use-after-free problems in initialization and shutdown, the latter of
+  which caused Bitcoin-Qt to crash on Windows when exiting.
+
+* Correct library linking so building on Windows natively works.
+
+* Avoid a race condition and out-of-bounds read in block creation/mining code.
+
+* Improve platform compatibility quirks, including fix for 100% CPU utilization
+  on FreeBSD 9.
+
+* A few minor corrections to error handling, and updated translations.
+
+* OSX 10.5 supported again
+
+----------------------------------------------------
+Thanks to everybody who contributed to this release:
+
+- Alex
+- dansmith
+- Gavin Andresen
+- Gregory Maxwell
+- Jeff Garzik
+- Luke Dashjr
+- Philip Kaufmann
+- Pieter Wuille
+- Wladimir J. van der Laan
+- grimd34th
 

--- a/_releases/2013-02-19-v0.8.0.md
+++ b/_releases/2013-02-19-v0.8.0.md
@@ -1,12 +1,142 @@
 ---
 title: Bitcoin-Qt version 0.8.0 released
 ---
-Bitcoin-Qt version 0.8.0 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.0/>
+Bitcoin-Qt version 0.8.0 are now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.0/>
 
 This is a major release designed to improve performance and handle the
 increasing volume of transactions on the network.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
 
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+The first time you run after the upgrade a re-indexing process will be
+started that will take anywhere from 30 minutes to several hours,
+depending on the speed of your machine.
+
+Incompatible Changes
+--------------------
+
+This release no longer maintains a full index of historical transaction ids
+by default, so looking up an arbitrary transaction using the getrawtransaction
+RPC call will not work. If you need that functionality, you must run once
+with -txindex=1 -reindex=1 to rebuild block-chain indices (see below for more
+details).
+
+Improvements
+------------
+
+Mac and Windows binaries are signed with certificates owned by the Bitcoin
+Foundation, to be compatible with the new security features in OSX 10.8 and
+Windows 8.
+
+LevelDB, a fast, open-source, non-relational database from Google, is
+now used to store transaction and block indices.  LevelDB works much better
+on machines with slow I/O and is faster in general. Berkeley DB is now only
+used for the wallet.dat file (public and private wallet keys and transactions
+relevant to you).
+
+Pieter Wuille implemented many optimizations to the way transactions are
+verified, so a running, synchronized node uses less working memory and does
+much less I/O. He also implemented parallel signature checking, so if you
+have a multi-CPU machine all CPUs will be used to verify transactions.
+
+New Features
+------------
+
+"Bloom filter" support in the network protocol for sending only relevant transactions to
+lightweight clients.
+
+contrib/verifysfbinaries is a shell-script to verify that the binary downloads
+at sourceforge have not been tampered with. If you are able, you can help make
+everybody's downloads more secure by running this occasionally to check PGP
+signatures against download file checksums.
+
+contrib/spendfrom is a python-language command-line utility that demonstrates
+how to use the "raw transactions" JSON-RPC api to send coins received from particular
+addresses (also known as "coin control").
+
+New/changed settings (command-line or bitcoin.conf file)
+--------------------------------------------------------
+
+dbcache : controls LevelDB memory usage.
+
+par : controls how many threads to use to validate transactions. Defaults to the number
+of CPUs on your machine, use -par=1 to limit to a single CPU.
+
+txindex : maintains an extra index of old, spent transaction ids so they will be found
+by the getrawtransaction JSON-RPC method.
+
+reindex : rebuild block and transaction indices from the downloaded block data.
+
+New JSON-RPC API Features
+-------------------------
+
+lockunspent / listlockunspent allow locking transaction outputs for a period of time so
+they will not be spent by other processes that might be accessing the same wallet.
+
+addnode / getaddednodeinfo methods, to connect to specific peers without restarting.
+
+importprivkey now takes an optional boolean parameter (default true) to control whether
+or not to rescan the blockchain for transactions after importing a new private key.
+
+Important Bug Fixes
+-------------------
+
+Privacy leak: the position of the "change" output in most transactions was not being
+properly randomized, making network analysis of the transaction graph to identify
+users' wallets easier. 
+
+Zero-confirmation transaction vulnerability: accepting zero-confirmation transactions
+(transactions that have not yet been included in a block) from somebody you do not
+trust is still not recommended, because there will always be ways for attackers to
+double-spend zero-confirmation transactions. However, this release includes a bug
+fix that makes it a little bit more difficult for attackers to double-spend a
+certain type ("lockTime in the future") of zero-confirmation transaction.
+
+Dependency Changes
+------------------
+
+Qt 4.8.3 (compiling against older versions of Qt 4 should continue to work)
+
+
+Thanks to everybody who contributed to this release:
+----------------------------------------------------
+
+- Alexander Kjeldaas
+- Andrey Alekseenko
+- Arnav Singh
+- Christian von Roques
+- Eric Lombrozo
+- Forrest Voight
+- Gavin Andresen
+- Gregory Maxwell
+- Jeff Garzik
+- Luke Dashjr
+- Matt Corallo
+- Mike Cassano
+- Mike Hearn
+- Peter Todd
+- Philip Kaufmann
+- Pieter Wuille
+- Richard Schwab
+- Robert Backhaus
+- Rune K. Svendsen
+- Sergio Demian Lerner
+- Wladimir J. van der Laan
+- burger2
+- default
+- fanquake
+- grimd34th
+- justmoon
+- redshark1802
+- tucenaber
+- xanatos

--- a/_releases/2013-03-18-v0.8.1.md
+++ b/_releases/2013-03-18-v0.8.1.md
@@ -1,11 +1,160 @@
 ---
 title: Bitcoin-Qt version 0.8.1 released
 ---
-Bitcoin-Qt version 0.8.1 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.1/>
+Bitcoin-Qt version 0.8.1 is now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.1/>
 
 This is a maintenance release that adds a new network rule to avoid
 a chain-forking incompatibility with versions 0.7.2 and earlier.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
+
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.1 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.1 Release notes
+===================
+
+The 0.8.1 release has just two changes from the 0.8.0 release:
+
+1. A new block-acceptance rule that will be enforced from 21 March 2013 until
+15 May 2013 to prevent accepting blocks that fail to validate on pre-0.8 peers.
+
+2. A new compiled-in checkpoint at block number 225,430 -- the first block
+of the 11 March 2013 chain fork.
+
+
+0.8.0 Release notes
+===================
+
+Incompatible Changes
+--------------------
+
+This release no longer maintains a full index of historical transaction ids
+by default, so looking up an arbitrary transaction using the getrawtransaction
+RPC call will not work. If you need that functionality, you must run once
+with -txindex=1 -reindex=1 to rebuild block-chain indices (see below for more
+details).
+
+Improvements
+------------
+
+Mac and Windows binaries are signed with certificates owned by the Bitcoin
+Foundation, to be compatible with the new security features in OSX 10.8 and
+Windows 8.
+
+LevelDB, a fast, open-source, non-relational database from Google, is
+now used to store transaction and block indices.  LevelDB works much better
+on machines with slow I/O and is faster in general. Berkeley DB is now only
+used for the wallet.dat file (public and private wallet keys and transactions
+relevant to you).
+
+Pieter Wuille implemented many optimizations to the way transactions are
+verified, so a running, synchronized node uses less working memory and does
+much less I/O. He also implemented parallel signature checking, so if you
+have a multi-CPU machine all CPUs will be used to verify transactions.
+
+New Features
+------------
+
+"Bloom filter" support in the network protocol for sending only relevant transactions to
+lightweight clients.
+
+contrib/verifysfbinaries is a shell-script to verify that the binary downloads
+at sourceforge have not been tampered with. If you are able, you can help make
+everybody's downloads more secure by running this occasionally to check PGP
+signatures against download file checksums.
+
+contrib/spendfrom is a python-language command-line utility that demonstrates
+how to use the "raw transactions" JSON-RPC api to send coins received from particular
+addresses (also known as "coin control").
+
+New/changed settings (command-line or bitcoin.conf file)
+--------------------------------------------------------
+
+dbcache : controls LevelDB memory usage.
+
+par : controls how many threads to use to validate transactions. Defaults to the number
+of CPUs on your machine, use -par=1 to limit to a single CPU.
+
+txindex : maintains an extra index of old, spent transaction ids so they will be found
+by the getrawtransaction JSON-RPC method.
+
+reindex : rebuild block and transaction indices from the downloaded block data.
+
+New JSON-RPC API Features
+-------------------------
+
+lockunspent / listlockunspent allow locking transaction outputs for a period of time so
+they will not be spent by other processes that might be accessing the same wallet.
+
+addnode / getaddednodeinfo methods, to connect to specific peers without restarting.
+
+importprivkey now takes an optional boolean parameter (default true) to control whether
+or not to rescan the blockchain for transactions after importing a new private key.
+
+Important Bug Fixes
+-------------------
+
+Privacy leak: the position of the "change" output in most transactions was not being
+properly randomized, making network analysis of the transaction graph to identify
+users' wallets easier. 
+
+Zero-confirmation transaction vulnerability: accepting zero-confirmation transactions
+(transactions that have not yet been included in a block) from somebody you do not
+trust is still not recommended, because there will always be ways for attackers to
+double-spend zero-confirmation transactions. However, this release includes a bug
+fix that makes it a little bit more difficult for attackers to double-spend a
+certain type ("lockTime in the future") of zero-confirmation transaction.
+
+Dependency Changes
+------------------
+
+Qt 4.8.3 (compiling against older versions of Qt 4 should continue to work)
+
+
+Thanks to everybody who contributed to the 0.8.0 release:
+---------------------------------------------------------
+
+- Alexander Kjeldaas
+- Andrey Alekseenko
+- Arnav Singh
+- Christian von Roques
+- Eric Lombrozo
+- Forrest Voight
+- Gavin Andresen
+- Gregory Maxwell
+- Jeff Garzik
+- Luke Dashjr
+- Matt Corallo
+- Mike Cassano
+- Mike Hearn
+- Peter Todd
+- Philip Kaufmann
+- Pieter Wuille
+- Richard Schwab
+- Robert Backhaus
+- Rune K. Svendsen
+- Sergio Demian Lerner
+- Wladimir J. van der Laan
+- burger2
+- default
+- fanquake
+- grimd34th
+- justmoon
+- redshark1802
+- tucenaber
+- xanatos

--- a/_releases/2013-05-29-v0.8.2.md
+++ b/_releases/2013-05-29-v0.8.2.md
@@ -1,11 +1,150 @@
 ---
 title: Bitcoin-Qt version 0.8.2 released
 ---
-Bitcoin-Qt version 0.8.2 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.2/>
+Bitcoin-Qt version 0.8.2 is now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.2/>
 
 This is a maintenance release that fixes many bugs and includes
 a few small new features.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.2 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.2 Release notes
+===================
+
+Fee Policy changes
+------------------
+
+The default fee for low-priority transactions is lowered from 0.0005 BTC 
+(for each 1,000 bytes in the transaction; an average transaction is
+about 500 bytes) to 0.0001 BTC.
+
+Payments (transaction outputs) of 0.543 times the minimum relay fee
+(0.00005430 BTC) are now considered 'non-standard', because storing them
+costs the network more than they are worth and spending them will usually
+cost their owner more in transaction fees than they are worth.
+
+Non-standard transactions are not relayed across the network, are not included
+in blocks by most miners, and will not show up in your wallet until they are
+included in a block.
+
+The default fee policy can be overridden using the -mintxfee and -minrelaytxfee
+command-line options, but note that we intend to replace the hard-coded fees
+with code that automatically calculates and suggests appropriate fees in the
+0.9 release and note that if you set a fee policy significantly different from
+the rest of the network your transactions may never confirm.
+
+Bitcoin-Qt changes
+------------------
+
+* New icon and splash screen
+* Improve reporting of synchronization process
+* Remove hardcoded fee recommendations
+* Improve metadata of executable on MacOSX and Windows
+* Move export button to individual tabs instead of toolbar
+* Add "send coins" command to context menu in address book
+* Add "copy txid" command to copy transaction IDs from transaction overview
+* Save & restore window size and position when showing & hiding window
+* New translations: Arabic (ar), Bosnian (bs), Catalan (ca), Welsh (cy),
+  Esperanto (eo), Interlingua (la), Latvian (lv) and many improvements
+  to current translations
+
+MacOSX:
+* OSX support for click-to-pay (bitcoin:) links
+* Fix GUI disappearing problem on MacOSX (issue #1522)
+
+Linux/Unix:
+* Copy addresses to middle-mouse-button clipboard
+
+
+Command-line options
+--------------------
+
+* -walletnotify will call a command on receiving transactions that affect the wallet.
+* -alertnotify will call a command on receiving an alert from the network.
+* -par now takes a negative number, to leave a certain amount of cores free.
+
+JSON-RPC API changes
+--------------------
+
+* fixed a getblocktemplate bug that caused excessive CPU creating blocks.
+* listunspent now lists account and address infromation.
+* getinfo now also returns the time adjustment estimated from your peers.
+* getpeerinfo now returns bytessent, bytesrecv and syncnode.
+* gettxoutsetinfo returns statistics about the unspent transaction output database.
+* gettxout returns information about a specific unspent transaction output.
+
+
+Networking changes
+------------------
+
+* Significant changes to the networking code, reducing latency and memory consumption.
+* Avoid initial block download stalling.
+* Remove IRC seeding support.
+* Performance tweaks.
+* Added testnet DNS seeds.
+
+Wallet compatibility/rescuing
+-----------------------------
+
+* Cases where wallets cannot be opened in another version/installation should be reduced.
+* -salvagewallet now works for encrypted wallets.
+
+
+Known Bugs
+----------
+
+* Entering the 'getblocktemplate' or 'getwork' RPC commands into the Bitcoin-Qt debug
+console will cause Bitcoin-Qt to crash. Run Bitcoin-Qt with the -server command-line
+option to workaround.
+
+Thanks to everybody who contributed to the 0.8.2 release!
+---------------------------------------------------------
+
+- APerson241
+- Andrew Poelstra
+- Calvin Owens
+- Chuck LeDuc Díaz
+- Colin Dean
+- David Griffith
+- David Serrano
+- Eric Lombrozo
+- Gavin Andresen
+- Gregory Maxwell
+- Jeff Garzik
+- Jonas Schnelli
+- Larry Gilbert
+- Luke Dashjr
+- Matt Corallo
+- Michael Ford
+- Mike Hearn
+- Patrick Brown
+- Peter Todd
+- Philip Kaufmann
+- Pieter Wuille
+- Richard Schwab
+- Roman Mindalev
+- Scott Howard
+- Tariq Bashir
+- Warren Togami
+- Wladimir J. van der Laan
+- freewil
+- gladoscc
+- kjj2
+- mb300sd
+- super3

--- a/_releases/2013-06-25-v0.8.3.md
+++ b/_releases/2013-06-25-v0.8.3.md
@@ -1,11 +1,157 @@
 ---
 title: Bitcoin-Qt version 0.8.3 released
 ---
-Bitcoin-Qt version 0.8.3 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.3/>
+Bitcoin-Qt version 0.8.3 is now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.3/>
 
 This is a maintenance release to fix a denial-of-service attack that
 can cause nodes to crash.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.3 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.3 Release notes
+===================
+
+Truncate over-size messages to prevent a memory exhaustion attack.
+
+Fix a regression that causes excessive re-writing of the 'peers.dat' file.
+
+0.8.2 Release notes
+===================
+
+Fee Policy changes
+------------------
+
+The default fee for low-priority transactions is lowered from 0.0005 BTC 
+(for each 1,000 bytes in the transaction; an average transaction is
+about 500 bytes) to 0.0001 BTC.
+
+Payments (transaction outputs) of 0.543 times the minimum relay fee
+(0.00005430 BTC) are now considered 'non-standard', because storing them
+costs the network more than they are worth and spending them will usually
+cost their owner more in transaction fees than they are worth.
+
+Non-standard transactions are not relayed across the network, are not included
+in blocks by most miners, and will not show up in your wallet until they are
+included in a block.
+
+The default fee policy can be overridden using the -mintxfee and -minrelaytxfee
+command-line options, but note that we intend to replace the hard-coded fees
+with code that automatically calculates and suggests appropriate fees in the
+0.9 release and note that if you set a fee policy significantly different from
+the rest of the network your transactions may never confirm.
+
+Bitcoin-Qt changes
+------------------
+
+* New icon and splash screen
+* Improve reporting of synchronization process
+* Remove hardcoded fee recommendations
+* Improve metadata of executable on MacOSX and Windows
+* Move export button to individual tabs instead of toolbar
+* Add "send coins" command to context menu in address book
+* Add "copy txid" command to copy transaction IDs from transaction overview
+* Save & restore window size and position when showing & hiding window
+* New translations: Arabic (ar), Bosnian (bs), Catalan (ca), Welsh (cy),
+  Esperanto (eo), Interlingua (la), Latvian (lv) and many improvements
+  to current translations
+
+MacOSX:
+* OSX support for click-to-pay (bitcoin:) links
+* Fix GUI disappearing problem on MacOSX (issue #1522)
+
+Linux/Unix:
+* Copy addresses to middle-mouse-button clipboard
+
+
+Command-line options
+--------------------
+
+* -walletnotify will call a command on receiving transactions that affect the wallet.
+* -alertnotify will call a command on receiving an alert from the network.
+* -par now takes a negative number, to leave a certain amount of cores free.
+
+JSON-RPC API changes
+--------------------
+
+* fixed a getblocktemplate bug that caused excessive CPU creating blocks.
+* listunspent now lists account and address infromation.
+* getinfo now also returns the time adjustment estimated from your peers.
+* getpeerinfo now returns bytessent, bytesrecv and syncnode.
+* gettxoutsetinfo returns statistics about the unspent transaction output database.
+* gettxout returns information about a specific unspent transaction output.
+
+
+Networking changes
+------------------
+
+* Significant changes to the networking code, reducing latency and memory consumption.
+* Avoid initial block download stalling.
+* Remove IRC seeding support.
+* Performance tweaks.
+* Added testnet DNS seeds.
+
+Wallet compatibility/rescuing
+-----------------------------
+
+* Cases where wallets cannot be opened in another version/installation should be reduced.
+* -salvagewallet now works for encrypted wallets.
+
+
+Known Bugs
+----------
+
+* Entering the 'getblocktemplate' or 'getwork' RPC commands into the Bitcoin-Qt debug
+console will cause Bitcoin-Qt to crash. Run Bitcoin-Qt with the -server command-line
+option to workaround.
+
+Thanks to everybody who contributed to the 0.8.2 and 0.8.3 releases!
+--------------------------------------------------------------------
+
+* APerson241
+* Andrew Poelstra
+* Calvin Owens
+* Chuck LeDuc Díaz
+* Colin Dean
+* David Griffith
+* David Serrano
+* Eric Lombrozo
+* Gavin Andresen
+* Gregory Maxwell
+* Jeff Garzik
+* Jonas Schnelli
+* Larry Gilbert
+* Luke Dashjr
+* Matt Corallo
+* Michael Ford
+* Mike Hearn
+* Patrick Brown
+* Peter Todd
+* Philip Kaufmann
+* Pieter Wuille
+* Richard Schwab
+* Roman Mindalev
+* Scott Howard
+* Tariq Bashir
+* Warren Togami
+* Wladimir J. van der Laan
+* freewil
+* gladoscc
+* kjj2
+* mb300sd
+* super3

--- a/_releases/2013-09-03-v0.8.4.md
+++ b/_releases/2013-09-03-v0.8.4.md
@@ -1,14 +1,86 @@
 ---
 title: Bitcoin-Qt version 0.8.4 released
 ---
-Bitcoin-Qt version 0.8.4 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.4/>
+Bitcoin-Qt version 0.8.4 is now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.4/>
 
 This is a maintenance release to fix a critical bug and three
 security issues; we urge all users to upgrade.
 
-There were no changes from 0.8.4 release candidate 2, so if you are running
-0.8.4rc2 you do not need to upgrade.
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.4 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.4 Release notes
+===================
+
+Security issues
+---------------
+
+An attacker could send a series of messages that resulted in
+an integer division-by-zero error in the Bloom Filter handling
+code, causing the Bitcoin-Qt or bitcoind process to crash.
+Bloom filters were introduced with version 0.8, so versions 0.8.0
+through 0.8.3 are vulnerable to this critical denial-of-service attack.
+
+A constant-time algorithm is now used to check RPC password
+guess attempts; fixes <https://github.com/bitcoin/bitcoin/issues/2838>
+(CVE-2013-4165)
+
+Implement a better fix for the fill-memory-with-orphan-transactions
+attack that was fixed in 0.8.3. See
+<https://bitslog.wordpress.com/2013/07/18/buggy-cve-2013-4627-patch-open-new-vectors-of-attack/>
+for a description of the weaknesses of the previous fix.
+(CVE-2013-4627)
+
+Bugs fixed
+----------
+
+Fix multi-block reorg transaction resurrection.
+
+Fix non-standard disconnected transactions causing mempool orphans.
+This bug could cause nodes running with the -debug flag to crash.
+
+OSX: use 'FD_FULLSYNC' with LevelDB, which will (hopefully!)
+prevent the database corruption issues many people have
+experienced on OSX.
+
+Linux: clicking on bitcoin: links was broken if you were using
+a Gnome-based desktop.
+
+Fix a hang-at-shutdown bug that only affects users that compile
+their own version of Bitcoin against Boost versions 1.50-1.52.
+
+Other changes
+-------------
+
+Checkpoint at block 250,000 to speed up initial block downloads
+and make the progress indicator when downloading more accurate.
+
+
+Thanks to everybody who contributed to the 0.8.4 releases!
+----------------------------------------------------------
+
+* Pieter Wuille
+* Warren Togami
+* Patrick Strateman
+* pakt
+* Gregory Maxwell
+* Sergio Demian Lerner
+* grayleonard
+* Cory Fields
+* Matt Corallo
+* Gavin Andresen

--- a/_releases/2013-09-13-v0.8.5.md
+++ b/_releases/2013-09-13-v0.8.5.md
@@ -1,11 +1,47 @@
 ---
 title: Bitcoin-Qt version 0.8.5 released
 ---
-Bitcoin-Qt version 0.8.5 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.5/>
+Bitcoin-Qt version 0.8.5 is now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.5/>
 
-This is a maintenance release to fix a critical bug; we urge all users to
-upgrade.
+This is a maintenance release to fix a critical bug;
+we urge all users to upgrade.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.5 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.5 Release notes
+===================
+
+Bugs fixed
+----------
+
+Transactions with version numbers larger than 0x7fffffff were
+incorrectly being relayed and included in blocks.
+
+Blocks containing transactions with version numbers larger
+than 0x7fffffff caused the code that checks for LevelDB database
+inconsistencies at startup to erroneously report database
+corruption and suggest that you reindex your database.
+
+This release also contains a non-critical fix to the code that
+enforces BIP 34 (block height in the coinbase transaction).
+
+--
+
+Thanks to Gregory Maxwell and Pieter Wuille for quickly
+identifying and fixing the transaction version number bug.

--- a/_releases/2013-12-09-v0.8.6.md
+++ b/_releases/2013-12-09-v0.8.6.md
@@ -1,11 +1,66 @@
 ---
 title: Bitcoin-Qt version 0.8.6 released
 ---
-Bitcoin-Qt version 0.8.6 is now available for download at:
-<http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.6/>
+Bitcoin-Qt version 0.8.6 is now available from:
+  <http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.6/>
 
 This is a maintenance release to fix a critical bug;
 we urge all users to upgrade.
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+Please report bugs using the issue tracker at github:
+  <https://github.com/bitcoin/bitcoin/issues>
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.6 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.6 Release notes
+===================
+
+- Default block size increase for miners.
+  (see <https://gist.github.com/gavinandresen/7670433#086-accept-into-block>)
+
+- Remove the all-outputs-must-be-greater-than-CENT-to-qualify-as-free rule for relaying
+  (see <https://gist.github.com/gavinandresen/7670433#086-relaying>)
+
+- Lower maximum size for free transaction creation
+  (see <https://gist.github.com/gavinandresen/7670433#086-wallet>)
+
+- OSX block chain database corruption fixes
+  - Update leveldb to 1.13
+  - Use fcntl with `F_FULLSYNC` instead of fsync on OSX
+  - Use native Darwin memory barriers
+  - Replace use of mmap in leveldb for improved reliability (only on OSX)
+
+- Fix nodes forwarding transactions with empty vins and getting banned
+
+- Network code performance and robustness improvements
+
+- Additional debug.log logging for diagnosis of network problems, log timestamps by default
+
+- Fix Bitcoin-Qt startup crash when clicking dock icon on OSX 
+
+- Fix memory leaks in CKey::SetCompactSignature() and Key::SignCompact()
+
+- Fix rare GUI crash on send
+
+- Various small GUI, documentation and build fixes
+
+Warning
+-------
+
+- There have been frequent reports of users running out of virtual memory on 32-bit systems
+  during the initial sync.
+  Hence it is recommended to use a 64-bit executable if possible.
+  A 64-bit executable for Windows is planned for 0.9.
+

--- a/_releases/2014-03-19-v0.9.0.md
+++ b/_releases/2014-03-19-v0.9.0.md
@@ -1,11 +1,415 @@
 ---
 title: Bitcoin Core version 0.9.0 released
 ---
-Bitcoin Core version 0.9.0 is now available for download at:
-<https://bitcoin.org/bin/0.9.0/>
+Bitcoin Core version 0.9.0 is now available from:
 
-This is a new major version that brings both new features and
-bug fixes; we urge all users to upgrade.
+  <https://bitcoin.org/bin/0.9.0/>
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+This is a new major version release, bringing both new features and
+bug fixes.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), uninstall all
+earlier versions of Bitcoin, then run the installer (on Windows) or just copy
+over /Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you run
+0.9.0 your blockchain files will be re-indexed, which will take anywhere from 
+30 minutes to several hours, depending on the speed of your machine.
+
+On Windows, do not forget to uninstall all earlier versions of the Bitcoin
+client first, especially if you are switching to the 64-bit version.
+
+Windows 64-bit installer
+-------------------------
+
+New in 0.9.0 is the Windows 64-bit version of the client. There have been
+frequent reports of users running out of virtual memory on 32-bit systems
+during the initial sync. Because of this it is recommended to install the
+64-bit version if your system supports it.
+
+NOTE: Release candidate 2 Windows binaries are not code-signed; use PGP
+and the SHA256SUMS.asc file to make sure your binaries are correct.
+In the final 0.9.0 release, Windows setup.exe binaries will be code-signed.
+
+OSX 10.5 / 32-bit no longer supported
+-------------------------------------
+
+0.9.0 drops support for older Macs. The minimum requirements are now:
+
+* A 64-bit-capable CPU (see <http://support.apple.com/kb/ht3696>);
+* Mac OS 10.6 or later (see <https://support.apple.com/kb/ht1633>).
+
+Downgrading warnings
+--------------------
+
+The 'chainstate' for this release is not always compatible with previous
+releases, so if you run 0.9 and then decide to switch back to a
+0.8.x release you might get a blockchain validation error when starting the
+old release (due to 'pruned outputs' being omitted from the index of
+unspent transaction outputs).
+
+Running the old release with the -reindex option will rebuild the chainstate
+data structures and correct the problem.
+
+Also, the first time you run a 0.8.x release on a 0.9 wallet it will rescan
+the blockchain for missing spent coins, which will take a long time (tens
+of minutes on a typical machine).
+
+Rebranding to Bitcoin Core
+---------------------------
+
+To reduce confusion between Bitcoin-the-network and Bitcoin-the-software we
+have renamed the reference client to Bitcoin Core.
+
+
+OP_RETURN and data in the block chain
+-------------------------------------
+On OP_RETURN:  There was been some confusion and misunderstanding in
+the community, regarding the OP_RETURN feature in 0.9 and data in the
+blockchain.  This change is not an endorsement of storing data in the
+blockchain.  The OP_RETURN change creates a provably-prunable output,
+to avoid data storage schemes -- some of which were already deployed --
+that were storing arbitrary data such as images as forever-unspendable
+TX outputs, bloating bitcoin's UTXO database.
+
+Storing arbitrary data in the blockchain is still a bad idea; it is less
+costly and far more efficient to store non-currency data elsewhere.
+
+Autotools build system
+-----------------------
+
+For 0.9.0 we switched to an autotools-based build system instead of individual
+(q)makefiles.
+
+Using the standard "./autogen.sh; ./configure; make" to build Bitcoin-Qt and
+bitcoind makes it easier for experienced open source developers to contribute 
+to the project.
+
+Be sure to check doc/build-*.md for your platform before building from source.
+
+Bitcoin-cli
+-------------
+
+Another change in the 0.9 release is moving away from the bitcoind executable
+functioning both as a server and as a RPC client. The RPC client functionality
+("tell the running bitcoin daemon to do THIS") was split into a separate
+executable, 'bitcoin-cli'. The RPC client code will eventually be removed from
+bitcoind, but will be kept for backwards compatibility for a release or two.
+
+`walletpassphrase` RPC
+-----------------------
+
+The behavior of the `walletpassphrase` RPC when the wallet is already unlocked
+has changed between 0.8 and 0.9.
+
+The 0.8 behavior of `walletpassphrase` is to fail when the wallet is already unlocked:
+
+    > walletpassphrase 1000
+    walletunlocktime = now + 1000
+    > walletpassphrase 10
+    Error: Wallet is already unlocked (old unlock time stays)
+
+The new behavior of `walletpassphrase` is to set a new unlock time overriding
+the old one:
+
+    > walletpassphrase 1000
+    walletunlocktime = now + 1000
+    > walletpassphrase 10
+    walletunlocktime = now + 10 (overriding the old unlock time)
+
+Transaction malleability-related fixes
+--------------------------------------
+
+This release contains a few fixes for transaction ID (TXID) malleability 
+issues:
+
+- -nospendzeroconfchange command-line option, to avoid spending
+  zero-confirmation change
+- IsStandard() transaction rules tightened to prevent relaying and mining of
+  mutated transactions
+- Additional information in listtransactions/gettransaction output to
+  report wallet transactions that conflict with each other because
+  they spend the same outputs.
+- Bug fixes to the getbalance/listaccounts RPC commands, which would report
+  incorrect balances for double-spent (or mutated) transactions.
+- New option: -zapwallettxes to rebuild the wallet's transaction information
+
+Transaction Fees
+----------------
+
+This release drops the default fee required to relay transactions across the
+network and for miners to consider the transaction in their blocks to
+0.01mBTC per kilobyte.
+
+Note that getting a transaction relayed across the network does NOT guarantee
+that the transaction will be accepted by a miner; by default, miners fill
+their blocks with 50 kilobytes of high-priority transactions, and then with
+700 kilobytes of the highest-fee-per-kilobyte transactions.
+
+The minimum relay/mining fee-per-kilobyte may be changed with the
+minrelaytxfee option. Note that previous releases incorrectly used
+the mintxfee setting to determine which low-priority transactions should
+be considered for inclusion in blocks.
+
+The wallet code still uses a default fee for low-priority transactions of
+0.1mBTC per kilobyte. During periods of heavy transaction volume, even this
+fee may not be enough to get transactions confirmed quickly; the mintxfee
+option may be used to override the default.
+
+0.9.0 Release notes
+=======================
+
+RPC:
+
+- New notion of 'conflicted' transactions, reported as confirmations: -1
+- 'listreceivedbyaddress' now provides tx ids
+- Add raw transaction hex to 'gettransaction' output
+- Updated help and tests for 'getreceivedby(account|address)'
+- In 'getblock', accept 2nd 'verbose' parameter, similar to getrawtransaction,
+  but defaulting to 1 for backward compatibility
+- Add 'verifychain', to verify chain database at runtime
+- Add 'dumpwallet' and 'importwallet' RPCs
+- 'keypoolrefill' gains optional size parameter
+- Add 'getbestblockhash', to return tip of best chain
+- Add 'chainwork' (the total work done by all blocks since the genesis block)
+  to 'getblock' output
+- Make RPC password resistant to timing attacks
+- Clarify help messages and add examples
+- Add 'getrawchangeaddress' call for raw transaction change destinations
+- Reject insanely high fees by default in 'sendrawtransaction'
+- Add RPC call 'decodescript' to decode a hex-encoded transaction script
+- Make 'validateaddress' provide redeemScript
+- Add 'getnetworkhashps' to get the calculated network hashrate
+- New RPC 'ping' command to request ping, new 'pingtime' and 'pingwait' fields
+  in 'getpeerinfo' output
+- Adding new 'addrlocal' field to 'getpeerinfo' output
+- Add verbose boolean to 'getrawmempool'
+- Add rpc command 'getunconfirmedbalance' to obtain total unconfirmed balance
+- Explicitly ensure that wallet is unlocked in `importprivkey`
+- Add check for valid keys in `importprivkey`
+
+Command-line options:
+
+- New option: -nospendzeroconfchange to never spend unconfirmed change outputs
+- New option: -zapwallettxes to rebuild the wallet's transaction information
+- Rename option '-tor' to '-onion' to better reflect what it does
+- Add '-disablewallet' mode to let bitcoind run entirely without wallet (when
+  built with wallet)
+- Update default '-rpcsslciphers' to include TLSv1.2
+- make '-logtimestamps' default on and rework help-message
+- RPC client option: '-rpcwait', to wait for server start
+- Remove '-logtodebugger'
+- Allow `-noserver` with bitcoind
+
+Block-chain handling and storage:
+
+- Update leveldb to 1.15
+- Check for correct genesis (prevent cases where a datadir from the wrong
+  network is accidentally loaded)
+- Allow txindex to be removed and add a reindex dialog
+- Log aborted block database rebuilds
+- Store orphan blocks in serialized form, to save memory
+- Limit the number of orphan blocks in memory to 750
+- Fix non-standard disconnected transactions causing mempool orphans
+- Add a new checkpoint at block 279,000
+
+Wallet:
+
+- Bug fixes and new regression tests to correctly compute
+  the balance of wallets containing double-spent (or mutated) transactions
+- Store key creation time. Calculate whole-wallet birthday.
+- Optimize rescan to skip blocks prior to birthday
+- Let user select wallet file with -wallet=foo.dat
+- Consider generated coins mature at 101 instead of 120 blocks
+- Improve wallet load time
+- Don't count txins for priority to encourage sweeping
+- Don't create empty transactions when reading a corrupted wallet
+- Fix rescan to start from beginning after importprivkey
+- Only create signatures with low S values
+
+Mining:
+
+- Increase default -blockmaxsize/prioritysize to 750K/50K
+- 'getblocktemplate' does not require a key to create a block template
+- Mining code fee policy now matches relay fee policy
+
+Protocol and network:
+
+- Drop the fee required to relay a transaction to 0.01mBTC per kilobyte
+- Send tx relay flag with version
+- New 'reject' P2P message (BIP 0061, see
+  <https://gist.github.com/gavinandresen/7079034> for draft)
+- Dump addresses every 15 minutes instead of 10 seconds
+- Relay OP_RETURN data TxOut as standard transaction type
+- Remove CENT-output free transaction rule when relaying
+- Lower maximum size for free transaction creation
+- Send multiple inv messages if mempool.size > MAX_INV_SZ
+- Split MIN_PROTO_VERSION into INIT_PROTO_VERSION and MIN_PEER_PROTO_VERSION
+- Do not treat fFromMe transaction differently when broadcasting
+- Process received messages one at a time without sleeping between messages
+- Improve logging of failed connections
+- Bump protocol version to 70002
+- Add some additional logging to give extra network insight
+- Added new DNS seed from bitcoinstats.com
+
+Validation:
+
+- Log reason for non-standard transaction rejection
+- Prune provably-unspendable outputs, and adapt consistency check for it.
+- Detect any sufficiently long fork and add a warning
+- Call the -alertnotify script when we see a long or invalid fork
+- Fix multi-block reorg transaction resurrection
+- Reject non-canonically-encoded serialization sizes
+- Reject dust amounts during validation
+- Accept nLockTime transactions that finalize in the next block
+
+Build system:
+
+- Switch to autotools-based build system
+- Build without wallet by passing `--disable-wallet` to configure, this 
+  removes the BerkeleyDB dependency
+- Upgrade gitian dependencies (libpng, libz, libupnpc, boost, openssl) to more
+  recent versions
+- Windows 64-bit build support
+- Solaris compatibility fixes
+- Check integrity of gitian input source tarballs
+- Enable full GCC Stack-smashing protection for all OSes
+
+GUI:
+
+- Switch to Qt 5.2.0 for Windows build
+- Add payment request (BIP 0070) support
+- Improve options dialog
+- Show transaction fee in new send confirmation dialog
+- Add total balance in overview page
+- Allow user to choose data directory on first start, when data directory is
+  missing, or when the -choosedatadir option is passed
+- Save and restore window positions
+- Add vout index to transaction id in transactions details dialog
+- Add network traffic graph in debug window
+- Add open URI dialog
+- Add Coin Control Features
+- Improve receive coins workflow: make the 'Receive' tab into a form to request
+  payments, and move historical address list functionality to File menu.
+- Rebrand to `Bitcoin Core`
+- Move initialization/shutdown to a thread. This prevents "Not responding"
+  messages during startup. Also show a window during shutdown.
+- Don't regenerate autostart link on every client startup
+- Show and store message of normal bitcoin:URI
+- Fix richtext detection hang issue on very old Qt versions
+- OS X: Make use of the 10.8+ user notification center to display Growl-like 
+  notifications
+- OS X: Added NSHighResolutionCapable flag to Info.plist for better font
+  rendering on Retina displays.
+- OS X: Fix bitcoin-qt startup crash when clicking dock icon
+- Linux: Fix Gnome bitcoin: URI handler
+
+Miscellaneous:
+
+- Add Linux script (contrib/qos/tc.sh) to limit outgoing bandwidth
+- Add '-regtest' mode, similar to testnet but private with instant block
+  generation with 'setgenerate' RPC.
+- Add 'linearize.py' script to contrib, for creating bootstrap.dat
+- Add separate bitcoin-cli client
+
+Credits
+--------
+
+Thanks to everyone who contributed to this release:
+
+- Andrey
+- Ashley Holman
+- b6393ce9-d324-4fe1-996b-acf82dbc3d53
+- bitsofproof
+- Brandon Dahler
+- Calvin Tam
+- Christian Decker
+- Christian von Roques
+- Christopher Latham
+- Chuck
+- coblee
+- constantined
+- Cory Fields
+- Cozz Lovan
+- daniel
+- Daniel Larimer
+- David Hill
+- Dmitry Smirnov
+- Drak
+- Eric Lombrozo
+- fanquake
+- fcicq
+- Florin
+- frewil
+- Gavin Andresen
+- Gregory Maxwell
+- gubatron
+- Guillermo Céspedes Tabárez
+- Haakon Nilsen
+- HaltingState
+- Han Lin Yap
+- harry
+- Ian Kelling
+- Jeff Garzik
+- Johnathan Corgan
+- Jonas Schnelli
+- Josh Lehan
+- Josh Triplett
+- Julian Langschaedel
+- Kangmo
+- Lake Denman
+- Luke Dashjr
+- Mark Friedenbach
+- Matt Corallo
+- Michael Bauer
+- Michael Ford
+- Michagogo
+- Midnight Magic
+- Mike Hearn
+- Nils Schneider
+- Noel Tiernan
+- Olivier Langlois
+- patrick s
+- Patrick Strateman
+- paveljanik
+- Peter Todd
+- phantomcircuit
+- phelixbtc
+- Philip Kaufmann
+- Pieter Wuille
+- Rav3nPL
+- R E Broadley
+- regergregregerrge
+- Robert Backhaus
+- Roman Mindalev
+- Rune K. Svendsen
+- Ryan Niebur
+- Scott Ellis
+- Scott Willeke
+- Sergey Kazenyuk
+- Shawn Wilkinson
+- Sined
+- sje
+- Subo1978
+- super3
+- Tamas Blummer
+- theuni
+- Thomas Holenstein
+- Timon Rapp
+- Timothy Stranex
+- Tom Geller
+- Torstein Husebø
+- Vaclav Vobornik
+- vhf / victor felder
+- Vinnie Falco
+- Warren Togami
+- Wil Bown
+- Wladimir J. van der Laan

--- a/_releases/2014-04-08-v0.9.1.md
+++ b/_releases/2014-04-08-v0.9.1.md
@@ -1,12 +1,57 @@
 ---
 title: Bitcoin Core version 0.9.1 released
 ---
-Bitcoin Core version 0.9.1 is now available for download at:
-<https://bitcoin.org/bin/0.9.1/>
+Bitcoin Core version 0.9.1 is now available from:
 
-This is a maintenance release to fix an urgent security
-vulnerability (CVE-2014-0160); all users should
-upgrade.
+  <https://bitcoin.org/bin/0.9.1/>
 
-Please report bugs using the issue tracker at GitHub:
-<https://github.com/bitcoin/bitcoin/issues>
+This is a security update. It is recommended to upgrade to this release
+as soon as possible.
+
+It is especially important to upgrade if you currently have version
+0.9.0 installed and are using the graphical interface OR you are using
+bitcoind from any pre-0.9.1 version, and have enabled SSL for RPC and
+have configured allowip to allow rpc connections from potentially
+hostile hosts.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), then run the
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you run
+0.9.1 your blockchain files will be re-indexed, which will take anywhere from 
+30 minutes to several hours, depending on the speed of your machine.
+
+0.9.1 Release notes
+-------------------
+
+No code changes were made between 0.9.0 and 0.9.1. Only the dependencies were changed.
+
+- Upgrade OpenSSL to 1.0.1g. This release fixes the following vulnerabilities which can
+  affect the Bitcoin Core software:
+
+  - CVE-2014-0160 ("heartbleed")
+    A missing bounds check in the handling of the TLS heartbeat extension can
+    be used to reveal up to 64k of memory to a connected client or server.
+
+  - CVE-2014-0076
+    The Montgomery ladder implementation in OpenSSL does not ensure that
+    certain swap operations have a constant-time behavior, which makes it
+    easier for local users to obtain ECDSA nonces via a FLUSH+RELOAD cache
+    side-channel attack.
+
+- Add statically built executables to Linux build
+
+Credits
+--------
+
+Credits go to the OpenSSL team for fixing the vulnerabilities quickly.
+


### PR DESCRIPTION
Live preview here:
(Merged)

For an unknown reason, 0.6.0 to 0.9.1 release notes are incomplete on bitcoin.org and sometime slightly different than READMEs on sourceforge.

Full release notes provide useful information and are already markdown-formatted, so they can be used directly. These information are useful for historical purposes, and we're now hosting binaries on bitcoin.org, but READMEs aren't automagically displayed like they used to on sourceforge.
