### PR TITLE
Remove download sizes

### DIFF
--- a/_templates/download.html
+++ b/_templates/download.html
@@ -10,14 +10,14 @@ id: download
   <div class="downloadbox">
     <p>{% translate downloados %}</p>
     <div>
-      <div><img src="/img/os/med_win.png" alt="windows"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-win32-setup.exe">Windows (32bit)</a> <small>~11MB</small></div>
-      <div><img src="/img/os/med_win.png" alt="windows"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-win64-setup.exe">Windows (64bit)</a> <small>~12MB</small></div>
-      <div><img src="/img/os/med_win.png" alt="windows"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-win.zip">Windows (zip)</a> <small>~61MB</small></div>
+      <div><img src="/img/os/med_win.png" alt="windows"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-win32-setup.exe">Windows (32bit)</a></div>
+      <div><img src="/img/os/med_win.png" alt="windows"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-win64-setup.exe">Windows (64bit)</a></div>
+      <div><img src="/img/os/med_win.png" alt="windows"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-win.zip">Windows (zip)</a></div>
     </div>
     <div>
-      <div><img src="/img/os/med_osx.png" alt="osx"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-osx.dmg">Mac OS X</a> <small>~13MB</small></div>
-      <div><img src="/img/os/med_linux.png" alt="linux"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-linux.tar.gz">Linux (tgz)</a> <small>~36MB</small></div>
-      <div><img src="/img/os/med_ubuntu.svg" alt="ubuntu"> <a href="https://launchpad.net/~bitcoin/+archive/bitcoin">Ubuntu (PPA)</a> <small>~5MB</small></div>
+      <div><img src="/img/os/med_osx.png" alt="osx"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-osx.dmg">Mac OS X</a></div>
+      <div><img src="/img/os/med_linux.png" alt="linux"> <a href="/bin/{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-linux.tar.gz">Linux (tgz)</a></div>
+      <div><img src="/img/os/med_ubuntu.svg" alt="ubuntu"> <a href="https://launchpad.net/~bitcoin/+archive/bitcoin">Ubuntu (PPA)</a></div>
     </div>
     <p>
       <a href="/bin/{{site.DOWNLOAD_VERSION}}/SHA256SUMS.asc">{% translate downloadsig %}</a><br>


### PR DESCRIPTION
These numbers must currently be updated manually after a release (but that never happens in practice).

Most of them could be updated automatically as the files are hosted on the same server but I personally don't think it's worth the trouble, and that it's better to remove them.
