### PR TITLE
Dev Docs Correction: Checkmultisg Requires Sigs In Same Order As PubKeys

### DIFF
--- a/_includes/guide_contracts.md
+++ b/_includes/guide_contracts.md
@@ -94,7 +94,10 @@ OP_0 [A's signature] [B's or C's signature] [serialized redeem script]
 
 (Op codes to push the signatures and redeem script onto the stack are
 not shown. `OP_0` is a workaround for an off-by-one error in the original
-implementation which must be preserved for compatibility.)
+implementation which must be preserved for compatibility.  Note that
+the signature script must provide signatures in the same order as the
+corresponding public keys appear in the redeem script.  See the description in
+[`OP_CHECKMULTISIG`][op_checkmultisig] for details.)
 
 When the transaction is broadcast to the network, each peer checks the
 signature script against the P2SH output Charlie previously paid,

--- a/_includes/guide_transactions.md
+++ b/_includes/guide_transactions.md
@@ -360,11 +360,16 @@ consumes one more value from the stack than indicated by *m*, so the
 list of secp256k1 signatures in the signature script must be prefaced with an extra value
 (`OP_0`) which will be consumed but not used.
 
+The signature script must provide signatures in the same order as the
+corresponding public keys appear in the pubkey script or redeem
+script. See the desciption in [`OP_CHECKMULTISIG`][op_checkmultisig]
+for details.
+
 {% endautocrossref %}
 
 ~~~
-Pubkey script: <m> <pubkey> [pubkey] [pubkey...] <n> OP_CHECKMULTISIG
-Signature script: OP_0 <sig> [sig] [sig...]
+Pubkey script: <m> <A pubkey> [B pubkey] [C pubkey...] <n> OP_CHECKMULTISIG
+Signature script: OP_0 <A sig> [B sig] [C sig...]
 ~~~
 
 {% autocrossref %}
@@ -375,8 +380,8 @@ Although it’s not a separate transaction type, this is a P2SH multisig with 2-
 
 ~~~
 Pubkey script: OP_HASH160 <Hash160(redeemScript)> OP_EQUAL
-Redeem script: <OP_2> <pubkey> <pubkey> <pubkey> <OP_3> OP_CHECKMULTISIG
-Signature script: OP_0 <sig> <sig> <redeemScript>
+Redeem script: <OP_2> <A pubkey> <B pubkey> <C pubkey> <OP_3> OP_CHECKMULTISIG
+Signature script: OP_0 <A sig> <C sig> <redeemScript>
 ~~~
 
 {% autocrossref %}


### PR DESCRIPTION
Preview: http://dg2.dtrt.org/en/developer-reference#term-op-checkmultisig

As reported by @gsalgado (thanks!), the docs incorrectly state that all sigs are compared against all pubkeys.  This commit provides a corrected description, additional details, and references in other parts of the text where we mention multisig. (Fixes #622)

Note: the wiki has the same error, so I'll be updating that momentarily.
