### PR TITLE
Build: Allow Rebuilding A Particular Commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ build:
 	  | egrep -v 'sha256sums.txt' \
 	  | sort \
 	  | xargs -d '\n' sha256sum > _site/sha256sums.txt
-	$S git show --oneline > _site/commit.txt
+	$S git log -1 --format="%H" > _site/commit.txt
 
 ## Jekyll annoyingly returns success even when it emits errors and
 ## exceptions, so we'll grep its output for error strings

--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -10,7 +10,12 @@ REPO='https://github.com/bitcoin-dot-org/bitcoin.org.git'
 BUNDLE_DIR='/bitcoin.org/bundle'
 SITEDIR='/bitcoin.org/site'
 DESTDIR='build@bitcoinorgsite:/var/www/site'
+LAST_SUCCESSFUL_BUILD_COMMITISH_FILE=/bitcoin.org/last-successful-build-commitish
 WORKDIR=`mktemp -d`
+
+## Parameters
+BUILD_TYPE="${1:-nil}"
+BUILD_COMMITISH="${2:-origin/master}"
 
 export BUNDLE_DIR
 
@@ -28,21 +33,18 @@ if [ ! -d $SITEDIR ]; then
 	git reset --hard HEAD~1
 fi
 
-# Exit if no new commit is available
+# Get commit data
 cd $SITEDIR
 git fetch -a
 LASTLOCALCOMMIT=`git log --format="%H" | head -n1`
-LASTREMOTECOMMIT=`git log origin/master --format="%H" | head -n1`
-if [ $LASTLOCALCOMMIT == $LASTREMOTECOMMIT ]; then
-	exit
-fi
+LASTREMOTECOMMIT=`git log "$BUILD_COMMITISH" --format="%H" | head -n1`
 
 # Update local branch
-git reset --hard origin/master
+git reset --hard "$LASTREMOTECOMMIT"
 git clean -x -f -d
 
 ## Whether to auto-build or force-build
-case "${1:-nil}" in
+case "$BUILD_TYPE" in
   auto)
     ## From git-log(1):
     ## %G?: show "G" for a Good signature, "B" for a Bad signature, "U"
@@ -51,6 +53,11 @@ case "${1:-nil}" in
     then
       echo "Commit tree tip not signed by an authorized signer.  Terminating build."
       exit 1
+    fi
+
+    ## Don't auto build if we already had this commit
+    if [ $LASTLOCALCOMMIT == $LASTREMOTECOMMIT ]; then
+            exit
     fi
   ;;
 
@@ -95,6 +102,11 @@ do
 	if [ -e "$WORKDIR/_builddone" ]; then
 		find $WORKDIR/_site \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.rss' -o -iname '*.xml' -o -iname '*.svg' -o -iname '*.ttf' \) -exec gzip -9 -k {} \;
 		rsync --delete -zrt $WORKDIR/_site/ $DESTDIR/
+
+                ## Save this commit's ID.  You can force rebuild the current commit using:
+                ##   update_site.sh force $( cat </path/to/last-successful-build-commitish> )
+                echo "$LASTREMOTECOMMIT" > $LAST_SUCCESSFUL_BUILD_COMMITISH_FILE
+
                 echo "Upload done; terminating script"
 		exit
 	fi


### PR DESCRIPTION
This PR updates the build script with two minor improvements:

1. When force building, the script no longer exits if you're attempting to the most recently-built commit.

2. The commit ID (commitish) of the most recently built commit is saved for use in other scripts

The intention here is to be able to create a cronjob for PR #976 that will force rebuild the site every night at midnight.  Point 1 makes that possible without the hard rebase hack @saivann and I currently use when manually rebuilding and point 2 prevents an automatic force build from allowing someone to bypass the signed commits by pushing a commit to master at exactly the right time.

I also switched the commit.txt command in the Makefile to use the same syntax as the build file, as I thought Saïvann's way was better.

This PR has not been tested, but I will test it when I manually update the file on the build server.