### PR TITLE
Devel Docs: Add Comparison-Based Attacks To Reasons Not To Reuse Keys

### DIFF
--- a/_includes/guide_transactions.md
+++ b/_includes/guide_transactions.md
@@ -602,7 +602,7 @@ described below, with more general attacks hypothesized).
 
 1. Unique (non-reused) P2PH and P2SH addresses protect against the first
    type of attack by keeping ECDSA public keys hidden (hashed) until the
-   first time satoshis stored in those addresses are spent, so attacks
+   first time satoshis sent to those addresses are spent, so attacks
    are effectively useless unless they can reconstruct private keys in
    less than the hour or two it takes for a transaction to be well
    protected by the block chain.
@@ -610,9 +610,10 @@ described below, with more general attacks hypothesized).
 2. Unique (non-reused) private keys protect against the second type of
    attack by only generating one signature per private key, so attackers
    never get a subsequent signature to use in comparison-based attacks.
-   Existing comparison-based attacks are only practical today when there
-   is an error in the ECDSA implementation or a lack of entropy in one
-   of the values used for signing.
+   Existing comparison-based attacks are only practical today when 
+   insufficient entropy is used in signing or when the entropy used
+   is exposed by some means, such as a
+   [side-channel attack](https://en.wikipedia.org/wiki/Side_channel_attack).
 
 So, for both privacy and security, we encourage you to build your
 applications to avoid public key reuse and, when possible, to discourage


### PR DESCRIPTION
Based on a request from @luke-jr and criteria from @mikehearn, this pull
replaces the the previous security text in the Avoiding Key Reuse
section with a slightly expanded version that also describes why
creating more than one signature with the same private key might be a
problem.

If this pull request is unsatisfactory and non-trivial changes are
required to make it satisfactory, I suggest that we simply delete the
existing security text and add describing ECDSA security in detail it to
our [todo list for the next version of the
guide.](https://github.com/saivann/bitcoin.org/wiki/Content-Suggestions)

Note: every occurrence of "ECDSA" in the guide is automatically linked to
the ECDSA Wikipedia entry which repeatedly explains the risks of lack of
entropy in _k_ values---with the Sony PS3 key compromise and
SecureRandom implementation being used as real-life examples. Anyone who
is curious about the details after reading our short description need
only click the link to start learning more.
