### PR TITLE
Add "New app" as a "Transparency" score for new wallets with a short track record

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -148,7 +148,7 @@ en:
     checkfailtransparencyremote: "Remote app"
     checkfailtransparencyremotetxt: "This wallet is loaded from a remote location. This means that whenever you use your wallet, you need to trust the developers not to steal or lose your bitcoins in an incident on their site. Using a browser extension or mobile app, if available, can reduce that risk."
     checkfailtransparencynew: "New app"
-    checkfailtransparencynewtxt: "The developers of this wallet publish the source code for the client. However, this wallet still has a short track record and few public feedback, testing and reviews. This means this app might be more at risk of hiding dangerous code or doing something you wouldn't agree to."
+    checkfailtransparencynewtxt: "The developers of this wallet publish the source code for the client. However, this wallet has not been tested and publicly reviewed by a significant number of people. This means this app might be more at risk of hiding dangerous code or doing something you wouldn't agree to."
     checkgoodenvironmenthardware: "Very secure environment"
     checkgoodenvironmenthardwaretxt: "This wallet is loaded from a secure specialized environment provided by the device. This provides very strong protection against computer vulnerabilities and malware since no software can be installed on this environment."
     checkpassenvironmentmobile: "Secure environment"


### PR DESCRIPTION
There seems to be a few interesting wallets (Aegis, Breadwallet, Ciphrex) which may be good choices for the user. However, many of them have been released only more recently.

This pull request adds a "Transparency" score text which warns the user that such wallets still don't have a very long track record, in order to find a good compromise that would allow us to list them while being transparent about the few public testing / review these wallets may have received yet.
