### PR TITLE
Update/fix block size limits

### DIFF
--- a/_includes/ref_block_chain.md
+++ b/_includes/ref_block_chain.md
@@ -19,8 +19,8 @@ As of version 2 blocks, each block consists of four root elements:
 
 2. A 4-byte unsigned integer indicating how many bytes follow until the
    end of the block. Although this field would suggest maximum block
-   sizes of 4 GiB, max block size is currently capped at 1 MiB and the
-   default max block size (used by most miners) is 350 KiB (although
+   sizes of 4 GiB, max block size is currently capped at 1 MB and the
+   default max block size (used by most miners) is 750 KB (although
    this will likely increase over time).
 
 3. An 80-byte block header described in the section below.


### PR DESCRIPTION
Bitcoin limits are usually defined using decimal-friendly numbers of bytes. The block size is limited to 1 MB, not 1 MiB, for example. Also, the latest block size limit is 750 KB, not 350 KB.
