### PR TITLE
Copyrights: Add MIT License Header To More Files

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,4 +1,7 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
 layout: base
 lang: en
 id: index

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-## Optional Makefile: only used for testing & maintainer automation;
-##                    not used to build live site
+## This file is licensed under the MIT License (MIT) available on
+## http://opensource.org/licenses/MIT.
 
 S=@  ## Silent: only print errors by default; 
      ## run `make S='' [other args]` to print commands as they're run
@@ -198,6 +198,12 @@ check-for-missing-copyright-licenses:
 ## say MIT license, but it has to say something.) This can be extended
 ## to include other directories by adding them after "_includes/"
 	$S git grep -iL 'This file is licensed' _includes/ | eval $(ERROR_ON_OUTPUT)
+	$S git ls-files | grep -v '^_alerts' \
+          | while read file ; do \
+            if sed -n 1p $$file | grep -q '^---$$' ; then \
+              grep -iL 'This file is licensed' $$file ; \
+            fi ; \
+          done | eval $(ERROR_ON_OUTPUT)
 
 check-for-missing-rpc-summaries:
 ## Make sure the Quick Reference section has a summary for each RPC we

--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ recommend naming it after the release, such as `0.10.0.md`
 Then copy in the following YAML header (the part between the three dashes, ---):
 ~~~
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
 ## Required value below populates the %v variable (note: % needs to be escaped in YAML if it starts a value)
 required_version: 0.10.0
 ## Optional release date.  May be filled in hours/days after a release

--- a/_alerts/2015-07-04-spv-mining.md
+++ b/_alerts/2015-07-04-spv-mining.md
@@ -1,4 +1,7 @@
 ---
+## This file is licensed under the MIT License (MIT) available on
+## http://opensource.org/licenses/MIT.
+
 title: "Some Miners Generating Invalid Blocks"
 alias: "spv-mining"
 active: false

--- a/_posts/2015-06-16-hard-fork-policy.md
+++ b/_posts/2015-06-16-hard-fork-policy.md
@@ -1,4 +1,7 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
 type: posts
 layout: post
 lang: en

--- a/_posts/2015-06-23-repository-move.md
+++ b/_posts/2015-06-23-repository-move.md
@@ -1,4 +1,7 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
 type: posts
 layout: post
 lang: en

--- a/_releases/0.10.0.md
+++ b/_releases/0.10.0.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Required value below populates the %v variable (note: % needs to be escaped in YAML if it starts a value)
 required_version: 0.10.0
 ## Optional release date.  May be filled in hours/days after a release

--- a/_releases/0.10.1.md
+++ b/_releases/0.10.1.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Required value below populates the %v variable (note: % needs to be escaped in YAML if it starts a value)
 required_version: 0.10.1
 ## Optional release date.  May be filled in hours/days after a release

--- a/_releases/0.10.2.md
+++ b/_releases/0.10.2.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Required value below populates the %v variable (note: % needs to be escaped in YAML if it starts a value)
 required_version: 0.10.2
 ## Optional release date.  May be filled in hours/days after a release

--- a/_releases/0.11.0.md
+++ b/_releases/0.11.0.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Required value below populates the %v variable (note: % needs to be escaped in YAML if it starts a value)
 required_version: 0.11.0
 ## Optional release date.  May be filled in hours/days after a release

--- a/_releases/0.3.21.md
+++ b/_releases/0.3.21.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.3.21
 optional_date: 2011-04-27

--- a/_releases/0.3.22.md
+++ b/_releases/0.3.22.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.3.22
 optional_date: 2011-06-05

--- a/_releases/0.3.23.md
+++ b/_releases/0.3.23.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.3.23
 optional_date: 2011-06-14

--- a/_releases/0.3.24.md
+++ b/_releases/0.3.24.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.3.24
 optional_date: 2011-07-08

--- a/_releases/0.4.0.md
+++ b/_releases/0.4.0.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.4.0
 optional_date: 2011-09-23

--- a/_releases/0.5.0.md
+++ b/_releases/0.5.0.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.5.0
 optional_date: 2011-11-21

--- a/_releases/0.5.1.md
+++ b/_releases/0.5.1.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.5.1
 optional_date: 2011-12-15

--- a/_releases/0.5.2.md
+++ b/_releases/0.5.2.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.5.2
 optional_date: 2012-01-09

--- a/_releases/0.5.3.1.md
+++ b/_releases/0.5.3.1.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.5.3.1
 optional_date: 2012-03-16

--- a/_releases/0.5.3.md
+++ b/_releases/0.5.3.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.5.3
 optional_date: 2012-03-14

--- a/_releases/0.6.0.md
+++ b/_releases/0.6.0.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.6.0
 optional_date: 2012-03-30

--- a/_releases/0.6.1.md
+++ b/_releases/0.6.1.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.6.1
 optional_date: 2012-05-04

--- a/_releases/0.6.2.md
+++ b/_releases/0.6.2.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.6.2
 optional_date: 2012-05-08

--- a/_releases/0.6.3.md
+++ b/_releases/0.6.3.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.6.3
 optional_date: 2012-06-25

--- a/_releases/0.7.0.md
+++ b/_releases/0.7.0.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.7.0
 optional_date: 2012-09-17

--- a/_releases/0.7.1.md
+++ b/_releases/0.7.1.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.7.1
 optional_date: 2012-10-19

--- a/_releases/0.7.2.md
+++ b/_releases/0.7.2.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.7.2
 optional_date: 2012-12-14

--- a/_releases/0.8.0.md
+++ b/_releases/0.8.0.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.8.0
 optional_date: 2013-02-19

--- a/_releases/0.8.1.md
+++ b/_releases/0.8.1.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.8.1
 optional_date: 2013-03-18

--- a/_releases/0.8.2.md
+++ b/_releases/0.8.2.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.8.2
 optional_date: 2013-05-29

--- a/_releases/0.8.3.md
+++ b/_releases/0.8.3.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.8.3
 optional_date: 2013-06-25

--- a/_releases/0.8.4.md
+++ b/_releases/0.8.4.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.8.4
 optional_date: 2013-09-03

--- a/_releases/0.8.5.md
+++ b/_releases/0.8.5.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.8.5
 optional_date: 2013-09-13

--- a/_releases/0.8.6.md
+++ b/_releases/0.8.6.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.8.6
 optional_date: 2013-12-09

--- a/_releases/0.9.0.md
+++ b/_releases/0.9.0.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.9.0
 optional_date: 2014-03-19

--- a/_releases/0.9.1.md
+++ b/_releases/0.9.1.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.9.1
 optional_date: 2014-04-08

--- a/_releases/0.9.2.1.md
+++ b/_releases/0.9.2.1.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.9.2.1
 optional_date: 2014-06-19

--- a/_releases/0.9.2.md
+++ b/_releases/0.9.2.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.9.2
 optional_date: 2014-06-16

--- a/_releases/0.9.3.md
+++ b/_releases/0.9.3.md
@@ -1,4 +1,9 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
 ## Please see _releases/0.10.0.md for a release template
 required_version: 0.9.3
 optional_date: 2014-09-27

--- a/_templates/privacy.html
+++ b/_templates/privacy.html
@@ -1,4 +1,7 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
 layout: base
 id: privacy
 ---

--- a/js/events.js
+++ b/js/events.js
@@ -1,4 +1,7 @@
 ---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
 layout: null
 ---
 


### PR DESCRIPTION
This pull updates the existing makefile test for copyright headers to also cover all files with a YAML header except those in the `_alerts` directory.  (I don't want anything to stop us from quickly publishing an alert.)

The rest of this pull adds any missing copyright headers.  I believe all the files with newly-added headers either came from the Bitcoin Core project (release notes), which is MIT licensed, or were created by @saivann or me.