### PR TITLE
Make no address reuse with change addresses a requirement for wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ Basic requirements:
 - SSL certificate passes [Qualys SSL Labs SSL test](https://www.ssllabs.com/ssltest/)
 - Website serving executable code or requiring authentication uses HSTS with a max-age of at least 180 days
 - The identity of CEOs and/or developers is public
+- Avoid address reuse by using a new change address for each transaction
 - If private keys or encryption keys are stored online:
   - Refuses weak passwords (short passwords and/or common passwords) used to secure access to any funds, or provides an aggressive account lock-out feature in response to failed login attempts along with a strict account recovery process.
 - If user has no access over its private keys:
@@ -725,7 +726,6 @@ Basic requirements:
 Optional criterias (some could become requirements):
 
 - Received independent security audit(s)
-- Avoid address reuse by using a new change address for each transaction
 - Avoid address reuse by displaying a new receiving address for each transaction in the wallet UI
 - Does not show "received from" Bitcoin addresses in the UI
 - Uses deterministic ECDSA nonces (RFC 6979)

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -502,23 +502,6 @@ wallets:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosureaccount"
           privacynetwork: "checkfailprivacynetworknosupporttor"
-      desktop:
-        text: "wallethive"
-        link: "http://mac.hivewallet.com/"
-        source: "https://github.com/hivewallet/hive-osx"
-        screenshot: "hivemac.png"
-        os:
-        - mac
-        check:
-          control: "checkgoodcontrolfull"
-          validation: "checkpassvalidationspvp2p"
-          transparency: "checkpasstransparencyopensource"
-          environment: "checkfailenvironmentdesktop"
-          privacy: "checkfailprivacyweak"
-        privacycheck:
-          privacyaddressreuse: "checkfailprivacyaddressrotation"
-          privacydisclosure: "checkfailprivacydisclosurespv"
-          privacynetwork: "checkpassprivacynetworksupporttorproxy"
       web:
         text: "wallethive-web"
         link: "https://hivewallet.com/"


### PR DESCRIPTION
This change was planned since a while and nearly all wallets avoid reusing change addresses by default now, including recently added wallets, so now seems like a good time to raise the bar.

The only exception is Hive for Mac, which might support it later. The Hive team is mostly focusing on Hive Web, which remains displayed on the website.