### PR TITLE
Add "Developer Communities" To Development Page

### DIFF
--- a/_includes/guide_intro.md
+++ b/_includes/guide_intro.md
@@ -5,7 +5,8 @@ Bitcoin and start building Bitcoin-based applications. To make the best use of
 this documentation, you may want to install the current version of Bitcoin
 Core, either from [source][core git] or from a [pre-compiled executable][core executable].
 
-Questions about Bitcoin development are best asked in the Bitcoin [IRC channels][].
+Questions about Bitcoin development are best asked in one of the
+[Bitcoin development communities][dev communities].
 Errors or suggestions related to
 documentation on Bitcoin.org can be [submitted as an issue][docs issue]
 or posted to the [bitcoin-documentation mailing list][].

--- a/_includes/ref_intro.md
+++ b/_includes/ref_intro.md
@@ -5,7 +5,8 @@ to help you start building Bitcoin-based applications. To make the best use of
 this documentation, you may want to install the current version of Bitcoin
 Core, either from [source][core git] or from a [pre-compiled executable][core executable].
 
-Questions about Bitcoin development are best asked in the Bitcoin [IRC channels][].
+Questions about Bitcoin development are best asked in one of the
+[Bitcoin development communities][dev communities].
 Errors or suggestions related to
 documentation on Bitcoin.org can be [submitted as an issue][docs issue]
 or posted to the [bitcoin-documentation mailing list][].

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -178,6 +178,7 @@
 [core script.h]: https://github.com/bitcoin/bitcoin/blob/master/src/script.h
 [CVE-2012-2459]: https://en.bitcoin.it/wiki/CVEs#CVE-2012-2459
 [DER]: https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One
+[dev communities]: /en/development#devcommunities
 [devex complex raw transaction]: /en/developer-examples#complex-raw-transaction
 [devex payment protocol]: /en/developer-examples#payment-protocol
 [devexamples]: /en/developer-examples

--- a/_templates/development.html
+++ b/_templates/development.html
@@ -63,6 +63,17 @@ id: development
   <li class="more"><a href="#" onclick="librariesShow(event)">{% translate moremore %}</a></li>
 </ul>
 
+<section id="devcommunities">
+  <h2>{% translate devcommunities %}</h2>
+  <p>{% translate devcommunitiesintro %}</p>
+
+  <ul>
+    <li>{% translate ircjoin %}</li>
+    <li>{% translate stackexchange %}</li>
+    <li>{% translate bitcointalkdev %}</li>
+  </ul>
+</section>
+
 <section id="contributors">
   <h2>{% translate contributors %}</h2>
   <p>{% translate contributorsorder %}</p>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -211,6 +211,11 @@ en:
     moremore: "Show more..."
     contributors: "Bitcoin Core contributors"
     contributorsorder: "(Ordered by number of commits)"
+    devcommunities: "Developer Communities"
+    devcommunitiesintro: "The following chatrooms and websites host discussions about Bitcoin development.  Please be sure to read their rules of conduct before posting."
+    ircjoin: "<a href=\"https://webchat.freenode.net/?channels=bitcoin-dev\">IRC Channel #bitcoin-dev</a> on freenode."
+    stackexchange: "<a href=\"https://bitcoin.stackexchange.com/\">Bitcoin StackExchange</a>"
+    bitcointalkdev: "<a href=\"https://bitcointalk.org/index.php?board=6.0\">BitcoinTalk Development & Technical Discussion Forum</a>"
   download:
     title: "Download - Bitcoin"
     pagetitle: "Download Bitcoin Core"


### PR DESCRIPTION
- Adds links to the #bitcoin IRC channel, Bitcoin StackExchange, and BitcoinTalk Dev & Tech board to the development page.
- Links to that section of the page from the devel docs.

Screenshot:

![2014-10-03-210045_452x338_scrot](https://cloud.githubusercontent.com/assets/61096/4514350/679172ce-4b67-11e4-88f3-aa3d1fd16a34.png)

**BitcoinTalk Quality:** a concern was raised in https://github.com/bitcoin/bitcoin.org/pull/589#discussion_r18311326 about the quality of help on BitcoinTalk. I did a quick, highly-subjective and unscientific survey of the top ten displayed non-stickied posts on the dev & tech board, and the help I saw being provided ranged from adequate to great. Many of the replies I saw came from members of the community whose expertise I trust.

I don't dispute that the forum has trolls and scammers, but I'd recommend it to a friend who needed a place to ask questions.

@saivann If you see anything that can be improved in the translation template stuff (or anything else), please feel free to push directly to the branch.
