### PR TITLE
Add warning icon to alert pages

### DIFF
--- a/_layouts/alert.html
+++ b/_layouts/alert.html
@@ -12,7 +12,7 @@ lang: en
 
 <link rel="alternate" type="application/rss+xml" href="/en/rss/alerts.rss" title="Bitcoin network status and alerts">
 <div class="alerttext">
-  <h1>{{ page.title }}<br><small>{{ page.date | date:"%e %B %Y" }}</small></h1>
+  <img src="/img/icons/warning.svg" class="alerticon" alt="warning"><h1>{{ page.title }}<br><small>{{ page.date | date:"%e %B %Y" }}</small></h1>
   {{ content }}
 </div>
 <a href="/en/alerts">Go back to the network alerts history</a>

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1778,6 +1778,9 @@ h2 .rssicon{
 .alerttext h1{
 	text-align:left;
 }
+.alerttext img+h1{
+	margin-left:54px;
+}
 .alertstatusinactive{
 	font-size:130%;
 	color:#0d579b;
@@ -1793,6 +1796,13 @@ h2 .rssicon{
 }
 .alertsactive a{
 	font-weight:bold;
+}
+.alerticon{
+	width:42px;
+	height:42px;
+	float:left;
+	margin-top:12px;
+	margin-right:12px;
 }
 
 .redirectmsg{


### PR DESCRIPTION
Alert pages look like typical blog posts, not a PSA. Just adding one icon to the layout seems enough to fix that. Please feel free to merge at any moment or ignore if you feel it's unimportant.

Edit: Travis fail due to broken HTML in spv-mining not related to this PR.

![capture du 2015-07-04 04 05 02](https://cloud.githubusercontent.com/assets/3578089/8507111/3a7c7ad2-2202-11e5-8fbf-2513a6fbd483.png)
