### PR TITLE
Alerts: Disable SPV Mining Alert

### DIFF
--- a/_alerts/2015-07-04-spv-mining.md
+++ b/_alerts/2015-07-04-spv-mining.md
@@ -1,21 +1,23 @@
 ---
 title: "Some Miners Generating Invalid Blocks"
 alias: "spv-mining"
-active: true
-banner: "WARNING: many wallets currently vulnerable to double-spending of confirmed transactions (click here to read)"
+active: false
+#banner: "WARNING: many wallets currently vulnerable to double-spending of confirmed transactions (click here to read)"
 bannerclass: "alert"
 ---
 *This document is being updated as new information arrives.  Last
-update: 2015-07-06 02:00.  All times are UTC.*
+update: 2015-07-15 13:00.  All times are UTC.*
 
-**Note: this alert is on-going: the situation has not yet been
-resolved. ([Update #1](#update-1))**
+**Note: this situation has not been fully resolved, and it does not
+appear that it will be fully resolved anytime soon. Users of the
+affected wallets listed below are still advised to wait additional
+confirmations or to switch to a safer wallet.**
 
 {% assign confs="30" %}
 
 ##Summary
 
-Your bitcoins are safe if you received them in transactions confirmed before 2015-07-06 00:00 UTC.
+Your bitcoins are safe if you received them in transactions confirmed before 2015-07-15 12:00 UTC.
 
 However, there has been a problem with a planned upgrade. For
 bitcoins received later than the time above, confirmation scores are


### PR DESCRIPTION
This PR removes the alert banner from every page of the site and changes the bolded text near the top of the alert to:

![screenshot-btcorg localhost 2015-07-15 08-59-50](https://cloud.githubusercontent.com/assets/61096/8699053/9f06f474-2ad0-11e5-90a9-84a8101955c5.png)

I'm not sure we should be disabling the alert banner: if I understand correctly, several large miners have decided to stay with SPV mining (or worse, previous-header-hash-only mining).

On the other hand, I'm not aware of any short-term proposals to restore SPV wallet confirmation reliability to what it was when every miner did full validation---so the alternative seems to be keeping this alert up indefinitely, and I don't want to do that.

Comments appreciated.