### PR TITLE
Alerts: SPV Mining more details

### DIFF
--- a/_alerts/2015-07-04-spv-mining.html
+++ b/_alerts/2015-07-04-spv-mining.html
@@ -7,14 +7,16 @@ banner: "WARNING: many wallets currently vulnerable to double-spending of confir
 <p><em>This document is being updated as new information arrives.  Last
 update: 2015-07-04 09:00 UTC</em></p>
 
-{% assign confs="15" %}
+{% assign confs="30" %}
 
 <h2 id="summary">Summary</h2>
 
 <p>Your bitcoins are safe if you received them in transactions confirmed before 2015-07-04 08:00 UTC.</p>
 
-<p>After that time, confirmation scores are not as reliable as they
-usually are for users of certain software:</p>
+<p>However, there has been a problem with a planned upgrade. For
+   bitcoins received later than the time above, confirmation scores are
+   significantly less reliable then they usually are for users of
+   certain software:</p>
 
 <ul>
   <li><b>Lightweight (SPV) wallet users</b> should wait an additional {{confs}}
@@ -72,12 +74,9 @@ real.
       consensus rules. <a href="/en/download">Upgrade</a> is recommended
       to return to full node security.</li>
 
-  <li><b>Lightweight (SPV) wallets</b> are not safe until all the major
-      pools switch to full validation. After all the major pools fix
-      their problems, lightweight wallets will remain vulnerable to one,
-      two, or rarely three confirmation double spends until near 100% of
-      total hash rate has upgraded to a BIP66-compliant version of
-      Bitcoin Core.</li>
+  <li><b>Lightweight (SPV) wallets</b> are not safe for less than
+      {{confs}} confirmations until all the major pools switch to full
+      validation.</li>
 
   <li><b>Web wallets</b> are very diverse in what infrastructure they
       run and how they handle double spends, so unless you know for sure
@@ -124,16 +123,6 @@ real.
    least temporarily). As this progresses, we will reduce our
    current recommendation of waiting {{confs}} extra confirmations to a
    lower number.</p>
-
-<p>However, the BIP66 soft fork implementation method of waiting for
-   only 95% of miners to upgrade does leave miner-trusting software such
-   as lightweight wallets at increased risk of seeing invalid single
-   confirmations (10% risk), invalid double confirmations (1% risk), and
-   maybe even invalid triple confirmations (0.1% risk) until more of
-   the 5% non-upgraded miners do finally upgrade.  So for the next
-   several weeks (maybe months), lightweight wallet users, web wallet
-   users, and users of old versions of Bitcoin Core should wait an extra
-   two to three confirmations.</p>
 
 <!--
 <div style="text-align:right">

--- a/_alerts/2015-07-04-spv-mining.html
+++ b/_alerts/2015-07-04-spv-mining.html
@@ -5,13 +5,13 @@ active: true
 banner: "WARNING: many wallets currently vulnerable to double-spending of confirmed transactions (click here to read)"
 ---
 <p><em>This document is being updated as new information arrives.  Last
-update: 2015-07-04 08:15 UTC</em></p>
+update: 2015-07-04 09:00 UTC</em></p>
 
-{% assign confs="30" %}
+{% assign confs="15" %}
 
 <h2 id="summary">Summary</h2>
 
-<p>Your bitcoins are safe if you received them in transactions confirmed before 2015-07-04 07:00 UTC.</p>
+<p>Your bitcoins are safe if you received them in transactions confirmed before 2015-07-04 08:00 UTC.</p>
 
 <p>After that time, confirmation scores are not as reliable as they
 usually are for users of certain software:</p>
@@ -54,13 +54,86 @@ systems.</p>
   <li><a href="https://www.f2pool.com/">F2Pool</a></li>
 </ul>
 
+<h2 id="solution">When Will Things Go Back To Normal?</h2>
+
+The problem is miners creating invalid blocks.  Some software can detect
+that those blocks are invalid and reject them; other software can't
+detect that blocks are invalid, so they show confirmations that aren't
+real.
+
+<ul>
+  <li><b>Bitcoin Core 0.9.5 and later</b> never had any problems because
+      it could detect which blocks were invalid.</li>
+
+  <li><b>Bitcoin Core 0.9.4 and earlier</b> will never provide as much
+      security as later versions of Bitcoin Core because it doesn't know
+      about the additional <a
+      href="https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki">BIP66</a>
+      consensus rules. <a href="/en/download">Upgrade</a> is recommended
+      to return to full node security.</li>
+
+  <li><b>Lightweight (SPV) wallets</b> are not safe until all the major
+      pools switch to full validation. After all the major pools fix
+      their problems, lightweight wallets will remain vulnerable to one,
+      two, or rarely three confirmation double spends until near 100% of
+      total hash rate has upgraded to a BIP66-compliant version of
+      Bitcoin Core.</li>
+
+  <li><b>Web wallets</b> are very diverse in what infrastructure they
+      run and how they handle double spends, so unless you know for sure
+      that they use Bitcoin Core 0.9.5 or later for full validation, you
+      should assume they have the same security as the lightweight
+      wallets described above.</li>
+</ul>
+
 <h2 id="cause">What's Happening</h2>
 
-<p>Some miners are currently generating invalid blocks.   Almost all
-software besides Bitcoin Core 0.9.5 and later will accept these invalid
-blocks under certain conditions.</p>
+<p>Summary: Some miners are currently generating invalid blocks. Almost
+   all software (besides Bitcoin Core 0.9.5 and later) will accept these
+   invalid blocks under certain conditions.  The paragraphs that follow
+   explain the cause more throughly.</p>
 
-<p><b>More information to follow.</b></p>
+<p>For several months, an increasing amount of mining hash rate has been
+   signaling its intent to begin enforcing <a
+   href="https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki">BIP66</a>
+   strict DER signatures.  As part of the BIP66 rules,
+   once 950 of the last 1,000 blocks were version 3 (v3) blocks, all
+   upgraded miners would reject version 2 (v2) blocks.</p>
+
+<p>Early morning UTC on 4 July 2015, the 950/1000 (95%) threshold was
+   reached. Shortly thereafter, a small miner (part of the non-upgraded
+   5%) mined an invalid block--as was an expected occurrence.
+   Unfortunately, it turned out that roughly half the network hash rate
+   was mining without fully validating blocks (called SPV mining), and
+   built new blocks on top of that invalid block.</p>
+
+<p>Note that the roughly 50% of the network that was SPV mining had
+   explicitly indicated that they would enforce the BIP66 rules. By not
+   doing so, several large miners have lost over $50,000 dollars worth
+   of mining income so far.</p>
+
+<p>All software that assumes blocks are valid (because invalid blocks
+   cost miners money) is at risk of showing transactions as confirmed
+   when they really aren't. This particularly affects lightweight (SPV)
+   wallets and software such as old versions of Bitcoin Core which have
+   been downgraded to SPV-level security by the new BIP66 consensus
+   rules.</p>
+
+<p>The immediate fix, which is well underway as of this writing, is to
+   get all miners off of SPV mining and back to full validation (at
+   least temporarily). As this progresses, we will reduce our
+   current recommendation of waiting {{confs}} extra confirmations to a
+   lower number.</p>
+
+<p>However, the BIP66 soft fork implementation method of waiting for
+   only 95% of miners to upgrade does leave miner-trusting software such
+   as lightweight wallets at increased risk of seeing invalid single
+   confirmations (10% risk), invalid double confirmations (1% risk), and
+   maybe even invalid triple confirmations (0.1% risk) until more of
+   the 5% non-upgraded miners do finally upgrade.  So for the next
+   several weeks (maybe months), lightweight wallet users, web wallet
+   users, and users of old versions of Bitcoin Core should wait an extra
+   two to three confirmations.</p>
 
 <!--
 <div style="text-align:right">

--- a/_alerts/2015-07-04-spv-mining.html
+++ b/_alerts/2015-07-04-spv-mining.html
@@ -5,7 +5,7 @@ active: true
 banner: "WARNING: many wallets currently vulnerable to double-spending of confirmed transactions (click here to read)"
 ---
 <p><em>This document is being updated as new information arrives.  Last
-update: 2015-07-04 09:00 UTC</em></p>
+update: 2015-07-04 09:30 UTC</em></p>
 
 {% assign confs="30" %}
 
@@ -24,7 +24,7 @@ update: 2015-07-04 09:00 UTC</em></p>
 
   <li><b>Bitcoin Core 0.9.4 or earlier users</b> should wait an
   additional {{confs}} confirmations more than you would normally
-  wait or upgrade to <a href="/en/download">Bitcoin Core 0.10.2</a>.</b></li>
+  wait or upgrade to <a href="/en/download">Bitcoin Core 0.10.2</a>.</li>
 
   <li><b>Web wallet users</b> should wait an additional {{confs}} confirmations
   more than you would normally wait, unless you know for sure that your
@@ -35,8 +35,8 @@ update: 2015-07-04 09:00 UTC</em></p>
 
 <h2 id="miners">Miners</h2>
 
-If you pool mine, please switch to a pool that properly validates
-blocks.  (If you solo mine, please switch to Bitcoin Core 0.10.2.)
+<p>If you pool mine, please switch to a pool that properly validates
+blocks.  (If you solo mine, please switch to Bitcoin Core 0.10.2.)</p>
 
 <p><b>Bad pools:</b> these pools are not correctly validating, and are
 losing money.</p>
@@ -58,10 +58,10 @@ systems.</p>
 
 <h2 id="solution">When Will Things Go Back To Normal?</h2>
 
-The problem is miners creating invalid blocks.  Some software can detect
+<p>The problem is miners creating invalid blocks.  Some software can detect
 that those blocks are invalid and reject them; other software can't
 detect that blocks are invalid, so they show confirmations that aren't
-real.
+real.</p>
 
 <ul>
   <li><b>Bitcoin Core 0.9.5 and later</b> never had any problems because


### PR DESCRIPTION
This adds more details to the current alert message.  With F2Pool now fully validating, I've also reduced the number of recommended extra confrimations to wait from 30 to 15.  According to @gmaxwell's online version of the [fork probability calculator](https://people.xiph.org/~greg/attack_success.html), 15 confirmations on the longest chain from 25% of hash rate has a probability of 0.01%.

Preview: http://dg0.dtrt.org/en/alert/2015-07-04-spv-mining

CC: @petertodd @luke-jr