### PR TITLE
Hide wallets on click, not on mouseout

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1295,7 +1295,6 @@ div.post {
 	background-repeat:no-repeat;
 	background-position:left 6px;
 	color:#383838;
-	cursor:pointer;
 	margin:15px 10px;
 	font-size:130%;
 	font-weight:bold;
@@ -1332,6 +1331,7 @@ div.post {
 	padding:8px 10px 5px 42px;
 	display:block;
 	white-space:nowrap;
+	cursor:pointer;/*Workaround for iPads*/
 }
 .walletmenu ul li ul{
 	display:none;

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1456,7 +1456,9 @@ div.post {
 	left:0;
 	right:0;
 }
-.wallets>div:hover>a>span{
+.wallets>div:hover>a>span,
+.wallets>div.active>a>span,
+.wallets>div.nohover.active:hover>a>span{
 	display:block;
 }
 .wallets>div.nohover:hover>a>span{
@@ -1498,7 +1500,11 @@ div.post {
 	z-index:102;
 }
 .wallets>div:hover>div,
-.wallets>div:hover>span{
+.wallets>div:hover>span,
+.wallets>div.active>div,
+.wallets>div.active>span,
+.wallets>div.nohover.active:hover>div,
+.wallets>div.nohover.active:hover>span{
 	opacity:1;
 	width:auto;
 	height:350px;

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -878,7 +878,7 @@ wallets:
 <h1>{% translate pagetitle %}</h1>
 <p class="summary">{% translate pagedesc %}</p>
 
-<div class="walletmenu" id="walletmenu" onmouseover="walletMenuListener(event);" onmouseout="walletMenuListener(event);" onclick="walletMenuListener(event);">
+<div class="walletmenu" id="walletmenu" onclick="walletMenuListener(event);">
   <ul onclick="mobileMenuHover(event);">
     <li class="wallet-mobile">
     <a id="mobile" data-walletcompat="mobile">{% translate walletcatmobile %}</a>

--- a/js/main.js
+++ b/js/main.js
@@ -390,7 +390,8 @@ var t = getEventTarget(e),
     walletShow = function() {
 	// Show wallet on click on mobile or desktop.
 	if (t.id == 'wallets') return;
-	while (t.parentNode.id != 'wallets') t = t.parentNode;
+	while (t.parentNode && t.parentNode.id != 'wallets') t = t.parentNode;
+	if (!t.parentNode) return;
 	if (isMobile()) {
 		var p = document.getElementById('walletsmobile');
 		t = t.cloneNode(true);
@@ -398,40 +399,21 @@ var t = getEventTarget(e),
 		p.appendChild(t);
 		scrollToNode(p);
 	} else {
-		var pc = t.getAttribute('data-previousclass');
-		if (pc === null || pc === '') t.setAttribute('data-previousclass', t.className);
-		removeClass(t, 'nohover');
-		removeClass(t, 'disabled');
-		addEvent(t, 'mouseover', walletListener);
-		addEvent(t, 'mouseout', walletListener);
+		addClass(t, 'active');
+		addEvent(document.body, 'click', walletListener);
 	}
     },
     walletHide = function() {
-	// Disable wallet when the mouse leaves the wallet bubble.
-	if (t.id == 'wallets') return;
-	while (t.parentNode.id != 'wallets') t = t.parentNode;
-	clearTimeout(t.getAttribute('data-disabletimeout'));
-	if (e.type == 'mouseover') return;
-	t.setAttribute('data-disabletimeout', setTimeout(function() {
-		var pc = t.getAttribute('data-previousclass');
-		if (pc === null) pc = '';
-		for (var i = 0, nds = pc.split(' '), n = nds.length; i < n; i++) addClass(t, nds[i]);
-		t.removeAttribute('data-previousclass');
-		t.removeAttribute('data-disabletimeout');
-		removeEvent(t, 'mouseout', walletListener);
-		removeEvent(t, 'mouseover', walletListener);
-	}, 1));
+	// Disable wallet when the mouse clicks elsewhere.
+	for (var i = 0, wallets = document.getElementById('wallets').childNodes, n = wallets.length; i < n; i++) {
+		if (wallets[i].nodeType != 1) continue;
+		removeClass(wallets[i], 'active');
+	}
+	removeEvent(document.body, 'click', walletListener);
 };
 // Pre-process events and call appropriate function.
-switch (e.type) {
-	case 'click':
-		walletShow();
-		break;
-	case 'mouseover':
-	case 'mouseout':
-		walletHide();
-		break;
-}
+walletHide();
+walletShow();
 }
 
 function walletShowPlatform(platform) {

--- a/js/main.js
+++ b/js/main.js
@@ -354,33 +354,11 @@ var t = getEventTarget(e),
 			scrollToNode(document.getElementById('wallets'));
 		}, 10);
 	}
-    },
-    walletFallbackPlatform = function() {
-	// Show back wallets for selected platform when the mouse leaves the menu without selecting another platform.
-	var select = null,
-	    active = null;
-	for (var i = 0, nds = walletMenu.getElementsByTagName('A'), n = nds.length; i < n; i++) {
-		if (nds[i].getAttribute('data-select') == '1') select = nds[i];
-		if (nds[i].getAttribute('data-active') == '1') active = nds[i];
-	}
-	if (select === null || active === null) return;
-	walletShowPlatform(select.getAttribute('data-walletcompat'));
     };
 // Pre-process events and call appropriate function.
-switch (e.type) {
-	case 'click':
-		if (t.nodeName == 'A') walletSelectPlatform();
-		break;
-	case 'mouseover':
-		if (t.nodeName == 'A') {
-			walletShowPlatform(t.getAttribute('data-walletcompat'));
-			clearTimeout(walletMenu.getAttribute('data-wallettimeout'));
-		}
-		break;
-	case 'mouseout':
-		clearTimeout(walletMenu.getAttribute('data-wallettimeout'));
-		walletMenu.setAttribute('data-wallettimeout', setTimeout(walletFallbackPlatform, 100));
-		break;
+if (t.nodeName == 'A') {
+	walletSelectPlatform();
+	walletShowPlatform(t.getAttribute('data-walletcompat'));
 }
 }
 
@@ -467,7 +445,6 @@ p.setAttribute('timeout', setTimeout(function() {
 	}
 	walletRotate()
 	removeClass(p, 'disabled');
-	document.getElementById('walletsmobile').innerHTML = '';
 }, ti));
 }
 


### PR DESCRIPTION
Live preview: http://bitcointest2.us.to/en/choose-your-wallet

This is a change I've noticed on bitcoin.com which I like. I often found that I have trouble navigating between wallets as the mouse easily slips outside of the bubble, which forces to me click on the wallet again to re-open the bubble. Opening and closing that bubble on click seems more consistent and convenient to me (and is actually simplier to implement).

This change keeps compatibility with javascript-disabled browsers, thanks to :hover CSS rules only overriden by javascript when it's enabled.

I have tested this pull request against IE 8-9, FF, SA, CH, OP, Android 2.3.6

Edit: I had to apply the same behavior to the menu following a bug report from @crwatkins