### PR TITLE
Grammar fixes + security note

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -159,7 +159,7 @@ en:
     checkfailprivacyreuse: "Weak privacy"
     checkfailprivacyreusetxt: "This wallet re-uses Bitcoin addresses. This means people you transact with can spy on your balance and payments."
     educate: "Take time to educate yourself"
-    educatetxt: "Bitcoin is different than what you know and use every day. Before you start using Bitcoin for any serious transaction, be sure to read <a href=\"#you-need-to-know#\"><b>what you need to know</b></a> and take appropriate steps to <a href=\"#secure-your-wallet#\"><b>secure your wallet</b></a>. Always remember that it is your responsibility to choose your wallet carefully and adopt good practices in order to protect your money."
+    educatetxt: "Bitcoin is different from what you know and use every day. Before you start using Bitcoin for any serious transaction, be sure to read <a href=\"#you-need-to-know#\"><b>what you need to know</b></a> and take appropriate steps to <a href=\"#secure-your-wallet#\"><b>secure your wallet</b></a>. Always remember that it is your responsibility to choose your wallet carefully and adopt good practices in order to protect your money."
   development:
     title: "Development - Bitcoin"
     pagetitle: "Bitcoin development"


### PR DESCRIPTION
I think it's important to mention the issue with Blockchain.info wallet backup e-mails --- folks need to realise that they must extend good security to their e-mail accounts, and not doing so has been the cause of a few thefts in the past --- but it's a bit of a struggle to keep the text appropriately brief.

Also, couldn't find the right place to edit it and even if I could I'm uncertain, but I thought Electrum would be more appropriately described with checkfaildecentralizecentralizedtxt than checkpassdecentralizespvtxt since Electrum's network is not the same as the Bitcoin one.  Worth checking with someone who understands Electrum better.
