### PR TITLE
Enable gzip compression

### DIFF
--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -64,7 +64,7 @@ do
 
 	# Update site and exit if site has been successfully built
 	if [ -e "$WORKDIR/_builddone" ]; then
-		find $WORKDIR/_site \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.svg' -o -iname '*.rss' -o -iname '*.xml' \) -exec gzip -9 -k {} \;
+		find $WORKDIR/_site \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.rss' -o -iname '*.xml' -o -iname '*.svg' -o -iname '*.ttf' \) -exec gzip -9 -k {} \;
 		rsync --delete -zrt $WORKDIR/_site/ $DESTDIR/
 		exit
 	fi

--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -64,6 +64,7 @@ do
 
 	# Update site and exit if site has been successfully built
 	if [ -e "$WORKDIR/_builddone" ]; then
+		find $WORKDIR/_site \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.svg' -o -iname '*.rss' -o -iname '*.xml' \) -exec gzip -9 -k {} \;
 		rsync --delete -zrt $WORKDIR/_site/ $DESTDIR/
 		exit
 	fi


### PR DESCRIPTION
This pull request adds support for gzip compression in order to increase performance and reduce load on the server (thanks to @louisjc and @harding for the idea on issue #916).

This single line change allows the build script to generate a .gz copy of all files for which compression offers a measurable improvement. This is done right after the website has successfully built, and before transferring files to the live server.

I have tested the build script and nginx locally with the following configuration and everything seemed to work as expected. Only compressed files are sent using gzip as the Content-Encoding header. The website also remains compatible with IE6 as expected.

~~~
	gzip_static on;
	gzip_disable "msie6";
~~~

@harding sha256sums.txt is already generated before files are compressed, so unless I am missing something, it should still work fine with that change.