### PR TITLE
Update Name & Link For Okupski Developer Reference At @minium's request

### DIFF
--- a/en/developer-documentation.md
+++ b/en/developer-documentation.md
@@ -80,7 +80,7 @@ title: "Developer Documentation - Bitcoin"
   <h2><img src="/img/ico_wiki.svg" class="titleicon" alt="Icon">Additional resources</h2>
   <p><a href="/bitcoin.pdf">Bitcoin: A Peer-to-Peer Electronic Cash System</a> - Satoshi Nakamoto</p>
   <p><a href="https://github.com/bitcoin/bips#readme">Bitcoin Improvement Proposals</a> - GitHub</p>
-  <p><a href="http://enetium.com/resources/Bitcoin.pdf">Bitcoin Protocol Specification (working paper)</a> - Krzysztof Okupski</p>
+  <p><a href="https://github.com/minium/Bitcoin-Spec">Bitcoin Developer Reference (working paper)</a> - Krzysztof Okupski</p>
   <p><a href="https://bitcoinj.github.io/#documentation">Bitcoinj Developer Documentation</a> - bitcoinj.org</p>
   <p><a href="https://en.bitcoin.it/wiki/Category:Technical">Technical Pages</a> - Wiki</p>
 </div></div>


### PR DESCRIPTION
Krzysztof Okupski (@minium) asked me to update our link from the Devel Docs portal page to his protocol specification.  We now link to his git repository which contains a versioned PDF plus licensing information (CC-By-SA).

At his request, I also changed the name of the doc from "Bitcoin Protocol Specification (working paper)" to "Bitcoin Developer Reference (working paper)".  That new name is the same as one of our docs, but I'm hoping it won't be too confusing.

If there's no critical feedback to this pull, I'll merge around 13:00 UTC Thursday.
