### PR TITLE
Set "checkfailtransparencynew" score to recent wallets codebase

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -253,7 +253,7 @@ wallets:
         check:
           control: "checkgoodcontrolfull"
           decentralization: "checkfaildecentralizecentralized"
-          transparency: "checkpasstransparencyopensource"
+          transparency: "checkfailtransparencynew"
           environment: "checkpassenvironmentmobile"
           privacy: "checkpassprivacybasic"
         privacycheck:
@@ -333,7 +333,7 @@ wallets:
         check:
           control: "checkpasscontrolhybrid"
           decentralization: "checkfaildecentralizecentralized"
-          transparency: "checkfailtransparencyclosedsource"
+          transparency: "checkfailtransparencynew"
           environment: "checkpassenvironmentmobile"
           privacy: "checkfailprivacyweak"
         privacycheck:
@@ -386,7 +386,7 @@ wallets:
         check:
           control: "checkpasscontrolhybrid"
           decentralization: "checkfaildecentralizecentralized"
-          transparency: "checkpasstransparencyopensource"
+          transparency: "checkfailtransparencynew"
           environment: "checkpassenvironmentmobile"
           privacy: "checkfailprivacyweak"
         privacycheck:
@@ -404,7 +404,7 @@ wallets:
         check:
           control: "checkpasscontrolhybrid"
           decentralization: "checkfaildecentralizecentralized"
-          transparency: "checkfailtransparencyclosedsource"
+          transparency: "checkfailtransparencynew"
           environment: "checkpassenvironmentmobile"
           privacy: "checkfailprivacyweak"
         privacycheck:


### PR DESCRIPTION
As discussed in #525.

IIRC, Hive iOS / Web and Blockchain.info's Android app are the apps that have been released / restarted within 6 months.
