### PR TITLE
Add a banner for outdated translations to invite new translators

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -16,10 +16,16 @@
 <body>
 <div id="detectmobile" class="detectmobile"></div>
 {% if site.ALERT %}
-  <div class="alert-message">
+  <div class="banner-message alert">
     <div><div>{{ site.ALERT }}</div></div>
   </div>
 {% endif %}
+{% case page.lang %}
+{% when 'fa' or 'pl' or 'tr' or 'zh_TW' %}
+  <div class="banner-message info">
+    <div><div>{% translate banner-translate layout %}</div></div>
+  </div>
+{% endcase %}
   <div class="head"><div>
     <select id="langselect" class="langselect" onchange="window.location=this.value;">
     {% for lang in site.langsorder %}{% assign active = ''%}{% if lang == page.lang %}{% assign active = ' selected="selected"'%}{% endif %}

--- a/_less/ie.css
+++ b/_less/ie.css
@@ -229,10 +229,10 @@ body{
 	display:inline;
 }
 
-.alert-message a:hover,
-.alert-message a:hover:link,
-.alert-message a:hover:active,
-.alert-message a:hover:visited{
+.banner-message a:hover,
+.banner-message a:hover:link,
+.banner-message a:hover:active,
+.banner-message a:hover:visited{
 	color:#fff;
 }
 

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -137,23 +137,26 @@ table td,table th{
 	font-style:italic;
 }
 
-.alert-message div{
-	background-color:#c5251f;
-}
-.alert-message div div{
+.banner-message div div{
 	margin:auto;
 	width:850px;
 	padding:10px;
 }
-.alert-message,
-.alert-message a,
-.alert-message a:link,
-.alert-message a:active,
-.alert-message a:visited{
+.banner-message,
+.banner-message a,
+.banner-message a:link,
+.banner-message a:active,
+.banner-message a:visited{
 	color:#fff;
 }
-.alert-message a:hover{
+.banner-message a:hover{
 	text-decoration:underline;
+}
+.banner-message.alert div{
+	background-color:#c5251f;
+}
+.banner-message.info div{
+	background-color:#0d579b;
 }
 
 .foundation-banner{
@@ -1972,6 +1975,9 @@ h2 .rssicon{
 	}
 	h1{
 		text-align:left;
+	}
+	.banner-message div div{
+		width:auto;
 	}
 	.summary{
 		text-align:left;

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -606,6 +606,7 @@ en:
     menu-support-bitcoin: Participate
     menu-vocabulary: Vocabulary
     menu-you-need-to-know: "You need to know"
+    banner-translate: "Translations for this language are outdated. <a href=\"https://github.com/bitcoin/bitcoin.org#translation\">Click here to help translate bitcoin.org in your language</a>."
     footer: "Released under the <a href=\"http://opensource.org/licenses/mit-license.php\" target=\"_blank\">MIT license</a>"
     sponsor: "A community website sponsored by"
     getstarted: "Get started with Bitcoin"


### PR DESCRIPTION
Currently at least Persian, Polish, Turkish and Chinese (traditional) translations are pretty outdated. This pull request adds a banner to these languages in order to invite new translators.

![capture du 2014-08-03 15 17 15](https://cloud.githubusercontent.com/assets/3578089/3793136/b6436fa4-1b8c-11e4-9a77-951f22eb5915.png)
