### PR TITLE
Allow disabling plugins for faster preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ commands:
     ## Or build the site and run all tests
     make all
 
+#### Partial build for faster preview
+
+In order to preview some changes faster, you can disable all plugins and
+languages but those you need by prefixing the `ENABLED_LANGS` and `ENABLED_PLUGINS`
+environment variables:
+
+    ENABLED_PLUGINS="events autocrossref" ENABLED_LANGS="en fr" make all
+
 ## Developer Documentation
 
 Each part of the documentation can be found in the [_includes](https://github.com/bitcoin/bitcoin.org/tree/master/_includes)

--- a/_plugins/alerts.rb
+++ b/_plugins/alerts.rb
@@ -48,8 +48,13 @@ module Jekyll
 
   class AlertPageGenerator < Generator
     def generate(site)
-      #generate each alert based on templates
+      #Generate each alert based on templates
       site.config['STATUS'] = 0
+      #Do nothing if plugin is disabled
+      if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('alerts').nil?
+        print 'Alerts disabled' + "\n"
+        return
+      end
       Dir.foreach('_alerts') do |file|
         next if file == '.' or file == '..'
         lang = 'en'

--- a/_plugins/autocrossref.rb
+++ b/_plugins/autocrossref.rb
@@ -86,4 +86,30 @@ require 'yaml'
   end
 end
 
-Liquid::Template.register_tag('autocrossref', Jekyll::AutoCrossRefBlock)
+module Jekyll
+
+require 'yaml'
+
+  class AutoCrossRefBlockDisabled < Liquid::Block
+
+    def initialize(tag_name, text, tokens)
+      super
+    end
+
+    def render(context)
+      output = super
+
+      output
+    end
+  end
+end
+
+
+
+#Do nothing if plugin is disabled
+if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('autocrossref').nil?
+  print 'Autocrossref disabled' + "\n"
+  Liquid::Template.register_tag('autocrossref', Jekyll::AutoCrossRefBlockDisabled)
+else
+  Liquid::Template.register_tag('autocrossref', Jekyll::AutoCrossRefBlock)
+end

--- a/_plugins/contributors.rb
+++ b/_plugins/contributors.rb
@@ -92,9 +92,21 @@ module Jekyll
           h
         end
       end
+
+      # Set site.corecontributors and site.sitecontributors arrays
+      site.corecontributors = {}
+      site.sitecontributors = {}
+
+      #Do nothing if plugin is disabled
+      if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('contributors').nil?
+        print 'Contributors disabled' + "\n"
+        return
+      end
+
       # Populate site.corecontributors and site.sitecontributors arrays
       site.corecontributors = contributors('bitcoin/bitcoin',site.config['aliases'])
       site.sitecontributors = contributors('bitcoin/bitcoin.org',site.config['aliases'])
+
     end
 
   end

--- a/_plugins/events.rb
+++ b/_plugins/events.rb
@@ -130,9 +130,19 @@ module Jekyll
           h
         end
       end
-      # Populate site.conferences array
+
+      # Set site.conferences and site.meetups arrays
+      site.conferences = {}
+      site.meetups = {}
+
+      #Do nothing if plugin is disabled
+      if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('events').nil?
+        print 'Events disabled' + "\n"
+        return
+      end
+
+      # Populate site.conferences and site.meetups arrays
       site.conferences = conferences()
-      # Populate site.meetups array
       site.meetups = meetups()
     end
 

--- a/_plugins/redirects.rb
+++ b/_plugins/redirects.rb
@@ -22,6 +22,13 @@ module Jekyll
 
   class RedirectPageGenerator < Generator
     def generate(site)
+
+      #Do nothing if plugin is disabled
+      if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('redirects').nil?
+        print 'Redirects disabled' + "\n"
+        return
+      end
+
       #Load redirections
       redirects = YAML.load_file("_config.yml")['redirects']
       #Generate each redirection page

--- a/_plugins/releases.rb
+++ b/_plugins/releases.rb
@@ -43,6 +43,13 @@ module Jekyll
 
   class ReleasePageGenerator < Generator
     def generate(site)
+
+      #Do nothing if plugin is disabled
+      if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('releases').nil?
+        print 'Releases disabled' + "\n"
+        return
+      end
+
       #generate each release based on templates
       Dir.foreach('_releases') do |file|
         next if file == '.' or file == '..'

--- a/_plugins/sitemap.rb
+++ b/_plugins/sitemap.rb
@@ -14,11 +14,23 @@ module Jekyll
 
   class SitemapGenerator < Generator
     def generate(site)
+      #Do nothing if plugin is disabled
+      if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('sitemap').nil?
+        print 'Sitemap disabled' + "\n"
+        return
+      end
       #Load translations
       locs = {}
+      enabled = ENV['ENABLED_LANGS'];
+      enabled = enabled.split(' ') if !enabled.nil?
       Dir.foreach('_translations') do |file|
         next if file == '.' or file == '..'
         lang=file.split('.')[0]
+        #Ignore lang if disabled
+        if lang != 'en' and !enabled.nil? and !enabled.include?(lang)
+          print 'Lang ' + lang + ' disabled' + "\n"
+          next
+        end
         locs[lang] = YAML.load_file('_translations/'+file)[lang]
       end
       #Create destination directory if does not exists

--- a/_plugins/templates.rb
+++ b/_plugins/templates.rb
@@ -22,9 +22,16 @@ module Jekyll
     def generate(site)
       #load translations files
       locs = {}
+      enabled = ENV['ENABLED_LANGS'];
+      enabled = enabled.split(' ') if !enabled.nil?
       Dir.foreach('_translations') do |file|
         next if file == '.' or file == '..'
         lang = file.split('.')[0]
+        #Ignore lang if disabled
+        if lang != 'en' and !enabled.nil? and !enabled.include?(lang)
+          print 'Lang ' + lang + ' disabled' + "\n"
+          next
+        end
         locs[lang] = YAML.load_file("_translations/"+file)[lang]
       end
       #Generate each translated page based on templates


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin.org/tree/partialbuild#partial-build-for-faster-preview

This can allow contributors to significantly reduce time spent on waiting for building the website with the increasing features and languages supported.

I'll do a little more testing but so far these changes seem pretty straightforward and successfully reduce build time from ~4 minutes to ~17 seconds.
