### PR TITLE
Drop good tor privacy score for mycelium

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -397,7 +397,7 @@ wallets:
         privacycheck:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosurecentralized"
-          privacynetwork: "checkpassprivacynetworksupporttorproxy"
+          privacynetwork: "checkfailprivacynetworknosupporttor"
 - blockchain:
     title: "Blockchain.info"
     titleshort: "Blockchain<br>.info"


### PR DESCRIPTION
Seems like Mycelium has a bug that makes it ignore socks settings (and tor).
https://github.com/mycelium-com/wallet/issues/109

@apetersson Feel free to comment here if you have relevant information, or to report when the app is fixed.

In the absence of critical feedback, this pull request will be merged on November 2th.
