### PR TITLE
Display "Source code" link for all wallets

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1398,10 +1398,10 @@ table td,table th{
 	margin:10px 0 12px 0;
 	padding:0;
 }
-.wallets>div>div>h2:first-child+div+div>a,
-.wallets>div>div>h2:first-child+div+div>a:visited,
-.wallets>div>div>h2:first-child+div+div>a:link,
-.wallets>div>div>h2:first-child+div+div>a:active{
+.wallets>div>div>h2:first-child+div+div>a:first-child,
+.wallets>div>div>h2:first-child+div+div>a:first-child:visited,
+.wallets>div>div>h2:first-child+div+div>a:first-child:link,
+.wallets>div>div>h2:first-child+div+div>a:first-child:active{
 	display:inline-block;
 	font-weight:bold;
 	text-decoration:none;
@@ -1418,8 +1418,23 @@ table td,table th{
 	-moz-border-radius:4px;
 	border-radius:4px;
 }
-.wallets>div>div>h2:first-child+div+div>a:hover{
+.wallets>div>div>h2:first-child+div+div>a:first-child:hover{
 	background-image:none;
+}
+.wallets>div>div>h2:first-child+div+div>a:first-child+a,
+.wallets>div>div>h2:first-child+div+div>a:first-child+a:visited,
+.wallets>div>div>h2:first-child+div+div>a:first-child+a:link,
+.wallets>div>div>h2:first-child+div+div>a:first-child+a:active{
+	display:inline-block;
+	font-weight:normal;
+	text-decoration:none;
+	color:#255f96;
+	border:1px solid #255f96;
+	margin-left:10px;
+	padding:4px 8px;
+	-webkit-border-radius:4px;
+	-moz-border-radius:4px;
+	border-radius:4px;
 }
 .wallets>div>div>h2:first-child+div+div+div{
 	margin:5px 0;

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -12,6 +12,7 @@ wallets:
       desktop:
         text: "walletbitcoinqt"
         link: "walletdownload"
+        source: "https://github.com/bitcoin/bitcoin"
         screenshot: "bitcoincore.png"
         os:
         - windows
@@ -36,6 +37,7 @@ wallets:
       desktop:
         text: "walletmultibit"
         link: "https://multibit.org"
+        source: "https://github.com/jim618/multibit"
         screenshot: "multibit.png"
         os:
         - windows
@@ -60,6 +62,7 @@ wallets:
       mobile:
         text: "wallethive-android"
         link: "https://play.google.com/store/apps/details?id=com.hivewallet.androidclient.wallet"
+        source: "https://github.com/hivewallet/hive-android"
         screenshot: "hiveandroid.png"
         os:
         - android
@@ -76,6 +79,7 @@ wallets:
       desktop:
         text: "wallethive"
         link: "https://hivewallet.com/#native"
+        source: "https://github.com/hivewallet/hive-osx"
         screenshot: "hivemac.png"
         os:
         - mac
@@ -98,6 +102,7 @@ wallets:
       desktop:
         text: "walletarmory"
         link: "https://bitcoinarmory.com"
+        source: "https://github.com/etotheipi/BitcoinArmory"
         screenshot: "armory.png"
         os:
         - windows
@@ -122,6 +127,7 @@ wallets:
       desktop:
         text: "walletelectrum"
         link: "https://electrum.org"
+        source: "https://github.com/spesmilo/electrum"
         screenshot: "electrum.png"
         os:
         - windows
@@ -146,6 +152,7 @@ wallets:
       mobile:
         text: "walletbitcoinwallet"
         link: "https://play.google.com/store/apps/details?id=de.schildbach.wallet"
+        source: "https://github.com/schildbach/bitcoin-wallet"
         screenshot: "bitcoinwalletandroid.png"
         os:
         - android
@@ -163,6 +170,7 @@ wallets:
       android:
         text: "walletbitcoinwallet"
         link: "https://play.google.com/store/apps/details?id=de.schildbach.wallet"
+        source: "https://github.com/schildbach/bitcoin-wallet"
         screenshot: "bitcoinwalletandroid.png"
         os:
         - android
@@ -180,6 +188,7 @@ wallets:
       blackberry:
         text: "walletbitcoinwallet"
         link: "http://appworld.blackberry.com/webstore/content/23952882/"
+        source: "https://github.com/schildbach/bitcoin-wallet"
         screenshot: "bitcoinwalletandroid.png"
         os:
         - android
@@ -203,6 +212,7 @@ wallets:
       mobile:
         text: "walletmyceliumwallet"
         link: "https://play.google.com/store/apps/details?id=com.mycelium.wallet"
+        source: "https://github.com/mycelium-com/wallet"
         screenshot: "mycelium.png"
         os:
         - android
@@ -224,8 +234,9 @@ wallets:
     platform:
       mobile:
         text: "walletblockchaininfo"
-        link: "https://itunes.apple.com/us/app/blockchain-bitcoin-wallet/id493253309"
-        screenshot: "blockchainiphone.png"
+        link: "https://play.google.com/store/apps/details?id=piuk.blockchain.android"
+        source: "https://github.com/blockchain/My-Wallet-Android"
+        screenshot: "blockchainandroid.png"
         os:
         - android
         - iphone
@@ -242,6 +253,7 @@ wallets:
       desktop:
         text: "walletblockchaininfo"
         link: "https://chrome.google.com/webstore/detail/blockchain/glaohkkooicollgefkkmndjcbblominl"
+        source: "https://github.com/blockchain/My-Wallet-Chrome-Extension"
         screenshot: "blockchaindesktop.png"
         os:
         - windows
@@ -260,6 +272,7 @@ wallets:
       web:
         text: "walletblockchaininfo"
         link: "https://chrome.google.com/webstore/detail/blockchain/glaohkkooicollgefkkmndjcbblominl"
+        source: "https://github.com/blockchain/My-Wallet-Chrome-Extension"
         screenshot: "blockchaindesktop.png"
         os:
         check:
@@ -275,6 +288,7 @@ wallets:
       iphone:
         text: "walletblockchaininfo"
         link: "https://itunes.apple.com/us/app/blockchain-bitcoin-wallet/id493253309"
+        source: "https://github.com/blockchain/My-Wallet-iPhone"
         screenshot: "blockchainiphone.png"
         os:
         - android
@@ -292,6 +306,7 @@ wallets:
       android:
         text: "walletblockchaininfo"
         link: "https://play.google.com/store/apps/details?id=piuk.blockchain.android"
+        source: "https://github.com/blockchain/My-Wallet-Android"
         screenshot: "blockchainandroid.png"
         os:
         - android
@@ -306,7 +321,6 @@ wallets:
           privacyaddressreuse: "checkfailprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosureaccount"
           privacynetwork: "checkfailprivacynetworknosupporttor"
-
 - bitgo:
     title: "BitGo"
     titleshort: "BitGo"
@@ -337,6 +351,7 @@ wallets:
       mobile:
         text: "walletgreenaddress"
         link: "https://play.google.com/store/apps/details?id=it.greenaddress.cordova"
+        source: "https://github.com/greenaddress/WalletCordova"
         screenshot: "greenaddressandroid.png"
         os:
         - android
@@ -354,6 +369,7 @@ wallets:
       desktop:
         text: "walletgreenaddress"
         link: "https://chrome.google.com/webstore/detail/greenaddressit/dgbimgjoijjemhdamicmljbncacfndmp"
+        source: "https://github.com/greenaddress/WalletCrx"
         screenshot: "greenaddressdesktop.png"
         os:
         - windows
@@ -372,6 +388,7 @@ wallets:
       web:
         text: "walletgreenaddress"
         link: "https://chrome.google.com/webstore/detail/greenaddressit/dgbimgjoijjemhdamicmljbncacfndmp"
+        source: "https://github.com/greenaddress/WalletCrx"
         screenshot: "greenaddressdesktop.png"
         os:
         check:
@@ -387,6 +404,7 @@ wallets:
       iphone:
         text: "walletgreenaddress"
         link: "https://itunes.apple.com/us/app/greenaddress/id889740745?ls=1&mt=8"
+        source: "https://github.com/greenaddress/WalletCordova"
         screenshot: "greenaddressandroid.png"
         os:
         - android
@@ -404,6 +422,7 @@ wallets:
       android:
         text: "walletgreenaddress"
         link: "https://play.google.com/store/apps/details?id=it.greenaddress.cordova"
+        source: "https://github.com/greenaddress/WalletCordova"
         screenshot: "greenaddressandroid.png"
         os:
         - android
@@ -517,7 +536,7 @@ wallets:
   <div>
     <h2>{{ wallet[1].title }}</h2>
     <div>{% for os in platform.os %}<img src="/img/os/{{ os }}.png" alt="{{ os }}" title="{{ os }}" />{% endfor %}</div>
-    <div>{% if platform.link contains '://' %}<a href="{{ platform.link }}">{% translate walletvisit %}</a>{% else %}{% translate {{platform.link}} %}{% endif %}</div>
+    <div>{% if platform.link contains '://' %}<a href="{{ platform.link }}">{% translate walletvisit %}</a>{% else %}{% translate {{platform.link}} %}{% endif %}{% if platform.source %}<a href="{{ platform.source }}">{% translate walletsourcecode %}</a>{% endif %}</div>
     <div>
       {% for check in platform.check %}{% if check[0] == 'privacy' and platform.privacycheck %}
       <div class="check{{ check[0] }} {% if check[1] contains "checkgood" %}checkgood{% elsif check[1] contains "checkpass" %}checkpass{% elsif check[1] contains "checkneutral" %}checkneutral{% else %}checkfail{% endif %}">{% translate {{check[1]}} %}<div><div>
@@ -547,7 +566,7 @@ wallets:
   <div>
     <h2>{{ wallet[1].title }}</h2>
     <div>{% for os in platform[1].os %}<img src="/img/os/{{ os }}.png" alt="{{ os }}" title="{{ os }}" />{% endfor %}</div>
-    <div>{% if platform[1].link contains '://' %}<a href="{{ platform[1].link }}">{% translate walletvisit %}</a>{% else %}{% translate {{platform[1].link}} %}{% endif %}</div>
+    <div>{% if platform[1].link contains '://' %}<a href="{{ platform[1].link }}">{% translate walletvisit %}</a>{% else %}{% translate {{platform[1].link}} %}{% endif %}{% if platform[1].source %}<a href="{{ platform[1].source }}">{% translate walletsourcecode %}</a>{% endif %}</div>
     <div>
       {% for check in platform[1].check %}{% if check[0] == 'privacy' and platform[1].privacycheck %}
       <div class="check{{ check[0] }} {% if check[1] contains "checkgood" %}checkgood{% elsif check[1] contains "checkpass" %}checkpass{% elsif check[1] contains "checkneutral" %}checkneutral{% else %}checkfail{% endif %}">{% translate {{check[1]}} %}<div><div>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -121,6 +121,7 @@ en:
     walletgreenaddress: "GreenAddress is a user-friendly multi-signature wallet with improved security and privacy. At no time your keys are server side, not even encrypted. For security reasons, you should always use 2FA and the browser extension or Android App."
     walletdownload: "<a href=\"#download#\">Download</a>"
     walletvisit: "Visit website"
+    walletsourcecode: "Source code"
     checkgoodcontrolfull: "Control over your money"
     checkgoodcontrolfulltxt: "This wallet gives you full control over your bitcoins. This means no third party can freeze or lose your funds. You are however still responsible for securing and backing up your wallet."
     checkpasscontrolhybrid: "Hosted control over your money"


### PR DESCRIPTION
Live preview: http://bitcointest1.us.to/en/choose-your-wallet

As suggested by @schildbach, this pull request adds a light "Source code" button near the "Download" button for each wallet. This way, it's a bit easier to keep track of each app transparency.
