### PR TITLE
Use modulo instead of cycle to split language menu

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -40,11 +40,11 @@ if(typeof(legacyIE)==='undefined'){
       <li><a href="#" onclick="return false;">{{ site.langs[page.lang] }}</a>
       <ul>
         <li><ul>
-        {% assign i == 0 %}
-        {% for lang in site.langsorder %}{% assign active = ''%}{% if lang == page.lang %}{% assign active = ' class="active"'%}{% endif %}
-        {% assign m = i | modulo:11 %}{% assign i = i | plus:1 %}{% if m == 0 and i != 1 %}</li></ul><li><ul>{% endif %}
+        {% assign i = 0 %}{% assign c = site.langsorder.size | divided_by: 2 | plus: 1 %}
+        {% for lang in site.langsorder %}{% assign mod = i | modulo: c %}{% assign active = ''%}{% if lang == page.lang %}{% assign active = ' class="active"'%}{% endif %}
+        {% if mod == 0 and i != 0 %}</li></ul><li><ul>{% endif %}
           <li><a href="/{{ lang }}/{% translate {{page.id}} url {{lang}} %}"{{ active }}>{{ site.langs[lang] }}</a></li>
-        {% endfor %}
+        {% assign i = i | plus: 1 %}{% endfor %}
         </ul></li>
       </ul>
       </li>


### PR DESCRIPTION
The jekyll {% cycle %} code is a little hard to understand, easy to break, and hard to update each time we need to change the number of languages displayed per column (so we don't end with a single language in the last column).

By using modulo and divided_by, ~~we would only need to edit "modulo:11" to set a different number of languages per column~~ we can automate the number of languages per column, and edit "divided_by: 2" to set a different number of columns. This seems a more elegant solution to me.

The modulo filter has been added to liquid in 2011 and seems supported even by old jekyll versions:
https://github.com/Shopify/liquid/commit/c4d713b6bbb1a61f65583de32112756200231d5e
