### PR TITLE
Temporarily hide Hive OS X and link to Hive Android on Google Play

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -35,7 +35,7 @@ id: choose-your-wallet
       <h2>Hive Android</h2>
       <span><img src="/img/os/android.png" alt="Android" title="Android" /></span>
       <p>{% translate wallethive-android %}</p>
-      <p><a href="https://www.hivewallet.com">{% translate walletvisit %}</a></p>
+      <p><a href="https://play.google.com/store/apps/details?id=com.hivewallet.androidclient.wallet">{% translate walletvisit %}</a></p>
     </div>
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-hive.png" alt="hive" />Hive<br>Android</a>
@@ -87,7 +87,7 @@ id: choose-your-wallet
       <h2>Hive OS X</h2>
       <span><img src="/img/os/osx-uni.png" alt="Mac OS X" title="Mac OS X" /></span>
       <p>{% translate wallethive %}</p>
-      <p><a href="https://www.hivewallet.com">{% translate walletvisit %}</a></p>
+      <p><a href="https://hivewallet.com/#native">{% translate walletvisit %}</a></p>
     </div>
   </div>
   <a href="#" onclick="return false;"><img src="/img/clients/lo-hive.png" alt="hive" />Hive OS X</a>
@@ -258,7 +258,7 @@ id: choose-your-wallet
       <h2>Hive OS X</h2>
       <span><img src="/img/os/osx-uni.png" alt="Mac OS X" title="Mac OS X" /></span>
       <p class="hyphenate">{% translate wallethive %}</p>
-      <p><a href="https://www.hivewallet.com">{% translate walletvisit %}</a></p>
+      <p><a href="https://hivewallet.com/#native">{% translate walletvisit %}</a></p>
     </div>
     <div class="b3"></div>
   </div>
@@ -313,7 +313,7 @@ id: choose-your-wallet
       <h2>Hive Android</h2>
       <span><img src="/img/os/android.png" alt="Android" title="Android" /></span>
       <p class="hyphenate">{% translate wallethive-android %}</p>
-      <p><a href="https://www.hivewallet.com">{% translate walletvisit %}</a></p>
+      <p><a href="https://play.google.com/store/apps/details?id=com.hivewallet.androidclient.wallet">{% translate walletvisit %}</a></p>
     </div>
     <div class="b3"></div>
   </div>


### PR DESCRIPTION
Links to Android and OS X wallets now point to Hive's web wallet.

So current traffic from bitcoin.org is basically redirected to a web wallet that hasn't been submitted in a pull request, users expect the OS X or Android app and get the web app instead.

In the absence of critical feedback, this pull request will be merged on June 28th.

@jsuder If you want to keep your OS X app listed, can you provide a dedicated page for Hive OS X?
