### PR TITLE
Make translate.rb plugin fallback to English by default

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -116,8 +116,8 @@ if(typeof(legacyIE)==='undefined'){
   </div>
   <div class="foundation-banner">
     {% case page.lang %}
-    {% when 'ar' or 'bg' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
-    <div style="direction:ltr;">{% translate sponsor layout en %} <a href="https://bitcoinfoundation.org/"><img src="/img/brand/logo_foundation.svg" alt="Foundation"> The Bitcoin Foundation</a></div>
+    {% when 'ar' or 'fa' %}
+    <div style="direction:ltr;">{% translate sponsor layout %} <a href="https://bitcoinfoundation.org/"><img src="/img/brand/logo_foundation.svg" alt="Foundation"> The Bitcoin Foundation</a></div>
     {% else %}
     <div>{% translate sponsor layout %} <a href="https://bitcoinfoundation.org/"><img src="/img/brand/logo_foundation.svg" alt="Foundation"> The Bitcoin Foundation</a></div>
     {% endcase %}

--- a/_plugins/translate.rb
+++ b/_plugins/translate.rb
@@ -63,6 +63,18 @@ module Jekyll
       if ar.has_key?(id) && ar[id].is_a?(String)
         text = ar[id]
       end
+      #fallback to English if string is empty
+      if text == ''
+        lang = 'en'
+        ar = site['loc'][lang]
+        for key in keys do
+          break if !ar.is_a?(Hash) || !ar.has_key?(key) || !ar[key].is_a?(Hash)
+          ar = ar[key]
+        end
+        if ar.has_key?(id) && ar[id].is_a?(String)
+          text = ar[id]
+        end
+      end
       #replace urls and anchors in string
       url = site['loc'][lang]['url']
       url.each do |key,value|

--- a/_templates/bitcoin-for-businesses.html
+++ b/_templates/bitcoin-for-businesses.html
@@ -28,7 +28,8 @@ id: bitcoin-for-businesses
 
 {% case page.lang %}
 {% when 'ar' or 'fa' or 'pl' or 'zh_TW' %}
+<div class="mainbutton"><a href="/en/{% translate getting-started url %}"><img src="/img/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
 {% else %}
-<div class="mainbutton"><a href="{% translate getting-started url %}"><img src="/img/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
+<div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
 {% endcase %}
 

--- a/_templates/bitcoin-for-developers.html
+++ b/_templates/bitcoin-for-developers.html
@@ -23,9 +23,4 @@ id: bitcoin-for-developers
 <h2><img class="titleicon" src="/img/ico_micro.svg" alt="Icon" />{% translate micro %}</h2>
 <p>{% translate microtext %}</p>
 
-{% case page.lang %}
-{% when 'ar' or 'fa' or 'pl' or 'zh_TW' %}
-{% else %}
 <div class="mainbutton"><a href="/en/developer-documentation"><img src="/img/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
-{% endcase %}
-

--- a/_templates/bitcoin-for-individuals.html
+++ b/_templates/bitcoin-for-individuals.html
@@ -25,6 +25,8 @@ id: bitcoin-for-individuals
 
 {% case page.lang %}
 {% when 'ar' or 'fa' or 'pl' or 'zh_TW' %}
+<div class="mainbutton"><a href="/en/{% translate getting-started url %}"><img src="/img/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
 {% else %}
-<div class="mainbutton"><a href="{% translate getting-started url %}"><img src="/img/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
+<div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
 {% endcase %}
+

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -29,9 +29,6 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-bitcoinwallet.png" alt="bitcoin wallet" />Bitcoin<br>Wallet</a>
 </div>
-{% case page.lang %}
-{% when 'ar' or 'bg' or 'de' or 'es' or 'fa' or 'fr' or 'hi' or 'hu' or 'id' or 'it' or 'nl' or 'pl' or 'pt_BR' or 'ro' or 'ru' or 'sv' or 'tr' or 'zh_CN' or 'zh_TW' %}
-{% else %}
 <div>
   <div>
     <div>
@@ -43,7 +40,6 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-hive.png" alt="hive" />Hive<br>Android</a>
 </div>
-{% endcase %}
 {% case page.lang %}
 {% when 'ar' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
 {% else %}
@@ -85,9 +81,6 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-multibit.png" alt="multibit" />MultiBit</a>
 </div>
-{% case page.lang %}
-{% when 'ar' or 'bg' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
-{% else %}
 <div>
   <div>
     <div>
@@ -99,7 +92,6 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-hive.png" alt="hive" />Hive OS X</a>
 </div>
-{% endcase %}
 <div>
   <div>
     <div>
@@ -259,9 +251,6 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-multibit.png" alt="multibit" />MultiBit</a>
 </div>
-{% case page.lang %}
-{% when 'ar' or 'bg' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
-{% else %}
 <div>
   <div>
     <div class="b1"></div>
@@ -275,7 +264,6 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-hive.png" alt="hive" />Hive OS X</a>
 </div>
-{% endcase %}
 <div>
   <div>
     <div class="b1"></div>
@@ -318,9 +306,6 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-bitcoinwallet.png" alt="bitcoin wallet" />Bitcoin<br>Wallet</a>
 </div>
-{% case page.lang %}
-{% when 'ar' or 'bg' or 'de' or 'es' or 'fa' or 'fr' or 'hi' or 'hu' or 'id' or 'it' or 'nl' or 'pl' or 'pt_BR' or 'ro' or 'ru' or 'sv' or 'tr' or 'zh_CN' or 'zh_TW' %}
-{% else %}
 <div>
   <div>
     <div class="b1"></div>
@@ -334,7 +319,6 @@ id: choose-your-wallet
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-hive.png" alt="hive" />Hive<br>Android</a>
 </div>
-{% endcase %}
 {% case page.lang %}
 {% when 'ar' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
 {% else %}

--- a/_templates/community.html
+++ b/_templates/community.html
@@ -54,7 +54,7 @@ id: community
 
 {% case page.lang %}
 {% when 'ar' or 'bg' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
-<h2>{% translate nonprofit community en %}</h2>
+<h2>{% translate nonprofit %}</h2>
 {% else %}
 <h2><a name="{% translate non-profit anchor.community %}">{% translate nonprofit %}</a></h2>
 {% endcase %}

--- a/_templates/development.html
+++ b/_templates/development.html
@@ -3,11 +3,7 @@ layout: base
 id: development
 ---
 <h1>{% translate pagetitle %}</h1>
-{% case page.lang %}
-{% when 'ar' or 'fa' or 'pl' or 'zh_TW' %}
-{% else %}
 <p class="summary">{% translate summary %}</p>
-{% endcase %}
 
 <h2>{% translate spec %}</h2>
 <p>{% translate spectxt %}</p>
@@ -33,22 +29,15 @@ id: development
   <div><div>Pieter Wuille</div><div><a href="mailto:pieter.wuille@gmail.com">pieter.wuille@gmail.com</a></div><div><a href="/pieterwuille.asc">PGP</a></div></div>
 </div>
 
-{% case page.lang %}
-{% when 'ar' or 'fa' or 'id' or 'pl' or 'zh_TW' %}
-{% else %}
 <h2>{% translate disclosure %}</h2>
 <p><a href="mailto:bitcoin-security@lists.sourceforge.net">bitcoin-security@lists.sourceforge.net</a></p>
 <p>{% translate disclosuretxt %}</p>
-{% endcase %}
 
 <h2>{% translate involve %}</h2>
 <p>{% translate involvetxt1 %}</p>
 <p>{% translate involvetxt2 %}</p>
 <div id="chatbox" class="chatbox"></div>
 
-{% case page.lang %}
-{% when 'ar' or 'fa' %}
-{% else %}
 <h2>{% translate more %}</h2>
 <ul class="devprojectlist">
   <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A Bitcoin client with enhanced security features.</li>
@@ -69,7 +58,6 @@ id: development
   <li><a href="https://sx.dyne.org/">sx</a> - Modular Bitcoin commandline utilities.</li>
   <li class="more"><a href="#" onclick="librariesShow(event)">{% translate moremore %}</a></li>
 </ul>
-{% endcase %}
 
 <section id="contributors">
   <h2>{% translate contributors %}</h2>

--- a/_templates/download.html
+++ b/_templates/download.html
@@ -20,21 +20,12 @@ id: download
       <div><img src="/img/os/med_ubuntu.svg" alt="ubuntu"> <a href="https://launchpad.net/~bitcoin/+archive/bitcoin">Ubuntu (PPA)</a> <small>~5MB</small></div>
     </div>
     <p>
-      <a href="/bin/{{site.DOWNLOAD_VERSION}}/SHA256SUMS.asc">{% case page.lang %}{% when 'ar' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}{% translate downloadsig download en %}{% else %}{% translate downloadsig %}{% endcase %}</a><br>
-      {% case page.lang %}
-      {% when 'ar' or 'bg' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
-      <a href="https://github.com/bitcoin/bitcoin">{% translate sourcecode download en %}</a><br>
-      {% else %}
+      <a href="/bin/{{site.DOWNLOAD_VERSION}}/SHA256SUMS.asc">{% translate downloadsig %}</a><br>
       <a href="https://github.com/bitcoin/bitcoin">{% translate sourcecode %}</a><br>
-      {% endcase %}
       <a href="/en/version-history">{% translate versionhistory %}</a>
     </p>
   </div>
-  {% case page.lang %}
-  {% when 'ar' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
-  {% else %}
   <h2><img src="/img/warning.svg" class="warningicon" alt="warning">{% translate patient %}</h2>
-  {% endcase %}
   <p>{% translate notesync %}</p>
   <p>{% translate notelicense %}</p>
 </div>

--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -38,9 +38,6 @@ id: resources
     <p><a href="http://bitcoincharts.com/charts/">Bitcoincharts.com</a></p>
   </div>
 </div>
-{% case page.lang %}
-{% when 'ar' or 'fa' or 'id' or 'nl' or 'tr' or 'zh_TW' %}
-{% else %}
 <div>
   <div>
     <h2><img src="/img/ico_doc.svg" class="titleicon" alt="Icon">{% translate documentaries %}</h2>
@@ -51,5 +48,4 @@ id: resources
     <p><a href="https://www.khanacademy.org/economics-finance-domain/core-finance/money-and-banking/bitcoin/v/bitcoin-what-is-it">Khan Academy</a></p>
   </div>
 </div>
-{% endcase %}
 </div>

--- a/_templates/secure-your-wallet.html
+++ b/_templates/secure-your-wallet.html
@@ -8,12 +8,8 @@ id: secure-your-wallet
 <h2><img src="/img/ico_warning.svg" class="titleicon" alt="warning">{% translate online %}</h2>
 <p>{% translate onlinetxt %}</p>
 
-{% case page.lang %}
-{% when 'ar' or 'fa' or 'pl' or 'zh_TW' %}
-{% else %}
 <h2>{% translate everyday %}</h2>
 <p>{% translate everydaytxt %}</p>
-{% endcase %}
 
 <h2>{% translate backup %}</h2>
 <p>{% translate backuptxt %}</p>
@@ -61,9 +57,6 @@ id: secure-your-wallet
 <p>{% translate offlinetxtxt5 %}</p>
 </div>
 
-{% case page.lang %}
-{% when 'ar' or 'fa' %}
-{% else %}
 <br>
 <div class="box boxexpand">
 <h3><a href="#" onclick="boxShow(event);">{% translate hardwarewallet %}</a></h3>
@@ -74,14 +67,9 @@ id: secure-your-wallet
 <a href="http://www.butterflylabs.com/bitcoin-hardware-wallet/">ButterflyLabs BitSafe</a>
 </p>
 </div>
-{% endcase %}
 
-{% case page.lang %}
-{% when 'ar' or 'fa' or 'pl' or 'zh_TW' %}
-{% else %}
 <h2>{% translate update %}</h2>
 <p>{% translate updatetxt %}</p>
-{% endcase %}
 
 <h2>{% translate offlinemulti %}</h2>
 <p>{% translate offlinemultitxt %}</p>

--- a/_templates/support-bitcoin.html
+++ b/_templates/support-bitcoin.html
@@ -11,20 +11,12 @@ id: support-bitcoin
 <h2><img class="titleicon" src="/img/ico_network.svg" alt="Icon" />{% translate node %}</h2>
 <p>{% translate nodetxt %}</p>
 
-{% case page.lang %}
-{% when 'ar' or 'bg' or 'fa' or 'id' or 'nl' or 'pl' or 'tr' or 'zh_TW' %}
-{% else %}
 <h2><img class="titleicon" src="/img/ico_mining.svg" alt="Icon" />{% translate mining %}</h2>
 <p>{% translate miningtxt %}</p>
-{% endcase %}
 
 <h2><img class="titleicon" src="/img/ico_translate.svg" alt="Icon" />{% translate translate %}</h2>
 <p>{% translate translatetxt %}</p>
-{% case page.lang %}
-{% when 'ar' %}
-{% else %}
 <p><a href="https://www.transifex.com/projects/p/bitcoin/">Bitcoin Core</a> - <a href="https://www.transifex.com/projects/p/bitcoinorg/">Bitcoin.org</a> - <a href="https://en.bitcoin.it/wiki/Bitcoin.it_Wiki">Bitcoin Wiki</a> - <a href="https://www.transifex.com/projects/p/bitcoin-wallet/">Bitcoin Wallet (Android)</a> - <a href="http://translate.multibit.org/">MultiBit</a> - <a href="http://crowdin.net/project/electrum">Electrum</a> - <a href="https://github.com/hivewallet/hive-osx/wiki/I18n-guide">Hive</a></p>
-{% endcase %}
 
 <h2><img class="titleicon" src="/img/ico_conf.svg" alt="Icon" />{% translate develop %}</h2>
 <p>{% translate developtxt %}</p>
@@ -33,7 +25,6 @@ id: support-bitcoin
 <p>{% translate donationtxt %}</p>
 
 {% case page.lang %}
-{% when 'ar' or 'fa' or 'pl' or 'zh_TW' %}
 {% when 'bg' or 'id' or 'nl' or 'tr' %}
 <h2><img class="titleicon" src="/img/ico_law.svg" alt="Icon" />{% translate foundation %}</h2>
 <p>{% translate foundationtxt %}</p>

--- a/_templates/you-need-to-know.html
+++ b/_templates/you-need-to-know.html
@@ -35,12 +35,8 @@ id: you-need-to-know
 <h2><img class="titleicon" src="/img/ico_anon.svg" alt="Icon" />{% translate anonymous %}</h2>
 <p>{% translate anonymoustxt %}</p>
 
-{% case page.lang %}
-{% when 'ar' or 'fa' %}
-{% else %}
 <h2><img class="titleicon" src="/img/ico_fast.svg" alt="Icon" />{% translate instant %}</h2>
 <p>{% translate instanttxt %}</p>
-{% endcase %}
 
 <h2><img class="titleicon" src="/img/ico_lab.svg" alt="Icon" />{% translate experimental %}</h2>
 <p>{% translate experimentaltxt %}</p>


### PR DESCRIPTION
Live preview: (Merged)

This pull requests allows {% translate %} to return the English string if no translated string is available. This can simplify updating translations and layouts in some cases.

This pull req also displays more English strings in outdated translations (e.g. some important texts still missing for some languages). This allows to reduce the number of "language-specific" content in templates and reduce the complexity of adding new content in some cases. Although displaying English strings in translations is not ideal, it appears better to me in some cases than serving incomplete content.
