### PR TITLE
(Trivial) Build: Put Current Git Commit ID On Site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ build:
 	  | egrep -v 'sha256sums.txt' \
 	  | sort \
 	  | xargs -d '\n' sha256sum > _site/sha256sums.txt
+	$S git show --oneline > _site/commit.txt
 
 ## Jekyll annoyingly returns success even when it emits errors and
 ## exceptions, so we'll grep its output for error strings


### PR DESCRIPTION
While testing an update to the build system, I needed this for easily tracking which of my automated local test builds were successful.  However, I think it could also be useful for easily tracking what commit the site is on, so I'm submitting it as a separate PR.  Here's what the command outputs on current HEAD:

    63361be Merge branch 'buildvendor'

I'd like to merge this later today; if anyone thinks this single line needs more review, please say so.

Once we upgrade to >= Jekyll 2.0, I think it might be worth trying https://github.com/ivantsepp/jekyll-git_metadata to add the current commit to templates, kind of like how Reddit has its current commit id and render date at the bottom right of every page.