### PR TITLE
Dev Docs: Update Disclaimer

### DIFF
--- a/_includes/fragment_reviews_needed.md
+++ b/_includes/fragment_reviews_needed.md
@@ -5,7 +5,7 @@ http://opensource.org/licenses/MIT.
 
 <!--Temporary disclaimer BEGIN-->
 <div id="develdocdisclaimer" class="develdocdisclaimer"><div>
-<b>BETA</b>: This documentation has been written recently and still needs more reviews to ensure all content is covered correctly and accurately; if you find a mistake, please <a href="https://github.com/bitcoin/bitcoin.org/issues/new" onmouseover="updateIssue(event);">report an issue</a> on GitHub. <a href="#" onclick="disclaimerClose(event);">Click here</a> to close this disclaimer.
+<b>BETA</b>: This documentation has not been extensively reviewed by Bitcoin experts and so likely contains numerous errors. Please use the <em>Issue</em> and <em>Edit</em> links on the bottom left menu to help us improve.  <a href="#" onclick="disclaimerClose(event);">Click here</a> to close this disclaimer.
 <a class="develdocdisclaimerclose" href="#" onclick="disclaimerClose(event);">X</a>
 </div></div>
 <script>disclaimerAutoClose();</script>


### PR DESCRIPTION
Ironically, the disclaimer about possible inaccuracies became itself inaccurate.  This commit fixes that.

**Current Disclaimer:**

![2014-12-12-195410_639x127_scrot](https://cloud.githubusercontent.com/assets/61096/5421867/3fa48fb6-823b-11e4-86b7-7b838b96ceee.png)

**New Disclaimer:**

![2014-12-12-195349_656x169_scrot](https://cloud.githubusercontent.com/assets/61096/5421868/4cfbe7b8-823b-11e4-85fb-46d6a11f4f65.png)
