### PR TITLE
Begin Split Testing Bullets on Index Page

### DIFF
--- a/_includes/index.html
+++ b/_includes/index.html
@@ -9,11 +9,30 @@ http://opensource.org/licenses/MIT.
   <div class="mainvideoicon"></div>
   <div class="mainvideoiconhover"></div>
 </div></div>
-<div class="mainlist">
-  <div><div><img src="/img/icons/main_ico_instant.svg" alt="Icon"><div>{% translate list1 %}</div></div></div>
-  <div><div><img src="/img/icons/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>
-  <div><div><img src="/img/icons/main_ico_lowfee.svg" alt="Icon"><div>{% translate list3 %}</div></div></div>
-</div>
+{% if page.lang == 'en' %}
+  {% capture test_number %}{{ site.time | date: "%j" | modulo:2 }}{% endcapture %}
+  <!-- date: {{ site.time | date: "%j" }}, test number: {{test_number}} -->
+  {% case test_number %}
+  {% when '0' %}{% comment %}// Control group \\{% endcomment %}
+  <div class="mainlist">
+    <div><div><img src="/img/icons/main_ico_instant.svg" alt="Icon"><div>{% translate list1 %}</div></div></div>
+    <div><div><img src="/img/icons/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>
+    <div><div><img src="/img/icons/main_ico_lowfee.svg" alt="Icon"><div>{% translate list3 %}</div></div></div>
+  </div>
+  {% when '1' %}{% comment %}// Test group \\{% endcomment %}
+  <div class="mainlist">
+    <div><div><img src="/img/icons/main_ico_instant.svg" alt="Icon"><div>Peer-to-peer<br>transactions</div></div></div>
+    <div><div><img src="/img/icons/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>
+    <div><div><img src="/img/icons/main_ico_lowfee.svg" alt="Icon"><div>Thousands of<br>merchants</div></div></div>
+  </div>
+  {% endcase %}
+{% else %}
+  <div class="mainlist">
+    <div><div><img src="/img/icons/main_ico_instant.svg" alt="Icon"><div>{% translate list1 %}</div></div></div>
+    <div><div><img src="/img/icons/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>
+    <div><div><img src="/img/icons/main_ico_lowfee.svg" alt="Icon"><div>{% translate list3 %}</div></div></div>
+  </div>
+{% endif %}
 <p class="maindesc">{% translate desc %}</p>
 <div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/icons/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>
 <div class="mainoverview">{% translate overview %}</div>


### PR DESCRIPTION
In aborted pull #972, I proposed to temporarily remove the three key points (bullet points) from the main page and to later replace them with different text that I thought had a lower probability of becoming untrue as Bitcoin grows and changes.

It was counter-argued that the points were important to making Bitcoin appealing so they should remain on the page, possibly after rewriting them better reflect the current situation or by adding asterisks (or links) pointing to qualifications.

This PR attempts to provide us with empirical evidence about how important the existing bullet points are by [split testing](https://en.wikipedia.org/wiki/A/B_testing) them against similar points that I think are more likely to remain true for the foreseeable future.

## Test Method

The test is only conducted on the English-language index page, `bitcoin.org/en/`.  The test does not use any Javascript or third-party analysis services.

Instead, a cronjob[1] will be added to the build server to force rebuild the site at midnight every night, with all site builds on even days-of-the-year (1..365) rendering the current site bullet points (the control text) and odd days-of-the-year using revised bullet points (the test text).

Page loads from the webserver logs will be collected, as we've done in the past, and anonymized with @saivann's [bitcoinstats](https://github.com/saivann/bitcoinstats) script.  I will write a script to determine the index page's bounce rate: how many unique visitors open it as the first page they visit but don't continue on to visit another page.

When we have enough data---I suggest 14 days, 7 days of the control text and 7 days of the test text---Saïvann and I will attempt to extract a fair sample of visits from the logs with an equal number of control and test visits, and then we'll run the bounce detection script to see what the difference between the two is.

Results and copies of all scripts used will be posted to this PR. (If you're logged into to GitHub, you can use the Subscribe button on the right side to receive notification of all subsequent comments posted on this PR.)

## Bullet Text

Here is the **control text**, the same text currently used on Bitcoin.org for over a year:

![screenshot-btcorg localhost 2015-07-25 23-53-37](https://cloud.githubusercontent.com/assets/61096/8892500/80b60fae-3328-11e5-8c0f-7ea2be9ed906.png)

Here is the **test text**. I revised/wrote it to work with the same icons, minimizing differences for the test and simplifying updating the translations if we later decide to make the test text the new control text:

![screenshot-btcorg localhost 2015-07-25 23-50-50](https://cloud.githubusercontent.com/assets/61096/8892494/18fefac4-3328-11e5-9780-063b830eeaad.png)

Note: Bitpay's home page says, "Trusted by Over 60,000 Businesses and Organizations", and Coinbase's [merchant page](https://www.coinbase.com/merchants) says, "Trusted by over 40,000 Businesses", so I think a claim of 'thousands of merchants' is warranted.

## Testing The Test

    apt-get install datefudge

    ## Quick build the site normally to see today's bullets
    ENABLED_PLUGINS="" ENABLED_LANGS="" make valid

    ## Quick build tomorrow's site and you should see different bullets
    ## (Unless it's December 31st on a non-leap year)
    ENABLED_PLUGINS="" ENABLED_LANGS="" datefudge tomorrow make valid

[1] Before installing the cronjob, a small update to the site build script is required. I've already written it and will be submitting it in a separate PR.  Also, reminder to myself: put the cronjob on a 30 second delay to avoid interfering with the regular build script.