### PR TITLE
Add "Developer Documentation" subsection in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ from _site/ to the root of your web server. If you have no web server, run
 http://127.0.0.1:4000/. This server requires you to add a trailing ".html"
 by hand in your browser address bar.
 
+## Developer Documentation
+
+Each part of the documentation can be found in the [_includes](https://github.com/bitcoin/bitcoin.org/tree/master/_includes)
+directory. Updates, fixes and improvements are welcome and can submitted using [pull requests](#working-with-github) on GitHub.
+
+**Mailing List**: General discussions can take place on the
+[mailing list](https://groups.google.com/forum/#!forum/bitcoin-documentation).
+
+**TODO List**: New content and suggestions for improvements can be submitted
+to the [TODO list](https://github.com/bitcoin/bitcoin.org/wiki/Documentation-TODO).
+You are also welcome if you want to assign yourself to any task.
+
+**Style Guide**: For better consistency, the [style guide](https://github.com/bitcoin/bitcoin.org/wiki/Documentation-Style-Guide)
+can be used as a reference for terminology, style and formatting. Suggested changes
+can also be submitted to this guide to keep it up to date.
+
+**Cross-Reference Links**: Cross-reference links can be defined in
+_includes/references.md. Terms which should automatically link to these
+references are defined in _autocrossref.yaml .
+
 ## Translation
 
 ### How To Translate


### PR DESCRIPTION
As suggested on the mailing list, this pull request adds some instructions in the README for potential contributors to the developer documentation.

Preview: https://github.com/bitcoin/bitcoin.org/tree/develdocreadme#developer-documentation
