### PR TITLE
Fix libbitcoin, urls, descriptions, split blkmaker, drop BOP, sort.

### DIFF
--- a/_templates/development.html
+++ b/_templates/development.html
@@ -39,7 +39,7 @@ id: development
 
 <ul class="devprojectlist">
   <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A Bitcoin client with enhanced security features.</li>
-  <li><a href="http://bfgminer.com">BFGMiner</a> - A modular ASIC/FPGA Bitcoin miner.</li>
+  <li><a href="http://bfgminer.com">BFGMiner</a> - A modular Bitcoin miner.</li>
   <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Explorer">Bitcoin Explorer</a> - A Bitcoin command line tool, built on libbitcoin.</li>
   <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Server">Bitcoin Server</a> - A Bitcoin full node and query server, built on libbitcoin.</li>
   <li><a href="https://github.com/schildbach/bitcoin-wallet">Bitcoin Wallet</a> - A thin SPV Bitcoin client for Android.</li>

--- a/_templates/development.html
+++ b/_templates/development.html
@@ -38,24 +38,24 @@ id: development
 <p>{% translate morechoose %}</p>
 
 <ul class="devprojectlist">
-  <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A Bitcoin client with enhanced security features.</li>
-  <li><a href="http://bfgminer.com">BFGMiner</a> - A modular Bitcoin miner.</li>
-  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Explorer">Bitcoin Explorer</a> - A Bitcoin command line tool, built on libbitcoin.</li>
-  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Server">Bitcoin Server</a> - A Bitcoin full node and query server, built on libbitcoin.</li>
-  <li><a href="https://github.com/schildbach/bitcoin-wallet">Bitcoin Wallet</a> - A thin SPV Bitcoin client for Android.</li>
-  <li><a href="https://bitcoinj.github.io">bitcoinj</a> - A Java Bitcoin client library for SPV clients.</li>
-  <li><a href="https://github.com/btcsuite/btcd">btcd</a> - A full node bitcoin implementation written in Go.</li>
-  <li><a href="https://github.com/btcsuite/btcwallet">btcwallet</a> - A hierarchical deterministic wallet daemon written in Go.</li>
-  <li><a href="https://electrum.org">Electrum</a> - A fast Bitcoin client relying on remote servers to store the blockchain.</li>
-  <li><a href="https://github.com/luke-jr/eloipool">Eloipool</a> - A fast Python mining pool server software.</li>
-  <li><a href="https://github.com/hivewallet">Hive</a> - A fast user-friendly SPV Bitcoin wallet.</li>
-  <li><a href="https://en.bitcoin.it/wiki/Libbitcoin">Libbitcoin</a> - A Bitcoin cross-platform C++ development toolkit.</li>
-  <li><a href="https://gitlab.com/bitcoin/libblkmaker">Libblkmaker</a> - A C client library for the getblocktemplate mining protocol.</li>
-  <li><a href="https://multibit.org">MultiBit HD</a> - A thin SPV international Bitcoin client for desktops.</li>
-  <li><a href="https://github.com/NicolasDorier/NBitcoin">NBitcoin</a> - A cross-platform .NET Bitcoin library. (Mac,IOS,Android,WP,Tablets,Mono,Desktop)</li>
-  <li><a href="https://github.com/jgarzik/picocoin">picocoin</a> - A tiny bitcoin library, with lightweight client and utils.</li>
-  <li><a href="https://github.com/petertodd/python-bitcoinlib">python-bitcoinlib</a> - A Python2/3 Bitcoin library.</li>
-  <li><a href="https://gitlab.com/bitcoin/python-blkmaker">Python Blkmaker</a> - A Python client library for the getblocktemplate mining protocol.</li>
+  <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A wallet with enhanced security features.</li>
+  <li><a href="http://bfgminer.com">BFGMiner</a> - A modular miner.</li>
+  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Explorer">Bitcoin Explorer</a> - A command line tool, built on libbitcoin.</li>
+  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Server">Bitcoin Server</a> - A full node and query server, built on libbitcoin.</li>
+  <li><a href="https://github.com/schildbach/bitcoin-wallet">Bitcoin Wallet</a> - A SPV wallet for Android and Blackberry.</li>
+  <li><a href="https://bitcoinj.github.io">bitcoinj</a> - A library for SPV wallets, written in Java.</li>
+  <li><a href="https://github.com/btcsuite/btcd">btcd</a> - A full node, written in Go.</li>
+  <li><a href="https://github.com/btcsuite/btcwallet">btcwallet</a> - A hierarchical deterministic wallet daemon, written in Go.</li>
+  <li><a href="https://electrum.org">Electrum</a> - A fast server-trusting wallet.</li>
+  <li><a href="https://github.com/luke-jr/eloipool">Eloipool</a> - A fast mining pool server application, written in Python.</li>
+  <li><a href="https://github.com/hivewallet">Hive</a> - A fast user-friendly SPV wallet.</li>
+  <li><a href="https://en.bitcoin.it/wiki/Libbitcoin">Libbitcoin</a> - A cross-platform development toolkit, written in C++.</li>
+  <li><a href="https://gitlab.com/bitcoin/libblkmaker">Libblkmaker</a> - A client library for the getblocktemplate mining protocol, written in C.</li>
+  <li><a href="https://multibit.org">MultiBit HD</a> - An international SPV wallet for desktops.</li>
+  <li><a href="https://github.com/NicolasDorier/NBitcoin">NBitcoin</a> - A cross-platform library, written in C#.</li>
+  <li><a href="https://github.com/jgarzik/picocoin">picocoin</a> - A tiny library with lightweight client and utilities, written in C.</li>
+  <li><a href="https://github.com/petertodd/python-bitcoinlib">python-bitcoinlib</a> - A library for structures and protocols, written in Python.</li>
+  <li><a href="https://gitlab.com/bitcoin/python-blkmaker">Python Blkmaker</a> - A client library for the getblocktemplate mining protocol, written in Python.</li>
   <li class="more"><a href="#" onclick="librariesShow(event)">{% translate moremore %}</a></li>
 </ul>
 

--- a/_templates/development.html
+++ b/_templates/development.html
@@ -39,23 +39,23 @@ id: development
 
 <ul class="devprojectlist">
   <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A Bitcoin client with enhanced security features.</li>
-  <li><a href="http://bfgminer.com">BFGMiner</a> - Modular Bitcoin mining software.</li>
-  <li><a href="https://code.google.com/p/bitcoinj/">bitcoinj</a> - A Java implementation of a Bitcoin client-only node used in thin SPV Bitcoin clients.</li>
-  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Explorer">Bitcoin Explorer</a> - A Bitcoin command line tool.</li>
-  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Server">Bitcoin Server</a> - A Bitcoin full node and query server.</li>
-  <li><a href="https://github.com/schildbach/bitcoin-wallet/">Bitcoin Wallet for Android</a> - A thin SPV Bitcoin client for mobiles.</li>
-  <li><a href="https://github.com/bitsofproof/supernode">Bits of Proof Enterprise Bitcoin Server</a> - A modular implementation of the Bitcoin protocol in Java.</li>
+  <li><a href="http://bfgminer.com">BFGMiner</a> - A modular ASIC/FPGA Bitcoin miner.</li>
+  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Explorer">Bitcoin Explorer</a> - A Bitcoin command line tool, built on libbitcoin.</li>
+  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Server">Bitcoin Server</a> - A Bitcoin full node and query server, built on libbitcoin.</li>
+  <li><a href="https://github.com/schildbach/bitcoin-wallet">Bitcoin Wallet</a> - A thin SPV Bitcoin client for Android.</li>
+  <li><a href="https://bitcoinj.github.io">bitcoinj</a> - A Java Bitcoin client library for SPV clients.</li>
   <li><a href="https://github.com/btcsuite/btcd">btcd</a> - A full node bitcoin implementation written in Go.</li>
   <li><a href="https://github.com/btcsuite/btcwallet">btcwallet</a> - A hierarchical deterministic wallet daemon written in Go.</li>
-  <li><a href="https://electrum.org/community.html">Electrum</a> - A fast Bitcoin client relying on remote servers to store the block chain.</li>
+  <li><a href="https://electrum.org">Electrum</a> - A fast Bitcoin client relying on remote servers to store the blockchain.</li>
   <li><a href="https://github.com/luke-jr/eloipool">Eloipool</a> - A fast Python mining pool server software.</li>
-  <li><a href="https://github.com/hivewallet">Hive</a> - A fast user-friendly SPV Bitcoin client.</li>
+  <li><a href="https://github.com/hivewallet">Hive</a> - A fast user-friendly SPV Bitcoin wallet.</li>
   <li><a href="https://en.bitcoin.it/wiki/Libbitcoin">Libbitcoin</a> - A Bitcoin cross-platform C++ development toolkit.</li>
-  <li><a href="https://en.bitcoin.it/wiki/Libblkmaker#For_developers">libblkmaker and python-blkmaker</a> - Client side libraries for the getblocktemplate mining protocol.</li>
-  <li><a href="https://multibit.org/">MultiBit HD</a> - A thin SPV international Bitcoin client for desktops.</li>
+  <li><a href="https://gitlab.com/bitcoin/libblkmaker">Libblkmaker</a> - A C client library for the getblocktemplate mining protocol.</li>
+  <li><a href="https://multibit.org">MultiBit HD</a> - A thin SPV international Bitcoin client for desktops.</li>
   <li><a href="https://github.com/NicolasDorier/NBitcoin">NBitcoin</a> - A cross-platform .NET Bitcoin library. (Mac,IOS,Android,WP,Tablets,Mono,Desktop)</li>
   <li><a href="https://github.com/jgarzik/picocoin">picocoin</a> - A tiny bitcoin library, with lightweight client and utils.</li>
   <li><a href="https://github.com/petertodd/python-bitcoinlib">python-bitcoinlib</a> - A Python2/3 Bitcoin library.</li>
+  <li><a href="https://gitlab.com/bitcoin/python-blkmaker">Python Blkmaker</a> - A Python client library for the getblocktemplate mining protocol.</li>
   <li class="more"><a href="#" onclick="librariesShow(event)">{% translate moremore %}</a></li>
 </ul>
 

--- a/_templates/development.html
+++ b/_templates/development.html
@@ -41,6 +41,8 @@ id: development
   <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A Bitcoin client with enhanced security features.</li>
   <li><a href="http://bfgminer.com">BFGMiner</a> - Modular Bitcoin mining software.</li>
   <li><a href="https://code.google.com/p/bitcoinj/">bitcoinj</a> - A Java implementation of a Bitcoin client-only node used in thin SPV Bitcoin clients.</li>
+  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Explorer">Bitcoin Explorer</a> - A Bitcoin command line tool.</li>
+  <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Server">Bitcoin Server</a> - A Bitcoin full node and query server.</li>
   <li><a href="https://github.com/schildbach/bitcoin-wallet/">Bitcoin Wallet for Android</a> - A thin SPV Bitcoin client for mobiles.</li>
   <li><a href="https://github.com/bitsofproof/supernode">Bits of Proof Enterprise Bitcoin Server</a> - A modular implementation of the Bitcoin protocol in Java.</li>
   <li><a href="https://github.com/btcsuite/btcd">btcd</a> - A full node bitcoin implementation written in Go.</li>
@@ -48,14 +50,12 @@ id: development
   <li><a href="https://electrum.org/community.html">Electrum</a> - A fast Bitcoin client relying on remote servers to store the block chain.</li>
   <li><a href="https://github.com/luke-jr/eloipool">Eloipool</a> - A fast Python mining pool server software.</li>
   <li><a href="https://github.com/hivewallet">Hive</a> - A fast user-friendly SPV Bitcoin client.</li>
-  <li><a href="https://github.com/libbitcoin/libbitcoin/">libbitcoin</a> - An asynchronous C++ library for Bitcoin.</li>
+  <li><a href="https://en.bitcoin.it/wiki/Libbitcoin">Libbitcoin</a> - A Bitcoin cross-platform C++ development toolkit.</li>
   <li><a href="https://en.bitcoin.it/wiki/Libblkmaker#For_developers">libblkmaker and python-blkmaker</a> - Client side libraries for the getblocktemplate mining protocol.</li>
   <li><a href="https://multibit.org/">MultiBit HD</a> - A thin SPV international Bitcoin client for desktops.</li>
   <li><a href="https://github.com/NicolasDorier/NBitcoin">NBitcoin</a> - A cross-platform .NET Bitcoin library. (Mac,IOS,Android,WP,Tablets,Mono,Desktop)</li>
-  <li><a href="https://github.com/libbitcoin/obelisk/">obelisk</a> - A libbitcoin-based blockchain query server.</li>
   <li><a href="https://github.com/jgarzik/picocoin">picocoin</a> - A tiny bitcoin library, with lightweight client and utils.</li>
   <li><a href="https://github.com/petertodd/python-bitcoinlib">python-bitcoinlib</a> - A Python2/3 Bitcoin library.</li>
-  <li><a href="https://sx.dyne.org/">sx</a> - Modular Bitcoin commandline utilities.</li>
   <li class="more"><a href="#" onclick="librariesShow(event)">{% translate moremore %}</a></li>
 </ul>
 


### PR DESCRIPTION
SX has been replaced by Bitcoin Explorer (bx) and Obelisk has been replaced by Bitcoin Server (bs). These are both based on the libraries `libbitcoin-explorer` and `libbitcoin-server`, among others.