### PR TITLE
body overflow (horizontal) fix for mobiles

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1991,9 +1991,9 @@ h2 .rssicon{
 		border:0;
 		font-size:115%;
 		position:absolute;
-		right:-20px;
+		right:10px;
 		top:18px;
-		width:120px;
+		width:110px;
 		text-indent:20px;
 	}
 	.menumobile{


### PR DESCRIPTION
the negative value of right on .langselect lead to an overflow of the body. This caused vertical scrolling on some browser + hides the arrow down to indicate an setting wich the user can change.
