### PR TITLE
Change Max PrivKey From n To n-1

### DIFF
--- a/_includes/guide_wallets.md
+++ b/_includes/guide_wallets.md
@@ -260,7 +260,7 @@ stored on pieces of paper.
 
 Private keys are what are used to unlock satoshis from a particular address. In Bitcoin, a private key in standard format is simply a 256-bit number, between the values:
 
-0x1 and 0xFFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFE BAAE DCE6 AF48 A03B BFD2 5E8C D036 4141, representing nearly the entire range of 2<sup>256</sup>-1 values. The range is governed by the secp256k1 ECDSA encryption standard used by Bitcoin. 
+0x01 and 0xFFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFE BAAE DCE6 AF48 A03B BFD2 5E8C D036 4140, representing nearly the entire range of 2<sup>256</sup>-1 values. The range is governed by the secp256k1 ECDSA encryption standard used by Bitcoin. 
 
 {% endautocrossref %}
 


### PR DESCRIPTION
I could use a quick confirmation on this issue/pull from someone knowledgeable about ECDSA.

I've been reading about ECDSA, and I'm pretty sure the value we have for the maximum private key (k(max)) is incorrect.  The value we have for k(max) is n (the multiplicative order of G), but I think k(max) is supposed to be n-1.

Although there's no guarantee its implementation is correct, pybitcointools seems to bear this out:

```
>>> kmax=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
>>> privtopub(kmax)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/bitcoin/main.py", line 346, in privkey_to_pubkey
    raise Exception("Invalid privkey")
Exception: Invalid privkey
>>> privtopub(kmax-1)
(55066263022277343669578718895168534326250603453777594175500187360389116729240L, 83121579216557378445487899878180864668798711284981320763518679672151497189239L)
```

In the context of child keys, this also makes sense, as n (mod n) would be 0, which is not a valid private key.

I'm guessing @instagibbs used this value because it's what https://en.bitcoin.it/wiki/Private_key says.  If I can get someone knowledgeable in secp256k1 to confirm k(max) = n-1, I'll update that wiki page also.
