### PR TITLE
Add more explicit RSS feed and other features from the blog layout to alerts

### DIFF
--- a/_layouts/alert.html
+++ b/_layouts/alert.html
@@ -11,8 +11,22 @@ lang: en
 {% endif %}
 
 <link rel="alternate" type="application/rss+xml" href="/en/rss/alerts.rss" title="Bitcoin network status and alerts">
-<div class="alerttext">
-  <img src="/img/icons/warning.svg" class="alerticon" alt="warning"><h1>{{ page.title }}<a type="application/rss+xml" href="/en/rss/alerts.rss"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a><br><small>{{ page.date | date:"%e %B %Y" }}</small></h1>
-  {{ content }}
+
+<div class="subhead-links">
+  <a href="/en/alerts">Network alerts history</a>
+| <a type="application/rss+xml" href="/en/rss/alerts.rss"><img src="/img/icons/icon_rss.svg" width="12px" alt="rss" class="rssicon"> Subscribe to RSS feed</a>
+| <a href="https://github.com/bitcoin-dot-org/bitcoin.org/commits/master/{{page.path|uri_escape}}">Post history</a>
+| <a href="https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?body=Source%20File%3A%20{{page.path|uri_escape}}%0A%0A">Report issue</a>
 </div>
-<a href="/en/alerts">Go back to the network alerts history</a>
+
+<div class="post">
+
+  <header class="post-header">
+    <h1 class="post-title alerttitle"><img src="/img/icons/warning.svg" alt="warning">{{ page.title }}<br><small>{{ page.date | date:"%e %B %Y" }}</small></h1>
+  </header>
+
+  <article class="post-content">
+    {{ content }}
+  </article>
+
+</div>

--- a/_layouts/alert.html
+++ b/_layouts/alert.html
@@ -12,7 +12,7 @@ lang: en
 
 <link rel="alternate" type="application/rss+xml" href="/en/rss/alerts.rss" title="Bitcoin network status and alerts">
 <div class="alerttext">
-  <img src="/img/icons/warning.svg" class="alerticon" alt="warning"><h1>{{ page.title }}<br><small>{{ page.date | date:"%e %B %Y" }}</small></h1>
+  <img src="/img/icons/warning.svg" class="alerticon" alt="warning"><h1>{{ page.title }}<a type="application/rss+xml" href="/en/rss/alerts.rss"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a><br><small>{{ page.date | date:"%e %B %Y" }}</small></h1>
   {{ content }}
 </div>
 <a href="/en/alerts">Go back to the network alerts history</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ lang: en
 <link rel="alternate" type="application/atom+xml" href="/en/rss/blog.xml" title="Bitcoin.org Site Blog">
 
 <div class="subhead-links"><a href="/en/blog">Blog home</a>
-| <a type="application/atom+xml" href="/en/rss/blog.xml"><img src="/img/icons/icon_rss.svg" width="12px" alt="rss" class="rssicon"></a> <a href="/en/rss/blog.xml">Subscribe to RSS feed</a>
+| <a type="application/atom+xml" href="/en/rss/blog.xml"><img src="/img/icons/icon_rss.svg" width="12px" alt="rss" class="rssicon"> Subscribe to RSS feed</a>
 | <a href="https://github.com/bitcoin-dot-org/bitcoin.org/commits/master/{{page.path|uri_escape}}">Post history</a>
 | <a href="https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?body=Source%20File%3A%20{{page.path|uri_escape}}%0A%0A">Report issue</a></div>
 

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -967,7 +967,6 @@ br.clear {
 }
 .subhead-links {
 	font-size: 85%;
-	height: 18px;
 }
 
 div.post {
@@ -1772,14 +1771,11 @@ h2 .rssicon{
 	text-align:left;
 }
 
-.alerttext{
-	margin-bottom:40px;
-}
-.alerttext h1{
-	text-align:left;
-}
-.alerttext img+h1{
-	margin-left:54px;
+.alerttitle img{
+	display:block;
+	margin:auto;
+	width:42px;
+	height:42px;
 }
 .alertstatusinactive{
 	font-size:130%;

--- a/_plugins/alerts.rb
+++ b/_plugins/alerts.rb
@@ -30,6 +30,7 @@ module Jekyll
       self.read_yaml(File.join(base, srcdir), src)
       self.data['lang'] = lang
       self.data['date'] = date
+      self.data['path'] = srcdir+'/'+src
       self.data['layout'] = 'alert'
       if dstdir == ''
         self.data['canonical'] = '/en/alert/' + src.split('.')[0]

--- a/en/alerts.html
+++ b/en/alerts.html
@@ -8,8 +8,13 @@ id: alerts
 title: Network status and alerts - Bitcoin
 ---
 <link rel="alternate" type="application/rss+xml" href="/en/rss/alerts.rss" title="Bitcoin network status and alerts">
-<div class="alerttext">
-  <h1>Network status and alerts<a type="application/rss+xml" href="/en/rss/alerts.rss"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></h1>
+
+
+<h1>Network status and alerts</h1>
+
+<p class="summary">Stay aware of network alerts by <a href="/en/rss/alerts.rss">subscribing to the RSS feed</a> <a type="application/rss+xml" href="/en/rss/alerts.rss"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></p>
+
+<div>
   {% if site.STATUS == 0 %}
   <div class="alertstatusinactive">There is no ongoing event on the Bitcoin network.</div>
   {% else %}

--- a/en/alerts.html
+++ b/en/alerts.html
@@ -12,7 +12,7 @@ title: Network status and alerts - Bitcoin
 
 <h1>Network status and alerts</h1>
 
-<p class="summary">Stay aware of network alerts by <a href="/en/rss/alerts.rss">subscribing to the RSS feed</a> <a type="application/rss+xml" href="/en/rss/alerts.rss"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></p>
+<p class="summary">Stay aware of network alerts by <a type="application/rss+xml" href="/en/rss/alerts.rss">subscribing to the RSS feed <img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></p>
 
 <div>
   {% if site.STATUS == 0 %}

--- a/en/blog.html
+++ b/en/blog.html
@@ -14,7 +14,7 @@ id: site-blog
   <h1 class="page-heading">Bitcoin.org Site Blog</h1>
 
 
-  <p class="summary">Discover what's new on Bitcoin.org or <a href="/en/rss/blog.xml">subscribe to the RSS feed</a> <a type="application/atom+xml" href="/en/rss/blog.xml"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></p>
+  <p class="summary">Discover what's new on Bitcoin.org or <a type="application/atom+xml" href="/en/rss/blog.xml">subscribe to the RSS feed <img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></p>
 
   <ul class="post-list">
     {% for post in site.posts %}


### PR DESCRIPTION
~~@harding @btcdrak Would just adding the RSS icon into individual alerts would be good enough for now? Please feel free to merge this pull request at any time.~~

This pull request adds RSS icons and other features from the blog post layout.

Live preview:
http://bitcointest4.us.to/en/alerts
http://bitcointest4.us.to/en/alert/2015-07-04-spv-mining