### PR TITLE
Add a temporary BETA disclaimer in devel-docs

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -772,6 +772,48 @@ table td,table th{
 	color:#646464;
 }
 
+.develdocdisclaimer{
+	padding:30px 0;
+	background:#fff;
+	bottom:0;
+	position:fixed;
+	width:600px;
+	z-index:1000;
+	border-top:1px solid #e0e0e0;
+}
+.develdocdisclaimer div{
+	border:2px dashed #ee9209;
+	background:#fff8ea;
+	padding:10px;
+	line-height:1.5em;
+	position:relative;
+}
+.develdocdisclaimerclose,
+.develdocdisclaimerclose:visited,
+.develdocdisclaimerclose:link,
+.develdocdisclaimerclose:active{
+	display:block;
+	padding:1px 8px 0 8px;
+	color:#fff;
+	background-color:#ee9209;
+	position:absolute;
+	top:-14px;
+	right:-14px;
+	font-weight:bold;
+	cursor:pointer;
+	border:2px solid #fff;
+	-webkit-border-radius:20px;
+	-moz-border-radius:20px;
+	border-radius:20px;
+}
+.develdocdisclaimerclose:hover,
+.develdocdisclaimerclose:visited:hover,
+.develdocdisclaimerclose:link:hover,
+.develdocdisclaimerclose:active:hover{
+	border:2px solid #ee9209;
+	color:#fff;
+}
+
 .highlight  { background: #ffffff; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
@@ -1544,6 +1586,9 @@ h2 .rssicon{
 	.toccontent{
 		width:auto;
 	}
+	.develdocdisclaimer{
+		display:none;
+	}
 }
 
 /*Styles specific to mobiles*/
@@ -1691,6 +1736,10 @@ h2 .rssicon{
 	.toccontent a.auto-link:link,
 	.toccontent a.auto-link:visited{
 		color:#2c6fad;
+	}
+	.develdocdisclaimer{
+		padding:15px;
+		width:auto;
 	}
 	.contributors{
 		width:auto;

--- a/en/developer-guide.md
+++ b/en/developer-guide.md
@@ -21,6 +21,14 @@ title: "Developer Guide - Bitcoin"
 
 <div markdown="1" class="toccontent">
 
+<!--Temporary disclaimer BEGIN-->
+<div id="develdocdisclaimer" class="develdocdisclaimer"><div>
+<b>BETA</b>: This documentation has been written recently and still needs more reviews to ensure all content is covered correctly and accurately; if you find a mistake, please <a href="https://github.com/bitcoin/bitcoin.org/issues/new" onmouseover="updateIssue(event);">report an issue</a> on GitHub. <a href="#" onclick="disclaimerClose(event);">Click here</a> to close this disclaimer.
+<a class="develdocdisclaimerclose" href="#" onclick="disclaimerClose(event);">X</a>
+</div></div>
+<script>disclaimerAutoClose();</script>
+<!--Temporary disclaimer END-->
+
 <!-- includes should be separated by an empty line to prevent a
 paragraph at the end of one file from breaking the heading at the start
 of the following file. -->

--- a/en/developer-reference.md
+++ b/en/developer-reference.md
@@ -20,6 +20,14 @@ title: "Developer Reference - Bitcoin"
 </div></div>
 <div markdown="1" class="toccontent">
 
+<!--Temporary disclaimer BEGIN-->
+<div id="develdocdisclaimer" class="develdocdisclaimer"><div>
+<b>BETA</b>: This documentation has been written recently and still needs more reviews to ensure all content is covered correctly and accurately; if you find a mistake, please <a href="https://github.com/bitcoin/bitcoin.org/issues/new" onmouseover="updateIssue(event);">report an issue</a> on GitHub. <a href="#" onclick="disclaimerClose(event);">Click here</a> to close this disclaimer.
+<a class="develdocdisclaimerclose" href="#" onclick="disclaimerClose(event);">X</a>
+</div></div>
+<script>disclaimerAutoClose();</script>
+<!--Temporary disclaimer END-->
+
 {% include ref_block_chain.md %}
 {% include ref_transactions.md %}
 {% include ref_wallets.md %}

--- a/js/main.js
+++ b/js/main.js
@@ -367,6 +367,21 @@ var t=getEventTarget(e);
 t.href='https://github.com/bitcoin/bitcoin.org/issues/new?body='+encodeURIComponent('Location: '+window.location.href.toString()+"\n\n");
 }
 
+function disclaimerClose(e){
+//Auto close temporary disclaimer in devel-docs
+if(e)cancelEvent(e);
+var t=document.getElementById('develdocdisclaimer')
+t.parentNode.removeChild(t);
+if(typeof(Storage)==='undefined')return;
+sessionStorage.setItem('develdocdisclaimerclose','1');
+}
+
+function disclaimerAutoClose(){
+//Auto close temporary disclaimer in devel-docs if session says so
+if(typeof(Storage)==='undefined')return;
+if(sessionStorage.getItem('develdocdisclaimerclose')==='1')disclaimerClose();
+}
+
 function makeEditable(e){
 //An easter egg that makes the page editable when user click on the page and hold their mouse button for one second.
 //This trick allows translators and writers to preview their work.


### PR DESCRIPTION
Live preview: (merged)

This pull req adds a temporary disclaimer in devel-guide and devel-ref, mentioning that the documentation is in BETA. Along with the "Report an issue" button in the toc, I think these are reasonable measures to let us publish this documentation while it is partially reviewed by core developers.

The disclaimer is fixed-positioned so it appears even when people click on anchors, and it can be closed until the browser session ends (thanks @harding for the idea).
