### PR TITLE
Build: Push Function Include Down Into Sub-Shell

### DIFF
--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -5,8 +5,6 @@
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin
 
-source /etc/profile.d/rvm.sh
-
 AUTHORIZED_SIGNERS_DIR='/bitcoin.org/auto-build-committers.gnupg'
 REPO='https://github.com/bitcoin-dot-org/bitcoin.org.git'
 BUNDLE_DIR='/bitcoin.org/bundle'
@@ -78,6 +76,7 @@ lasttime=`stat -c %Y "$SITEDIR/_buildlock" | cut -d ' ' -f1`
 
 # Build website in a child process
 (
+source /etc/profile.d/rvm.sh
 cd $WORKDIR
 make deployment && touch "$WORKDIR/_builddone" || touch "$WORKDIR/_buildfail"
 )&
@@ -96,6 +95,7 @@ do
 	if [ -e "$WORKDIR/_builddone" ]; then
 		find $WORKDIR/_site \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.rss' -o -iname '*.xml' -o -iname '*.svg' -o -iname '*.ttf' \) -exec gzip -9 -k {} \;
 		rsync --delete -zrt $WORKDIR/_site/ $DESTDIR/
+                echo "Upload done; terminating script"
 		exit
 	fi
 

--- a/_build/update_txpreview.sh
+++ b/_build/update_txpreview.sh
@@ -5,8 +5,6 @@
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin
 
-source /etc/profile.d/rvm.sh
-
 # Set variables and create temporary directories
 LANGS=('ar' 'bg' 'bn' 'ca' 'cs' 'da' 'de' 'el' 'es' 'fa' 'fr' 'hi' 'hr' 'hu' 'id' 'it' 'ja' 'ko' 'lv' 'ml' 'nl' 'no' 'pl' 'pt_BR' 'ro' 'ru' 'sl' 'sr' 'sv' 'tr' 'uk' 'zh_CN' 'zh_TW')
 WORKDIR=`mktemp -d`
@@ -92,6 +90,7 @@ done
 
 # Build website in a child process
 (
+source /etc/profile.d/rvm.sh
 cd $WORKDIR
 bundle install
 ENABLED_PLUGINS='alerts redirects releases' make build && touch "$WORKDIR/_builddone" || touch "$WORKDIR/_buildfail"
@@ -111,6 +110,7 @@ do
 	if [ -e "$WORKDIR/_builddone" ]; then
 		cd $LIVEDIR
 		rsync --delete -zrt --exclude '/.git' $WORKDIR/_site/ $DESTDIR/
+                echo "Upload done; terminating script"
 		exit
 	fi
 


### PR DESCRIPTION
Fixes issue (bug) #941 

While installing rvm as root (which is a pain) for a test environment, I realized what the problem with the current script was:

- `kill 0` kills all process in the current process group.  That includes *children* of the current shell, but not the shell itself (which has the pgid of its parent shell).

- By sourcing `rvm.sh` we were including the `rvm` shell function into the shell.  Unlike commands such as git, rsync, etc..., `rvm` wasn't a child process.

- So, when `kill 0` was run, it had no effect on the `rvm` function.

The solution was easy: push the sourcing of the `rvm.sh` function down a level into the build process sub-shell.

This PR has been implemented and well tested on the build server (and implemented and lightly tested on the translation preview server).  The testing on the build server included:

- A regular build. Rsync was run and the tmp directory in the /tmp directory was removed as expected.

- A build with an artificially-induced error.  The build aborted and the tmp directory was removed.  Rsync was not run.

- Two successive builds: when the second build started, the first build aborted and its tmp directory was removed.  When the second build finished, rsync was run and the tmp directory was removed.

This PR also now prints a message on success, as the shell-generated "Terminated" message after a successful run confused me for a bit.

I think this is all I'm going to do for now.  I have an idea for queuing of builds using lock files, but now that the main problem is fixed, I find I'm not so enthusiastic about implementing it. :-)

As noted, the solution is already deployed, so I think this PR can be merged as soon as @saivann has reviewed it. (It can be merged using the GitHub merge button since it doesn't affect website content.)