### PR TITLE
default to mobile on choose-your-wallet

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -763,7 +763,7 @@ wallets:
 
 <div class="wallets walletsmobile" id="walletsmobile"></div>
 
-<script>if(isMobile())walletShowPlatform('mobile');else walletShowPlatform('desktop');</script>
+<script>walletShowPlatform('mobile');</script>
 
 <div class="walletsdisclaimer">
 <h2><img src="/img/warning.svg" class="warningicon" alt="warning">{% translate educate %}</h2>


### PR DESCRIPTION
I'm biased, but I propose that the choose-your-wallet page should default to mobile wallets even if the user views the page from a desktop system. Most new users learning about bitcoin for the first time are going to have very little computer security knowledge, and the prevalence of bitcoin stealing malware is growing at an alarming rate. http://www.coindesk.com/report-bitcoin-targeted-22-financial-malware-attacks/

We should encourage new users to use mobile platforms that use app sandboxing and other methods of hardening against malware. The problem of bitcoin stealing malware is only going to get worse. I'd like to hear feedback from others.
