### PR TITLE
Only display wallets for selected platform

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1266,16 +1266,45 @@ table td,table th{
 
 .wallets{
 	width:605px;
+	height:250px;
 	text-align:left;
 	position:relative;
 	margin:auto;
 	padding:40px 0 20px 0;
 	font-size:0;
+	opacity:1;
+	-moz-transition:opacity 400ms ease-out;
+	-webkit-transition:opacity 400ms ease-out;
+	transition:opacity 400ms ease-out;
+}
+.wallets.disabled{
+	opacity:0;
 }
 .wallets>div{
-	display:inline-block;
+	display:none;
 	vertical-align:top;
 	font-size:16px;
+}
+.wallets>div:nth-child(1n){
+	display:inline-block;
+}
+.wallets>div:nth-child(1n+13){
+	display:none;
+}
+.wallets>div:first-child,
+.wallets>div:first-child+div,
+.wallets>div:first-child+div+div,
+.wallets>div:first-child+div+div+div,
+.wallets>div:first-child+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div{
+	/*IE8 Support*/
+	display:inline-block;
 }
 .wallets>div>a,
 .wallets>div>a:visited,
@@ -1295,18 +1324,6 @@ table td,table th{
 	-moz-transition:opacity 400ms ease-out;
 	-webkit-transition:opacity 400ms ease-out;
 	transition:opacity 400ms ease-out;
-}
-.wallets>div.disabled>a{
-	cursor:default;
-	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
-	opacity:0.2;
-	-webkit-filter:grayscale(100%);
-	-moz-filter:grayscale(100%);
-	-ms-filter:grayscale(100%);
-	-o-filter:grayscale(100%);
-	filter:grayscale(100%);
-	filter:url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#grayscale");
-	filter:alpha(opacity=20), gray;
 }
 .wallets>div>a>span{
 	display:none;
@@ -2345,9 +2362,7 @@ h2 .rssicon{
 	}
 	.wallets{
 		width:auto;
-	}
-	.wallets>div.disabled{
-		display:none;
+		height:auto;
 	}
 	.wallets>div:hover>span{
 		display:none;

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -701,7 +701,7 @@ wallets:
   </ul>
 </div>
 
-<div class="wallets" id="wallets" onclick="walletMobileShow(event);walletDisabledShow(event);">
+<div class="wallets" id="wallets" onclick="walletShow(event);">
 {% for wallet in page.wallets %}{% for wallet in wallet %}{% if wallet[1].platform.mobile %}{% assign platform = wallet[1].platform.mobile %}{% elsif wallet[1].platform.desktop %}{% assign platform = wallet[1].platform.desktop %}{% elsif wallet[1].platform.hardware %}{% assign platform = wallet[1].platform.hardware %}{% else %}{% assign platform = wallet[1].platform.web %}{% endif %}
 <div id="wallet-{{ wallet[0] }}" data-walletcompat="{{ wallet[1].compat }}" data-walletlevel="{{ wallet[1].level }}">
   <span></span>
@@ -764,7 +764,6 @@ wallets:
 <div class="wallets walletsmobile" id="walletsmobile"></div>
 
 <script>if(isMobile())walletShowPlatform('mobile');else walletShowPlatform('desktop');</script>
-<script>walletRotate();</script>
 
 <div class="walletsdisclaimer">
 <h2><img src="/img/warning.svg" class="warningicon" alt="warning">{% translate educate %}</h2>


### PR DESCRIPTION
Live preview: (Merged)

This change allows the page to scale better with the increasing number of wallets by displaying only selected wallets. This way the page can display more wallets on two lines instead of three, and prevent the education disclaimer to be buried too far at the end of the page. 

This also allows to avoid a layout with too much greyed out entries, which can be counter-intuitive, and avoid providing too much choice by default (to not fall too much into the paradox of choice). At some point, a "Show all" button could be added to display more than 12 wallets.

At the same time, this pull req fixes issue #488.
