### PR TITLE
Added missing punctuation to  bitcoin paragraph on /en/vocabulary page

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -499,7 +499,7 @@ en:
     address: "Address"
     addresstxt: "A Bitcoin address is <b>similar to a physical address or an email</b>. It is the only information you need to provide for someone to pay you with Bitcoin. An important difference, however, is that each address should only be used for a single transaction."
     bitcoin: "Bitcoin"
-    bitcointxt: "Bitcoin - with capitalization, is used when describing the concept of Bitcoin, or the entire network itself. e.g. \"I was learning about the Bitcoin protocol today.\"<br>bitcoin - without capitalization, is used to describe bitcoins as a unit of account. e.g. \"I sent ten bitcoins today.\"; it is also often abbreviated BTC or XBT"
+    bitcointxt: "Bitcoin - with capitalization, is used when describing the concept of Bitcoin, or the entire network itself. e.g. \"I was learning about the Bitcoin protocol today.\"<br>bitcoin - without capitalization, is used to describe bitcoins as a unit of account. e.g. \"I sent ten bitcoins today.\"; it is also often abbreviated BTC or XBT."
     blockchain: "Block Chain"
     blockchaintxt: "The block chain is a <b>public record of Bitcoin transactions</b> in chronological order. The block chain is shared between all Bitcoin users. It is used to verify the permanence of Bitcoin transactions and to prevent <a href=\"#[vocabulary.doublespend]\">double spending</a>."
     block: "Block"


### PR DESCRIPTION
Didn't update this on transifex though..
