### PR TITLE
Add #2 iTunes Bitcoin Podcast to Resources Page

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -52,6 +52,7 @@ id: resources
   </div><div>
     <h2><img src="/img/icons/ico_solve.svg" class="titleicon" alt="Icon">{% translate learn %}</h2>
     <p><a href="http://letstalkbitcoin.com/">Let's Talk Bitcoin</a></p>
+    <p><a href="http://www.bitcoin.kn/">Bitcoin Knowledge Podcast</a></p>
     <p><a href="https://www.khanacademy.org/economics-finance-domain/core-finance/money-and-banking/bitcoin/v/bitcoin-what-is-it">Khan Academy</a></p>
   </div>
 </div>


### PR DESCRIPTION
Add link to homepage of the #2 Bitcoin podcast in iTunes.
