### PR TITLE
DON'T MERGE: Adding Psuedo-Type Info To RPC/REST JSON

### DIFF
--- a/_includes/ref/bitcoin-core/rpcs/rpcs/addmultisigaddress.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/addmultisigaddress.md
@@ -17,31 +17,31 @@ The `addmultisigaddress` RPC {{summary_addMultiSigAddress}}
 
 *Parameter #1---the number of signatures required*
 
-| Name               | Type            | Presence                    | Description
-|--------------------|-----------------|-----------------------------|----------------
-| Required           | number (int)    | Required<br>(exactly 1)     | The minimum (*m*) number of signatures required to spend this m-of-n multisig script
+| Name               | Type            | #   | Description
+|--------------------|-----------------|-----|----------------
+| Required           | {{t_m_p2sh_msig}} | 1 | The minimum (*m*) number of signatures required to spend this m-of-n multisig script
 {:.ntpd}
 
 *Parameter #2---the full public keys, or addresses for known public keys*
 
-| Name                | Type            | Presence                    | Description
+| Name                | Type            | #   | Description
 |---------------------|-----------------|-----------------------------|----------------
-| Keys Or Addresses   | array           | Required<br>(exactly 1)     | An array of strings with each string being a public key or address
-| →<br>Key Or Address | string          | Required<br>(1 or more)     | A public key against which signatures will be checked.  Alternatively, this may be a P2PKH address belonging to the wallet---the corresponding public key will be substituted.  There must be at least as many keys as specified by the Required parameter, and there may be more keys
+| Keys Or Addresses   | {{t_array}}     | 1   | An array of strings with each string being a public key or address
+| →<br>Key Or Address | {{t_pubkey}}, {{t_p2pkh_address}} | >=1 | A public key against which signatures will be checked.  Alternatively, this may be a P2PKH address belonging to the wallet---the corresponding public key will be substituted.  There must be at least as many keys as specified by the Required parameter, and there may be more keys
 {:.ntpd}
 
 *Parameter #3---the account name*
 
-| Name               | Type            | Presence                    | Description
+| Name               | Type            | #   | Description
 |--------------------|-----------------|-----------------------------|----------------
-| Account            | string          | Optional<br>(0 or 1)        | The account name in which the address should be stored.  Default is the default account, "" (an empty string)
+| Account            | {{t_account}}   | 0,1 | The account name in which the address should be stored.  Default is the default account, "" (an empty string)
 {:.ntpd}
 
 *Result---a P2SH address printed and stored in the wallet*
 
-| Name               | Type            | Presence                    | Description
+| Name               | Type            | #     | Description
 |--------------------|-----------------|-----------------------------|----------------
-| `result`           | string (base58) | Required<br>(exactly 1)     | The P2SH multisig address.  The address will also be added to the wallet, and outputs paying that address will be tracked by the wallet
+| `result`           | {{t_p2sh_address}} | 1  | The P2SH multisig address.  The address will also be added to the wallet, and outputs paying that address will be tracked by the wallet
 {:.ntpd}
 
 *Example from Bitcoin Core 0.10.0*

--- a/_includes/ref/bitcoin-core/types.md
+++ b/_includes/ref/bitcoin-core/types.md
@@ -1,0 +1,96 @@
+{% comment %}
+This file is licensed under the MIT License (MIT) available on
+http://opensource.org/licenses/MIT.
+{% endcomment %}
+
+### Types
+
+<!-- TK:TODO
+  * Need test in Makefile to error on unset {{variables}}
+  * Maybe move each type to a separate file and put in
+    alphabetical order
+  * Type variable assignments need to be in vars.md so we can also use
+    them earlier in the docs
+  * Need to update RPC introduction to describe changing "Presence"
+    field name to "#"
+  * Maybe give the type column a min-width so nearby tables with
+    different width columns don't look so ugly
+  * Maybe put "#" column before "Type" column
+  * Add autocrossref
+
+-->
+
+{{WARNING}} This type reference is not normative. JSON only supports six
+(TK:check) types, and any additional type-like restrictions Bitcoin Core
+currently provides should not be relied upon.
+
+#### M (Of-N In P2SH Multisig) {#t_m_p2sh_msig}
+
+{% assign t_m_p2sh_msig="[m (P2SH multisig)][t_m_p2sh_msig]" %}
+
+*JSON numeric:* An integer enumerating the *minimum* (m) number of
+signatures required to spend a multisignature script. Minimum value 1
+(TK:check, although 0 would be silly). Maximum value for a valid script
+is 20 (TK:check), but only up to 15 compressed pubkeys (7 uncompressed)
+will fit in a max-sized 520-byte P2SH multisig script.
+
+#### JSON Array {#t_array}
+
+{% assign t_array="[array][t_array]" %}
+
+*JSON array:* A JSON array.  See JSON specification (TK:link).
+
+#### Public Key {#t_pubkey}
+
+{% assign t_pubkey="[pubkey][t_pubkey]" %}
+
+*JSON string:* An ECDSA 33-byte compressed public key or 65-byte
+uncompressed public key encoded as hexadecimal. Example
+(compressed pubkey):
+
+{% highlight text %}
+02032ef18b83b9a0487452cc6ea288428c29c138cc76e48db6fe6034a981ed7051
+{% endhighlight %}
+
+#### P2PKH Address {#t_p2pkh_address}
+
+{% assign t_p2pkh_address="[P2PKH address][t_p2pkh_address]" %}
+
+*JSON string:* A base58check string encoding a version byte and the HASH160 of a
+compressed or uncompressed public key in internal byte order. See
+the address conversion section (TK:link) for details.  Example
+(testnet):
+
+{% highlight text %}
+n1AR3hM31xh2rjmhRi1z5Qj2hy5oQMgRXR
+{% endhighlight %}
+
+Note: the version byte must be verified as appropriate for the network.
+The version byte is 0x00 on mainnet, and is 0x6f on testnet and regtest.
+
+#### Account {#t_account}
+
+{% assign t_account="[account][t_account]" %}
+
+{{WARNING}} The account system, which includes this type, is deprecated
+and will be removed in a future Bitcoin Core release.
+
+*JSON string:* A unicode (TK:check) string naming an account. An empty
+string ("") has special meaning as the default account. An ASCII
+asterisk ("*") has special meaning in some listing contexts as "display
+values from all accounts". Maximum string length is TK:research.
+
+#### P2SH Address {#t_p2sh_address}
+
+{% assign t_p2sh_address="[P2SH address][t_p2sh_address]" %}
+
+*JSON string:* A base58check string encoding a version byte and the
+HASH160 of a serialized script (up to 520 bytes). See the address
+conversion section (TK:link) for details. Example (testnet):
+
+{% highlight text %}
+2MyVxxgNBk5zHRPRY2iVjGRJHYZEp1pMCSq
+{% endhighlight %}
+
+Note: the version byte must be verified as appropriate for the network.
+The version byte is 0x05 on mainnet, and is 0xc4 on testnet and regtest.

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -301,6 +301,14 @@ http://opensource.org/licenses/MIT.
 [rest get block-notxdetails]: /en/developer-reference#get-blocknotxdetails
 [rest get tx]: /en/developer-reference#get-tx
 
+<!-- Types used in RPC & REST (and maybe elsewhere); alphabetical order -->
+[t_account]: /en/developer-reference#t_account
+[t_array]: /en/developer-reference#t_array
+[t_m_p2sh_msig]: /en/developer-reference#t_m_p2sh_msig
+[t_p2sh_address]: /en/developer-reference#t_p2sh_address
+[t_p2pkh_address]: /en/developer-reference#t_p2pkh_address
+[t_pubkey]: /en/developer-reference#t_pubkey
+
 <!-- Other internal site links; alphabetical order -->
 [Bitcoin Core 0.6.0]: /en/release/v0.6.0
 [Bitcoin Core 0.6.1]: /en/release/v0.6.1

--- a/en/developer-reference.md
+++ b/en/developer-reference.md
@@ -40,6 +40,8 @@ title: "Developer Reference - Bitcoin"
 
 {% include ref/bitcoin-core/api-intro.md %}
 
+{% include ref/bitcoin-core/types.md %}
+
 {% include ref/bitcoin-core/rpcs/intro.md %}
 
 {% include ref/bitcoin-core/rpcs/quick-ref.md %}


### PR DESCRIPTION
This is a quick (but functional) mock-up of @darioteixeira's recent [suggestion to bitcoin-development](http://www.mail-archive.com/bitcoin-development@lists.sourceforge.net/msg07069.html) implemented for just a single RPC, AddMultiSigAddress.

We add a new section ([preview](http://dg2.dtrt.org/en/developer-reference#types)) for types, which starts with a warning that the extended type definitions are non-normative.

The essential characteristics of each type are described. For this quick mock-up, I provided type details off the top of my head, and only did the types used by AddMultiSigAddress. For an actual pull, I'd of course check the code or run tests.

Then we use those types in the AddMultiSignature description ([HTML preview](http://dg2.dtrt.org/en/developer-reference#addmultisigaddress)), which looks like this:

![2015-02-18-191357_628x362_scrot](https://cloud.githubusercontent.com/assets/61096/6259649/0721d6b0-b7a3-11e4-8596-b34de988d913.png)

To make some extra room, I renamed the Presence column to "#" and used symbolic representations of the previous text description.  I dislike this---it's less clear---but space is limited.

That's it. Making some crude guesses, I think there's probably between 20 to 40 "types" that would need to be researched and written, and then all the tables would need to be updated, making for probably about a 10 to 20 hour update.  The change seems useful enough, although probably not a high priority.

@darioteixeira comments?  Anyone else, comments?