### PR TITLE
DevDocs: update a mis-directed link and clarify SIGHASH_SINGLE definitions

### DIFF
--- a/_data/glossary/en/sighash-anyonecanpay.yaml
+++ b/_data/glossary/en/sighash-anyonecanpay.yaml
@@ -37,7 +37,7 @@ optional:
         - "`sighash_single|sighash_anyonecanpay`"
 
     not_to_be_confused_with_capitalize_first_letter:
-        - SIGHASH_SINGLE (which signs only a single input, like SIGHASH_ANYONECANPAY, but also signs a single output)
+        - SIGHASH_SINGLE (which signs only a single output while allowing the sequence number of other inputs to be updated)
 
     links_html_or_markdown_style_capitalize_first_letter:
         - "[SIGHASH_ANYONECANPAY](/en/developer-guide#term-sighash-anyonecanpay) --- Bitcoin.org Developer Guide"

--- a/_data/glossary/en/sighash-anyonecanpay.yaml
+++ b/_data/glossary/en/sighash-anyonecanpay.yaml
@@ -7,8 +7,7 @@ required:
     title_max_40_characters_no_formatting: SIGHASH_ANYONECANPAY
 
     summary_max_255_characters_no_formatting: >
-        A signature hash type which modifies the behavior of other signature hash types
-        to allow signing only the current input.
+        A signature hash type which signs only the current input.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - SIGHASH_ANYONECANPAY
@@ -37,7 +36,7 @@ optional:
         - "`sighash_single|sighash_anyonecanpay`"
 
     not_to_be_confused_with_capitalize_first_letter:
-        - SIGHASH_SINGLE (which signs only a single output while allowing the sequence number of other inputs to be updated)
+        - SIGHASH_SINGLE (which signs this input, its corresponding output, and other inputs partially)
 
     links_html_or_markdown_style_capitalize_first_letter:
         - "[SIGHASH_ANYONECANPAY](/en/developer-guide#term-sighash-anyonecanpay) --- Bitcoin.org Developer Guide"

--- a/_data/glossary/en/sighash-single.yaml
+++ b/_data/glossary/en/sighash-single.yaml
@@ -7,10 +7,10 @@ required:
     title_max_40_characters_no_formatting: SIGHASH_SINGLE
 
     summary_max_255_characters_no_formatting: >
-        Signature hash type which signs the output corresponding to this input
+        Signature hash type that signs the output corresponding to this input
         (the one with the same index value), this input, and any other inputs
-        partially. Allows modification of other outputs. The partial signing of
-        other inputs allows modification of their sequence numbers.
+        partially. Allows modification of other outputs and the sequence number
+        of other inputs.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - SIGHASH_SINGLE

--- a/_data/glossary/en/sighash-single.yaml
+++ b/_data/glossary/en/sighash-single.yaml
@@ -7,10 +7,10 @@ required:
     title_max_40_characters_no_formatting: SIGHASH_SINGLE
 
     summary_max_255_characters_no_formatting: >
-        Signature hash type which signs all of the inputs, but only the one
-        output corresponding to this input (the one with the same index value),
-        allowing modification of other outputs and the sequence number of other
-        inputs.
+        Signature hash type which signs the output corresponding to this input
+        (the one with the same index value), this input, and any other inputs
+        partially. Allows modification of other outputs. The partial signing of
+        other inputs allows modification of their sequence numbers.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - SIGHASH_SINGLE

--- a/_data/glossary/en/sighash-single.yaml
+++ b/_data/glossary/en/sighash-single.yaml
@@ -7,9 +7,10 @@ required:
     title_max_40_characters_no_formatting: SIGHASH_SINGLE
 
     summary_max_255_characters_no_formatting: >
-        Signature hash type which only signs its input and the output
-        with the same index value, allowing modification of other inputs
-        and outputs.
+        Signature hash type which signs all of the inputs, but only the one
+        output corresponding to this input (the one with the same index value),
+        allowing modification of other outputs and the sequence number of other
+        inputs.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - SIGHASH_SINGLE
@@ -19,7 +20,7 @@ optional:
         - "`SIGHASH_SINGLE`"
 
     not_to_be_confused_with_capitalize_first_letter:
-        - SIGHASH_ANYONECANPAY (a flag to signature hash types that only signs a single input, like SIGHASH_SINGLE, but which doesn't sign any outputs.)
+        - SIGHASH_ANYONECANPAY (a flag to signature hash types that only signs this single input)
 
     links_html_or_markdown_style_capitalize_first_letter:
         - "[`SIGHASH_SINGLE`](/en/developer-guide#term-sighash-single) --- Bitcoin.org Developer Guide"

--- a/_includes/guide_transactions.md
+++ b/_includes/guide_transactions.md
@@ -517,12 +517,13 @@ currently available:
   allowing anyone to change where the satoshis are going unless other
   signatures using other signature hash flags protect the outputs.
 
-* [`SIGHASH_SINGLE`][/en/glossary/sighash-none]{:#term-sighash-single}{:.term} signs only this input and only one corresponding
-  output (the output with the same output index number as the input), ensuring
+* [`SIGHASH_SINGLE`][/en/glossary/sighash-single]{:#term-sighash-single}{:.term}
+  signs only the output corresponding to this input (the output
+  with the same output index number as the input), ensuring
   nobody can change your part of the transaction but allowing other
   signers to change their part of the transaction. The corresponding
   output must exist or the value "1" will be signed, breaking the security
-  scheme.
+  scheme. The sequence numbers of other inputs are not signed and can be updated.
 
 The base types can be modified with the [`SIGHASH_ANYONECANPAY`][/en/glossary/sighash-anyonecanpay]{:#term-sighash-anyonecanpay}{:.term} (anyone can
 pay) flag, creating three new combined types:
@@ -536,9 +537,8 @@ pay) flag, creating three new combined types:
   allows anyone to add or remove other inputs or outputs, so anyone who
   gets a copy of this input can spend it however they'd like.
 
-* `SIGHASH_SINGLE|SIGHASH_ANYONECANPAY` signs only this input and only
-  one corresponding output, but it also allows anyone to add or remove
-  other inputs.
+* `SIGHASH_SINGLE|SIGHASH_ANYONECANPAY` signs this one input and its
+  corresponding output. Allows anyone to add or remove other inputs.
 
 Because each input is signed, a transaction with multiple inputs can
 have multiple signature hash types signing different parts of the transaction. For

--- a/_includes/guide_transactions.md
+++ b/_includes/guide_transactions.md
@@ -518,12 +518,13 @@ currently available:
   signatures using other signature hash flags protect the outputs.
 
 * [`SIGHASH_SINGLE`][/en/glossary/sighash-single]{:#term-sighash-single}{:.term}
-  signs only the output corresponding to this input (the output
-  with the same output index number as the input), ensuring
-  nobody can change your part of the transaction but allowing other
-  signers to change their part of the transaction. The corresponding
-  output must exist or the value "1" will be signed, breaking the security
-  scheme. The sequence numbers of other inputs are not signed and can be updated.
+  the only output signed is the one corresponding to this input (the output
+  with the same output index number as this input), ensuring nobody can change
+  your part of the transaction but allowing other signers to change their part
+  of the transaction. The corresponding output must exist or the value "1" will
+  be signed, breaking the security scheme. This input, as well as other inputs,
+  are included in the signature. The sequence numbers of other inputs are not
+  included in the signature, and can be updated.
 
 The base types can be modified with the [`SIGHASH_ANYONECANPAY`][/en/glossary/sighash-anyonecanpay]{:#term-sighash-anyonecanpay}{:.term} (anyone can
 pay) flag, creating three new combined types:


### PR DESCRIPTION
First, there was a mis-directed link that was going to the SIGHASH_NONE definition page.

Second, the definitions for SIGHASH_SINGLE didn't seem to be consistent with the current code. The definitions at https://en.bitcoin.it/wiki/OP_CHECKSIG seem much closer. The code I'm looking at is https://github.com/bitcoin/bitcoin/blob/bc60b2b4b401f0adff5b8b9678903ff8feb5867b/src/script/interpreter.cpp#L-1024-1101

Hopefully, these definitions are closer to how it actually works.