### PR TITLE
Simplify javascript code for expanding lists and blocks

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,6 +12,7 @@
 {% capture metadescription %}{% translate metadescription %}{% endcapture %}{% if metadescription != '' %}<meta name="description" content="{{ metadescription }}">{% endif %}
 {% lesscss main.less %}
 <!--[if lt IE 8]>{% lesscss ie.css %}<script type="text/javascript" src="/js/ie.js"></script><![endif]-->
+<!--[if IE 8]>{% lesscss ie8.less %}<![endif]-->
 {% if page.lang == 'ar' or page.lang == 'fa' %}{% lesscss rtl.less %}{% endif %}
 {% if page.lang == 'bg' or page.lang == 'el' or page.lang == 'ko' or page.lang == 'hi' or page.lang == 'pl' or page.lang == 'sl' or page.lang == 'ro' or page.lang == 'ru' or page.lang == 'tr' or page.lang == 'uk' or page.lang == 'zh_CN' or page.lang == 'zh_TW' %}{% lesscss sans.less %}{% endif %}
 <script type="text/javascript" src="/js/base.js"></script>

--- a/_less/ie8.less
+++ b/_less/ie8.less
@@ -1,0 +1,82 @@
+/*
+This file is licensed under the MIT License (MIT) available on
+http://opensource.org/licenses/MIT.
+*/
+
+.wallets>div{
+	display:none;
+}
+.wallets>div:first-child,
+.wallets>div:first-child+div,
+.wallets>div:first-child+div+div,
+.wallets>div:first-child+div+div+div,
+.wallets>div:first-child+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div{
+	display:inline-block;
+}
+
+.wallets>div:first-child+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div>span{
+	top:-222px;
+}
+
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>span,
+.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>span{
+	top:-92px;
+}
+
+.press-quotes p{
+	display:none;
+}
+.press-quotes p:first-child,
+.press-quotes p:first-child+p,
+.press-quotes p:first-child+p+p,
+.press-quotes p:first-child+p+p+p,
+.press-quotes p:first-child+p+p+p+p,
+.press-quotes p:first-child+p+p+p+p+p,
+.press-quotes p:first-child+p+p+p+p+p+p,
+.press-quotes p:first-child+p+p+p+p+p+p+p{
+	display:inline-block;
+}
+.press-quotes.expanded p{
+	display:inline-block;
+}
+
+.devprojectlist li{
+	display:none;
+}
+.devprojectlist li:first-child,
+.devprojectlist li:first-child+li,
+.devprojectlist li:first-child+li+li,
+.devprojectlist li:first-child+li+li+li{
+	display:list-item;
+}
+.devprojectlist.expanded li{
+	display:list-item;
+}

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1024,6 +1024,9 @@ div.post {
 }
 .boxexpand{
 	overflow:hidden;
+	-moz-transition:height 400ms ease-out;
+	-webkit-transition:height 400ms ease-out;
+	transition:height 400ms ease-out;
 }
 .boxexpand>*{
 	display:none;
@@ -1036,6 +1039,9 @@ div.post {
 .boxexpand>h3:first-child a:visited,
 .boxexpand>h3:first-child a:active{
 	text-decoration:none;
+}
+.boxexpand.expanded>*{
+	display:block;
 }
 
 .titlelight{
@@ -1217,19 +1223,24 @@ div.post {
 .devprojectlist{
 	overflow:hidden;
 	margin:-10px 0;
+	-moz-transition:height 400ms ease-out;
+	-webkit-transition:height 400ms ease-out;
+	transition:height 400ms ease-out;
 }
 .devprojectlist li{
-	display:none;
 	margin:10px 0;
 }
-.devprojectlist li:first-child,
-.devprojectlist li:first-child+li,
-.devprojectlist li:first-child+li+li,
-.devprojectlist li:first-child+li+li+li{
+.devprojectlist li:nth-child(1n+4){
+	display:none;
+}
+.devprojectlist.expanded li:nth-child(1n+4){
 	display:list-item;
 }
 .devprojectlist li.more{
 	display:block;
+}
+.devprojectlist.expanded li.more{
+	display:none;
 }
 .devprojectlist a{
 	display:inline-block;
@@ -1379,30 +1390,12 @@ div.post {
 	opacity:0;
 }
 .wallets>div{
-	display:none;
+	display:inline-block;
 	vertical-align:top;
 	font-size:16px;
 }
-.wallets>div:nth-child(1n){
-	display:inline-block;
-}
 .wallets>div:nth-child(1n+13){
 	display:none;
-}
-.wallets>div:first-child,
-.wallets>div:first-child+div,
-.wallets>div:first-child+div+div,
-.wallets>div:first-child+div+div+div,
-.wallets>div:first-child+div+div+div+div,
-.wallets>div:first-child+div+div+div+div+div,
-.wallets>div:first-child+div+div+div+div+div+div,
-.wallets>div:first-child+div+div+div+div+div+div+div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div{
-	/*IE8 Support*/
-	display:inline-block;
 }
 .wallets>div>a,
 .wallets>div>a:visited,
@@ -1494,38 +1487,8 @@ div.post {
 .wallets>div:nth-child(1n+7)>span{
 	top:-222px;
 }
-.wallets>div:first-child+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div>span{
-	/*IE8 Support*/
-	top:-222px;
-}
 .wallets>div:nth-child(1n+13)>div,
 .wallets>div:nth-child(1n+13)>span{
-	top:-92px;
-}
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>div,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>span,
-.wallets>div:first-child+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div+div>span{
-	/*IE8 Support*/
 	top:-92px;
 }
 .wallets>div>div>h2{
@@ -1993,6 +1956,9 @@ h2 .rssicon{
 	-webkit-transition:height 400ms ease-out;
 	transition:height 400ms ease-out;
 }
+.press-faq>div>div.expanded{
+	height:auto;
+}
 .press-faq li{
 	line-height:1.5em;
 }
@@ -2052,16 +2018,18 @@ h2 .rssicon{
 
 .press-quotes{
 	margin-bottom:40px;
+	overflow:hidden;
+	-moz-transition:height 400ms ease-out;
+	-webkit-transition:height 400ms ease-out;
+	transition:height 400ms ease-out;
+}
+.press-quotes.expanded{
+	height:auto;
 }
 .press-quotes div{
 	position:relative;
 	left:-20px;
 	text-align:left;
-	height:350px;
-	overflow:hidden;
-	-moz-transition:height 400ms ease-out;
-	-webkit-transition:height 400ms ease-out;
-	transition:height 400ms ease-out;
 }
 .press-quotes p{
 	display:inline-block;
@@ -2069,10 +2037,19 @@ h2 .rssicon{
 	width:400px;
 	margin:0 0 20px 20px;
 }
+.press-quotes p:nth-child(1n+9){
+	display:none;
+}
+.press-quotes.expanded p:nth-child(1n+9){
+	display:inline-block;
+}
 .press-quotes>a{
 	display:inline-block;
 	padding-top:10px;
 	font-weight:bold;
+}
+.press-quotes.expanded>a{
+	display:none;
 }
 .press-quotes span:first-child{
 	font-weight:bold;

--- a/js/main.js
+++ b/js/main.js
@@ -115,54 +115,43 @@ for (var i = 0, n = domPrefixes.length; i < n; i++) {
 return false;
 }
 
+function expandBox(t) {
+// Expand or shrink box.
+var phe = getHeight(t);
+t.style.transition = t.style.MozTransition = t.style.WebkitTransition = 'all 0s ease 0s';
+if (t.className.indexOf('expanded') === -1) addClass(t, 'expanded');
+else removeClass(t, 'expanded');
+t.style.height = '';
+var nhe = getHeight(t);
+t.style.height = phe + 'px';
+// Async call to prevent transition from applying on last style.height statement.
+setTimeout(function() {
+	t.style.transition = t.style.MozTransition = t.style.WebkitTransition = '';
+	t.style.height = nhe + 'px';
+}, 20);
+}
+
 function boxShow(e) {
 // Display the box content when the user click a box on the "Secure your wallet" page.
-var p = t = getEventTarget(e);
-while (p.nodeName != 'DIV') p = p.parentNode;
-var sh = getHeight(p);
-for (var i = 0, nds = p.childNodes, n = nds.length; i < n; i++)
-	if (nds[i].nodeType == 1) nds[i].style.display = 'block';
-t.removeAttribute('href');
-t.onclick = '';
-var dh = getHeight(p);
-p.style.height = sh + 'px';
-setTimeout(function() {
-	p.style.transition = 'height 400ms ease-out';
-	p.style.MozTransition = 'height 400ms ease-out';
-	p.style.WebkitTransition = 'height 400ms ease-out';
-	setTimeout(function() {
-		p.style.height = dh + 'px';
-	}, 20);
-}, 20);
+var t = getEventTarget(e);
+while (t.nodeName != 'DIV') t = t.parentNode;
+expandBox(t);
 cancelEvent(e);
 }
 
 function faqShow(e) {
 // Display the content of a question in the FAQ at user request.
-var p = t = getEventTarget(e);
-while (p.nodeType != 1 || p.nodeName != 'DIV') p = p.nextSibling;
-var pp = p.cloneNode(true);
-pp.style.visibility = 'hidden';
-pp.style.height = 'auto';
-p.parentNode.appendChild(pp);
-var nhe = getHeight(pp);
-pp.parentNode.removeChild(pp);
-p.style.height = (p.style.height != '0px' && p.style.height != '') ? '0px' : nhe + 'px';
+var t = getEventTarget(e);
+while (t.nodeType != 1 || t.nodeName != 'DIV') t = t.nextSibling;
+expandBox(t);
 cancelEvent(e);
 }
 
 function materialShow(e) {
 // Display more materials on the "Press center" page at user request.
 var p = t = getEventTarget(e);
-while (p.nodeType != 1 || p.nodeName != 'DIV') p = p.previousSibling;
-var pp = p.cloneNode(true);
-pp.style.visibility = 'hidden';
-pp.style.height = 'auto';
-p.parentNode.appendChild(pp);
-var nhe = getHeight(pp);
-pp.parentNode.removeChild(pp);
-p.style.height = (p.style.height != '0px' && p.style.height != '') ? '0px' : nhe + 'px';
-t.style.display = 'none';
+while (p.nodeType != 1 || p.nodeName != 'DIV') p = p.parentNode;
+expandBox(p);
 cancelEvent(e);
 }
 
@@ -170,19 +159,7 @@ function librariesShow(e) {
 // Display more open source projects on the "Development" page at user request.
 var p = t = getEventTarget(e);
 while (p.nodeType != 1 || p.nodeName != 'UL') p = p.parentNode;
-var sh = getHeight(p);
-for (var i = 0, nds = p.getElementsByTagName('LI'), n = nds.length; i < n; i++) nds[i].style.display = 'list-item';
-t.parentNode.parentNode.removeChild(t.parentNode);
-var dh = getHeight(p);
-p.style.height = sh + 'px';
-setTimeout(function() {
-	p.style.transition = 'height 400ms ease-out';
-	p.style.MozTransition = 'height 400ms ease-out';
-	p.style.WebkitTransition = 'height 400ms ease-out';
-	setTimeout(function() {
-		p.style.height = dh + 'px';
-	}, 20);
-}, 20);
+expandBox(p);
 cancelEvent(e);
 }
 


### PR DESCRIPTION
There is currently 4 different javascript functions duplicating code for doing mostly the same thing; animating lists or boxes as they expand on user demand.

This pull request makes some optimizations to simplify and shorten the code, by adopting better practices such as moving styles to CSS stylesheets and using a single function to do the animation.

At the same time, some big blocks of related CSS code used only for IE8's compatibility are moved into a separate file to reduce the load for most browsers and simplify compatibility maintenance.

I have tested the changes with IE8-9-10 and various OP, CH, SA, FF versions.

Live preview:
http://bitcointest1.us.to/en/press
http://bitcointest1.us.to/en/secure-your-wallet
http://bitcointest1.us.to/en/choose-your-wallet
http://bitcointest1.us.to/en/development

In the absence of critical feedback, this pull request will be merged on June 29th.