### PR TITLE
Combine /index, /<lang>/index, and /404

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,13 +14,4 @@ window.location.href='/'+lang+'/';
 </script>
 <!--Fallback page, don't allow indexing-->
 <meta name="robots" content="noindex">
-<h1>An open source P2P digital currency</h1>
-<p style="font-size:125%;">Bitcoin is a currency, a protocol, and a software that enables
-<ul style="font-size:125%">
-  <li>Instant peer to peer transactions</li>
-  <li>Worldwide payments</li>
-  <li>Low or zero processing fees</li>
-  <li>And much more!</li>
-</ul>
-<p>Bitcoin uses peer to peer technology to operate with no central authority; managing transactions and issuing Bitcoins are carried out <b>collectively by the network</b>. Through many of its unique properties, Bitcoin allows exciting uses that could not be covered by any previous payment systems.</p>
-<p>The software is a community-driven <a href="http://www.fsf.org/about/what-is-free-software">free open source</a> project, released under the <a href="http://creativecommons.org/licenses/MIT/">MIT license</a>.</p>
+{% include index.html %}

--- a/_includes/index.html
+++ b/_includes/index.html
@@ -1,0 +1,20 @@
+{% comment %}
+This file is licensed under the MIT License (MIT) available on
+http://opensource.org/licenses/MIT.
+{% endcomment %}
+
+<p class="mainsummary">{% translate listintro %}</p>
+<div class="mainvideo"><div onclick="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/Gc2en3nHxA4?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">
+  <img src="/img/video/video_wuc.jpg" alt="Youtube video">
+  <div class="mainvideoicon"></div>
+  <div class="mainvideoiconhover"></div>
+</div></div>
+<div class="mainlist">
+  <div><div><img src="/img/icons/main_ico_instant.svg" alt="Icon"><div>{% translate list1 %}</div></div></div>
+  <div><div><img src="/img/icons/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>
+  <div><div><img src="/img/icons/main_ico_lowfee.svg" alt="Icon"><div>{% translate list3 %}</div></div></div>
+</div>
+<p class="maindesc">{% translate desc %}</p>
+<div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/icons/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
+<div class="mainoverview">{% translate overview %}</div>
+<div class="mainoverviews"><a href="/{{ page.lang }}/{% translate bitcoin-for-individuals url %}">{% translate menu-bitcoin-for-individuals layout %}</a> <a href="/{{ page.lang }}/{% translate bitcoin-for-businesses url %}">{% translate menu-bitcoin-for-businesses layout %}</a> <a href="/{{ page.lang }}/{% translate bitcoin-for-developers url %}">{% translate menu-bitcoin-for-developers layout %}</a></div>

--- a/_templates/index.html
+++ b/_templates/index.html
@@ -5,18 +5,4 @@
 layout: base
 id: index
 ---
-<p class="mainsummary">{% translate listintro %}</p>
-<div class="mainvideo"><div onclick="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/Gc2en3nHxA4?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">
-  <img src="/img/video/video_wuc.jpg" alt="Youtube video">
-  <div class="mainvideoicon"></div>
-  <div class="mainvideoiconhover"></div>
-</div></div>
-<div class="mainlist">
-  <div><div><img src="/img/icons/main_ico_instant.svg" alt="Icon"><div>{% translate list1 %}</div></div></div>
-  <div><div><img src="/img/icons/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>
-  <div><div><img src="/img/icons/main_ico_lowfee.svg" alt="Icon"><div>{% translate list3 %}</div></div></div>
-</div>
-<p class="maindesc">{% translate desc %}</p>
-<div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/icons/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
-<div class="mainoverview">{% translate overview %}</div>
-<div class="mainoverviews"><a href="/{{ page.lang }}/{% translate bitcoin-for-individuals url %}">{% translate menu-bitcoin-for-individuals layout %}</a> <a href="/{{ page.lang }}/{% translate bitcoin-for-businesses url %}">{% translate menu-bitcoin-for-businesses layout %}</a> <a href="/{{ page.lang }}/{% translate bitcoin-for-developers url %}">{% translate menu-bitcoin-for-developers layout %}</a></div>
+{% include index.html %}

--- a/index.html
+++ b/index.html
@@ -7,18 +7,4 @@ lang: en
 id: index
 title: Bitcoin
 ---
-<p class="mainsummary">{% translate listintro %}</p>
-<div class="mainvideo"><div onclick="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/Gc2en3nHxA4?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">
-  <img src="/img/video/video_wuc.jpg" alt="Youtube video">
-  <div class="mainvideoicon"></div>
-  <div class="mainvideoiconhover"></div>
-</div></div>
-<div class="mainlist">
-  <div><div><img src="/img/icons/main_ico_instant.svg" alt="Icon"><div>{% translate list1 %}</div></div></div>
-  <div><div><img src="/img/icons/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>
-  <div><div><img src="/img/icons/main_ico_lowfee.svg" alt="Icon"><div>{% translate list3 %}</div></div></div>
-</div>
-<p class="maindesc">{% translate desc %}</p>
-<div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/icons/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
-<div class="mainoverview">{% translate overview %}</div>
-<div class="mainoverviews"><a href="/{{ page.lang }}/{% translate bitcoin-for-individuals url %}">{% translate menu-bitcoin-for-individuals layout %}</a> <a href="/{{ page.lang }}/{% translate bitcoin-for-businesses url %}">{% translate menu-bitcoin-for-businesses layout %}</a> <a href="/{{ page.lang }}/{% translate bitcoin-for-developers url %}">{% translate menu-bitcoin-for-developers layout %}</a></div>
+{% include index.html %}


### PR DESCRIPTION
When working on #972, I discovered Bitcoin.org has three pages with nearly identical content:

- `/<language>/index.html` which provides the Bitcoin.org index page localized into each supported language
- `/index.html` which provides a fallback in case language redirection doesn't work.  This page is currently identical to the English localized index page.
- `/404.html` which provides the 404 error page, which includes a Javascript redirect to the localized index page plus fallback content that looks like an old version of the English localized index page.

This PR now builds all three pages from the same source so that if we change any text, we only have to change it once.  (No text changes are introduced in this PR, except that text displayed on the 404 page is now identical to the text displayed on the index pages.)

I tested this for English and Spanish.