### PR TITLE
Minor Additions: Payment Req Generator & 210,000 Block Halving

### DIFF
--- a/_includes/guide_payment_processing.md
+++ b/_includes/guide_payment_processing.md
@@ -361,6 +361,9 @@ aware of the payment protocol, it accesses the URL specified in the `r`
 parameter, which should provide it with a serialized PaymentRequest
 served with the [MIME][] type `application/bitcoin-paymentrequest`<!--noref-->.
 
+**Resource:** Gavin Andresen's [Payment Request Generator][] generates
+custom example URIs and payment requests for use with testnet.
+
 {% endautocrossref %}
 
 ##### PaymentRequest & PaymentDetails

--- a/_includes/ref_block_chain.md
+++ b/_includes/ref_block_chain.md
@@ -32,8 +32,8 @@ spend any transaction fees paid by transactions included in this block.
 All blocks with a block height less than 6,930,000 are entitled to
 receive a [block reward][]{:#term-block-reward}{:.term} of newly created bitcoin value, which also
 should be spent in the coinbase transaction. (The block reward started
-at 50 bitcoins and is being halved approximately every four years. As of
-April 2014, it's 25 bitcoins.) A coinbase transaction is invalid if it 
+at 50 bitcoins and is being halved every 210,000 blocks---approximately once every four years. As of
+June 2014, it's 25 bitcoins.) A coinbase transaction is invalid if it 
 tries to spend more value than is available from the transaction 
 fees and block reward.
 

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -192,6 +192,7 @@
 [MIME]: https://en.wikipedia.org/wiki/Internet_media_type
 [Merge Avoidance subsection]: /en/developer-guide#merge-avoidance
 [mozrootstore]: https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/
+[Payment Request Generator]: http://bitcoincore.org/~gavin/createpaymentrequest.php
 [Piotr Piasecki's testnet faucet]: https://tpfaucet.appspot.com/
 [prime symbol]: https://en.wikipedia.org/wiki/Prime_%28symbol%29
 [protobuf]: https://developers.google.com/protocol-buffers/


### PR DESCRIPTION
Two unrelated minor additions which were requested at nearly the same time.
- @mikehearn requested we add a link to @gavinandresen's PaymentRequest generator. Added to _includes/guide_payment_processing.md with link definition in _includes/references.md
- @Burrito-Bazooka requested we mention that the block reward halves every 210,000 blocks. Added to _includes/ref_block_chain.md

This PR seems non-conroversial to me, but it does include a new external link, so I'm not commiting it directly. I'll merge this after receiving one ACK or after 24 hours, whichever comes sooner.
