### PR TITLE
Add "Documentation" entry in the menu

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -69,6 +69,7 @@ if(typeof(legacyIE)==='undefined'){
         <ul>
           <li{% if page.id == 'resources' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate resources url %}">{% translate menu-resources layout %}</a></li>
           <li{% if page.id == 'community' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate community url %}">{% translate menu-community layout %}</a></li>
+          {% if page.lang == 'en' %}<li{% if page.id == 'developer-documentation' %} class="active"{% endif %}><a href="/en/developer-documentation">Documentation</a></li>{% endif %}
           <li{% if page.id == 'development' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate development url %}">{% translate menu-development layout %}</a></li>
           <li{% if page.id == 'vocabulary' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate vocabulary url %}">{% translate menu-vocabulary layout %}</a></li>
           {% case page.lang %}


### PR DESCRIPTION
As suggested on the mailing list. This documentation is probably part of the most important content served on bitcoin.org so adding it to the menu seemed like a logical step.

![capture du 2014-05-29 14 19 16](https://cloud.githubusercontent.com/assets/3578089/3122725/93ac7a22-e76a-11e3-932f-6119b9caaceb.png)

Consistently with other English-only pages, devel-docs is only displayed in the English menu (maintaining translations for devel-guide and devel-ref seems unfeasible right now).
