### PR TITLE
Add Warning About Handling Private Keys To Transaction Examples

### DIFF
--- a/_includes/example_transactions.md
+++ b/_includes/example_transactions.md
@@ -1178,6 +1178,10 @@ transaction, the same way we got private keys in the Complex Raw
 Transaction subsection. Recall that we created a 2-of-3 multisig script,
 so signatures from two private keys are needed.
 
+**Reminder:** Users should never manually manage private keys on
+mainnet. See the warning in the [complex raw transaction section][devex
+complex raw transaction].
+
 <div markdown="1" class="multicode">
 {% highlight bash %}
 > bitcoin-cli -regtest signrawtransaction $RAW_TX '''

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -177,6 +177,7 @@
 [core paymentrequest.proto]: https://github.com/bitcoin/bitcoin/blob/master/src/qt/paymentrequest.proto
 [core script.h]: https://github.com/bitcoin/bitcoin/blob/master/src/script.h
 [DER]: https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One
+[devex complex raw transaction]: /en/developer-examples#complex-raw-transaction
 [devex payment protocol]: /en/developer-examples#payment-protocol
 [devguide]: /en/developer-guide
 [devguide avoiding key reuse]: /en/developer-guide#avoiding-key-reuse


### PR DESCRIPTION
(As an embarrassing footnote, the only time I ever handled private keys on mainnet, I lost $4.00 worth of bitcoins.  Lesson learned.)
