### PR TITLE
Update settxfee description to match actual behavior

### DIFF
--- a/_includes/ref/bitcoin-core/rpcs/rpcs/settxfee.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/settxfee.md
@@ -21,7 +21,7 @@ The `settxfee` RPC {{summary_setTxFee}}
 - n: "Transaction Fee Per Kilobyte"
   t: "number (bitcoins)"
   p: "Required<br>(exactly 1)"
-  d: "The transaction fee to pay, in bitcoins, for each kilobyte of transaction data.  The value `0` will not be accepted.  Be careful setting the fee too low---your transactions may not be relayed or included in blocks"
+  d: "The transaction fee to pay, in bitcoins, for each kilobyte of transaction data.  Be careful setting the fee too low---your transactions may not be relayed or included in blocks"
 
 {% enditemplate %}
 


### PR DESCRIPTION
Currently, Bitcoin Core accepts 0 as an argument to settxfee, see settxfee() in https://github.com/bitcoin/bitcoin/blob/master/src/wallet/rpcwallet.cpp

I've updated the description of settxfee to reflect this.