### PR TITLE
Avoid reinstalling dependencies with bundler on every build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,11 @@ install-deps-development:
 
 ## Install dependencies (deployment version)
 install-deps-deployment:
+ifdef BUNDLE_DIR
+	bundle install --deployment --without :slow_test --path=$(BUNDLE_DIR)
+else
 	bundle install --deployment --without :slow_test
+endif
 
 ## Pre-build tests which, aggregated together, take less than 10 seconds to run on a typical PC
 pre-build-tests-fast: check-for-non-ascii-urls check-for-wrong-filename-assignments \

--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -9,9 +9,12 @@ source /etc/profile.d/rvm.sh
 
 AUTHORIZED_SIGNERS_DIR='/bitcoin.org/auto-build-committers.gnupg'
 REPO='https://github.com/bitcoin-dot-org/bitcoin.org.git'
+BUNDLE_DIR='/bitcoin.org/bundle'
 SITEDIR='/bitcoin.org/site'
 DESTDIR='build@bitcoinorgsite:/var/www/site'
 WORKDIR=`mktemp -d`
+
+export BUNDLE_DIR
 
 # Stop script in case a single command fails
 set -e
@@ -38,7 +41,7 @@ fi
 
 # Update local branch
 git reset --hard origin/master
-git clean -f -d
+git clean -x -f -d
 
 ## Whether to auto-build or force-build
 case "${1:-nil}" in

--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -38,7 +38,7 @@ fi
 
 # Update local branch
 git reset --hard origin/master
-git clean -x -f -d
+git clean -f -d
 
 ## Whether to auto-build or force-build
 case "${1:-nil}" in


### PR DESCRIPTION
This change brings significant performance improvement for the build process, as the build script otherwise deletes ./vendor, which forces bundler to reinstall every dependency from scratch on every build, which then delays the build for approximately 3 minutes.

It also seems to me that downloading and installing dependencies on every build exposes us to some more third party risk for no reason.

Git clean man file for the -x option:
https://git-scm.com/docs/git-clean

