### PR TITLE
Adding the link to the official Romanian forum

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -14,7 +14,7 @@ id: community
     {% if page.lang == 'es' %}<p><a href="http://forobitco.in/">ForoBitco.in en Español</a></p>{% endif %}
     {% if page.lang == 'es' %}<p><a href="http://www.forobtc.com/">Foro Bitcoin en Español</a></p>{% endif %}
     {% if page.lang == 'pl' %}<p><a href="https://forum.bitcoin.pl/">Polski portal bitcoin.pl</a></p>{% endif %}
-    {% if page.lang == 'ro' %}<p><a href="http://forum.bitcoin.ro/">Forumul oficial Bitcoin Romania</a></p>{% endif %}
+    {% if page.lang == 'ro' %}<p><a href="http://forum.bitcoin.ro/">Forumul comunitatii Bitcoin Romania</a></p>{% endif %}
     <p>{% translate bitcointalk %}</p>
     <p><a href="http://reddit.com/r/Bitcoin/">{% translate reddit %}</a></p>
     <p><a href="https://bitcoin.stackexchange.com/">{% translate stackexchange %}</a></p>


### PR DESCRIPTION
Please include this change so that Romanian speaking users can have a link to the official forum from the community page.

Thank you!
