### PR TITLE
Site Readme: Link To More Advanced Workflow Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ You simply need to push additional commits on the appropriate branch of your Git
 3. Replace your master branch by the upstream master branch. `git reset --hard upstream/master`
 4. Replace your master branch on GitHub. `git push origin master -f`
 
+**Advanced GitHub Workflow**
+
+If you continue to contribute to Bitcoin.org beyond a single pull
+request, you may want to use a more [advanced GitHub
+workflow](https://gist.github.com/harding/1a99b0bad37f9498709f).
+
 ### Previewing
 
 #### Preview Small Text Changes


### PR DESCRIPTION
The Bitcoin.org readme covers the basics of opening a PR, but it doesn't document any sort of everyday workflow for regular contributors.  I think documenting that directly in the readme might confuse newbies, so I documented it elsewhere and asked a couple contributors to review it.

They thought it was useful (thanks!), so this PR adds a link to it from the readme.