### PR TITLE
Update text on FAQ & Innovation pages

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -407,16 +407,19 @@ en:
 
     fee: "How much will the transaction fee be?"
     feetxt1: >
-      Transactions can be processed without fees, but users are
-      encouraged to pay a voluntary fee for faster confirmation of
-      their transactions and to remunerate miners. When fees are
-      required, they currently don't exceed a few pennies in value,
-      but this may increase over time. Your
-      Bitcoin client will pay what it thinks is an appropriate fee.
+      Transactions can be processed without fees, but trying to send
+      free transactions can require waiting days or weeks. Although fees
+      may increase over time, normal fees currently only cost a tiny
+      amount. By default, all <a href="#choose-your-wallet#">Bitcoin
+      wallets</a> listed on Bitcoin.org add what they think is an
+      appropriate fee to your transactions; most of those wallets will
+      also give you chance to review the fee before sending the
+      transaction.
 
     feetxt2: >
       Transaction fees are used as a protection against users sending
-      transactions to overload the network. The precise manner in which
+      transactions to overload the network and as a way to pay
+      miners for their work helping to secure the network. The precise manner in which
       fees work is still being developed and will change over time.
       Because the fee is not related to the amount of bitcoins being
       sent, it may seem extremely low or unfairly high. Instead, the

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -297,16 +297,18 @@ en:
     advantages: "What are the advantages of Bitcoin?"
     advantagesli1: >
       <em><b>Payment freedom</b></em> - It is possible to send and
-      receive any amount of money instantly anywhere in the world at any
-      time. No bank holidays. No borders. No imposed limits. Bitcoin
+      receive bitcoins anywhere in the world at any
+      time. No bank holidays. No borders. No bureaucracy. Bitcoin
       allows its users to be in full control of their money.
 
     advantagesli2: >
-      <em><b>Very low fees</b></em> - Bitcoin payments are currently
-      processed with either no fees or extremely small fees. Users may
-      include fees with transactions to receive priority processing,
-      which results in faster confirmation of transactions by the
-      network. Additionally, merchant processors exist to assist
+      <em><b>Choose your own fees</b></em> - There is no fee to receive
+      bitcoins, and many wallets let you control how large a fee to pay
+      when spending. Higher fees can encourage faster <a
+      href="#you-need-to-know##instant">confirmation</a> of your
+      transactions. Fees are unrelated to the amount transferred, so
+      it's possible to send 100,000 bitcoins for the same fee it costs
+      to send 1 bitcoin. Additionally, merchant processors exist to assist
       merchants in processing transactions, converting bitcoins to fiat
       currency and depositing funds directly into merchants' bank
       accounts daily. As these services are based on Bitcoin, they can
@@ -383,45 +385,46 @@ en:
     bettercurrency: "What if someone creates a better digital currency?"
     bettercurrencytxt1: "That can happen. For now, Bitcoin remains by far the most popular decentralized virtual currency, but there can be no guarantee that it will retain that position. There is already a set of alternative currencies inspired by Bitcoin. It is however probably correct to assume that significant improvements would be required for a new currency to overtake Bitcoin in terms of established market, even though this remains unpredictable. Bitcoin could also conceivably adopt improvements of a competing currency so long as it doesn't change fundamental parts of the protocol."
     transactions: "Transactions"
-    tenminutes: "Why do I have to wait 10 minutes?"
+    tenminutes: "Why do I have to wait for confirmation?"
     tenminutestxt1: >
-      Receiving a payment is almost instant with Bitcoin. However, there
-      is a 10 minutes delay on average before the network begins to
-      confirm your transaction by including it in a block and before you
-      can spend the bitcoins you receive. A confirmation means that
+      Receiving notification of a payment is almost instant with Bitcoin. However, there
+      is a delay before the network begins to
+      confirm your transaction by including it in a block.
+      A confirmation means that
       there is a consensus on the network that the bitcoins you received
       haven't been sent to anyone else and are considered your property.
       Once your transaction has been included in one block, it will
       continue to be buried under every block after it, which will
       exponentially consolidate this consensus and decrease the risk of
-      a reversed transaction. Every user is free to determine at what
-      point they consider a transaction confirmed, but 6 confirmations
+      a reversed transaction.
+      Each confirmation takes between a few seconds and 90 minutes, with
+      10 minutes being the average. If the transaction pays too low a
+      fee or is otherwise atypical, getting the first confirmation can
+      take much longer.  Every user is free to determine at what
+      point they consider a transaction sufficiently confirmed, but <a href="#you-need-to-know##instant">6 confirmations</a>
       is often considered to be as safe as waiting 6 months on a credit
       card transaction.
 
     fee: "How much will the transaction fee be?"
     feetxt1: >
-      Most transactions can be processed without fees, but users are
-      encouraged to pay a small voluntary fee for faster confirmation of
+      Transactions can be processed without fees, but users are
+      encouraged to pay a voluntary fee for faster confirmation of
       their transactions and to remunerate miners. When fees are
-      required, they generally don't exceed a few pennies in value. Your
-      Bitcoin client will usually try to estimate an appropriate fee
-      when required.
+      required, they currently don't exceed a few pennies in value,
+      but this may increase over time. Your
+      Bitcoin client will pay what it thinks is an appropriate fee.
 
     feetxt2: >
       Transaction fees are used as a protection against users sending
       transactions to overload the network. The precise manner in which
       fees work is still being developed and will change over time.
       Because the fee is not related to the amount of bitcoins being
-      sent, it may seem extremely low (0.0005 BTC for a 1,000 BTC
-      transfer) or unfairly high (0.004 BTC for a 0.02 BTC payment). The
-      fee is defined by attributes such as data in transaction and
-      transaction recurrence. For example, if you are receiving a large
-      number of tiny amounts, then fees for sending will be higher. Such
-      payments are comparable to paying a restaurant bill using only
-      pennies. Spending small fractions of your bitcoins rapidly may
-      also require a fee. If your activity follows the pattern of
-      conventional transactions, the fees should remain very low.
+      sent, it may seem extremely low or unfairly high. Instead, the
+      fee is relative to the number of bytes in the transaction, so
+      using multisig or spending multiple previously-received amounts
+      may cost more than simpler transactions. If your activity follows
+      the pattern of conventional transactions, you won't have to pay
+      unusually high fees.
 
     poweredoff: "What if I receive a bitcoin when my computer is powered off?"
     poweredofftxt1: "This works fine. The bitcoins will appear next time you start your wallet application. Bitcoins are not actually received by the software on your computer, they are appended to a public ledger that is shared between all the devices on the network. If you are sent bitcoins when your wallet client program is not running and you later launch it, it will download blocks and catch up with any transactions it did not already know about, and the bitcoins will eventually appear as if they were just received in real time. Your wallet is only needed when you wish to spend bitcoins."
@@ -525,14 +528,15 @@ en:
     crowdfundingtext: "Bitcoin can be used to run Kickstarter-like crowdfunding campaigns, in which individuals pledge money to a project that is taken from them only if enough pledges are received to meet the target. Such assurance contracts are processed by the Bitcoin protocol, which prevents a transaction from taking place until all conditions have been met. <a href=\"https://en.bitcoin.it/wiki/Contracts#Example_3:_Assurance_contracts\">Learn more</a> about the technology behind crowdfunding and try <a href=\"https://www.vinumeris.com/lighthouse\">Lighthouse</a>."
     micro: "Micro payments"
     microtext: >
-      Bitcoin can process payments to the scale of a dollar and soon
-      even much smaller amounts. Such payments are routine even today.
       Imagine listening to Internet radio paid by the second, viewing
       web pages with a small tip for each ad not shown, or buying
       bandwidth from a WiFi hotspot by the kilobyte. Bitcoin is
       efficient enough to make all of these ideas possible. <a
       href="https://bitcoinj.github.io/working-with-micropayments">Learn
-      more</a> about the technology behind Bitcoin micro payments.
+      more</a> about the technology behind Bitcoin micro payments
+      or about <a href="http://lightning.network/">future upgrades</a> currently
+      being designed and implemented to make micro payments more
+      accessible.
 
     mediation: "Dispute mediation"
     mediationtext: "Bitcoin can be used to develop innovative dispute mediation services using multiple signatures. Such services could make it possible for a third party to approve or reject a transaction in case of disagreement between the other parties without having control on their money. Since these services would be compatible with any user and merchant using Bitcoin, this would likely lead to free competition and higher quality standards."

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -295,8 +295,24 @@ en:
     makepayment: "How difficult is it to make a Bitcoin payment?"
     makepaymenttxt1: "Bitcoin payments are easier to make than debit or credit card purchases, and can be received without a merchant account. Payments are made from a wallet application, either on your computer or smartphone, by entering the recipient's address, the payment amount, and pressing send. To make it easier to enter a recipient's address, many wallets can obtain the address by scanning a QR code or touching two phones together with NFC technology."
     advantages: "What are the advantages of Bitcoin?"
-    advantagesli1: "<em><b>Payment freedom</b></em> - It is possible to send and receive any amount of money anywhere in the world at any time. No bank holidays. No borders. No imposed limits. Bitcoin allows its users to be in full control of their money."
-    advantagesli2: "<em><b>Low fees</b></em> - Bitcoin payments are currently processed with either no fees or extremely small fees. Users may include fees with transactions to receive priority processing, which results in faster confirmation of transactions by the network. Additionally, merchant processors exist to assist merchants in processing transactions, converting bitcoins to fiat currency and depositing funds directly into merchants' bank accounts daily. As these services are based on Bitcoin, they can be offered for much lower fees than with PayPal or credit card networks."
+    advantagesli1: >
+      <em><b>Payment freedom</b></em> - It is possible to send and
+      receive any amount of money instantly anywhere in the world at any
+      time. No bank holidays. No borders. No imposed limits. Bitcoin
+      allows its users to be in full control of their money.
+
+    advantagesli2: >
+      <em><b>Very low fees</b></em> - Bitcoin payments are currently
+      processed with either no fees or extremely small fees. Users may
+      include fees with transactions to receive priority processing,
+      which results in faster confirmation of transactions by the
+      network. Additionally, merchant processors exist to assist
+      merchants in processing transactions, converting bitcoins to fiat
+      currency and depositing funds directly into merchants' bank
+      accounts daily. As these services are based on Bitcoin, they can
+      be offered for much lower fees than with PayPal or credit card
+      networks.
+
     advantagesli3: "<em><b>Fewer risks for merchants</b></em> - Bitcoin transactions are secure, irreversible, and do not contain customers’ sensitive or personal information. This protects merchants from losses caused by fraud or fraudulent chargebacks, and there is no need for PCI compliance. Merchants can easily expand to new markets where either credit cards are not available or fraud rates are unacceptably high. The net results are lower fees, larger markets, and fewer administrative costs."
     advantagesli4: "<em><b>Security and control</b></em> - Bitcoin users are in full control of their transactions; it is impossible for merchants to force unwanted or unnoticed charges as can happen with other payment methods. Bitcoin payments can be made without personal information tied to the transaction. This offers strong protection against identity theft. Bitcoin users can also protect their money with backup and encryption."
     advantagesli5: "<em><b>Transparent and neutral</b></em> - <a href=\"https://www.biteasy.com/\">All information</a> concerning the Bitcoin money supply itself is readily available on the block chain for anybody to verify and use in real-time. No individual or organization can control or manipulate the Bitcoin protocol because it is cryptographically secure. This allows the core of Bitcoin to be trusted for being completely neutral, transparent and predictable."
@@ -368,10 +384,45 @@ en:
     bettercurrencytxt1: "That can happen. For now, Bitcoin remains by far the most popular decentralized virtual currency, but there can be no guarantee that it will retain that position. There is already a set of alternative currencies inspired by Bitcoin. It is however probably correct to assume that significant improvements would be required for a new currency to overtake Bitcoin in terms of established market, even though this remains unpredictable. Bitcoin could also conceivably adopt improvements of a competing currency so long as it doesn't change fundamental parts of the protocol."
     transactions: "Transactions"
     tenminutes: "Why do I have to wait 10 minutes?"
-    tenminutestxt1: "Receiving a payment is almost instant with Bitcoin. However, there is a 10 minutes delay on average before the network begins to confirm your transaction by including it in a block and before you can spend the bitcoins you receive. A confirmation means that there is a consensus on the network that the bitcoins you received haven't been sent to anyone else and are considered your property. Once your transaction has been included in one block, it will continue to be buried under every block after it, which will exponentially consolidate this consensus and decrease the risk of a reversed transaction. Every user is free to determine at what point they consider a transaction confirmed, but 6 confirmations is often considered to be as safe as waiting 6 months on a credit card transaction."
+    tenminutestxt1: >
+      Receiving a payment is almost instant with Bitcoin. However, there
+      is a 10 minutes delay on average before the network begins to
+      confirm your transaction by including it in a block and before you
+      can spend the bitcoins you receive. A confirmation means that
+      there is a consensus on the network that the bitcoins you received
+      haven't been sent to anyone else and are considered your property.
+      Once your transaction has been included in one block, it will
+      continue to be buried under every block after it, which will
+      exponentially consolidate this consensus and decrease the risk of
+      a reversed transaction. Every user is free to determine at what
+      point they consider a transaction confirmed, but 6 confirmations
+      is often considered to be as safe as waiting 6 months on a credit
+      card transaction.
+
     fee: "How much will the transaction fee be?"
-    feetxt1: "Most transactions can be processed without fees, but users are encouraged to pay a small voluntary fee for faster confirmation of their transactions and to remunerate miners. When fees are required, they generally don't exceed a few pennies in value. Your Bitcoin client will usually try to estimate an appropriate fee when required."
-    feetxt2: "Transaction fees are used as a protection against users sending transactions to overload the network. The precise manner in which fees work is still being developed and will change over time. Because the fee is not related to the amount of bitcoins being sent, it may seem extremely low (0.0005 BTC for a 1,000 BTC transfer) or unfairly high (0.004 BTC for a 0.02 BTC payment). The fee is defined by attributes such as data in transaction and transaction recurrence. For example, if you are receiving a large number of tiny amounts, then fees for sending will be higher. Such payments are comparable to paying a restaurant bill using only pennies. Spending small fractions of your bitcoins rapidly may also require a fee. If your activity follows the pattern of conventional transactions, the fees should remain very low."
+    feetxt1: >
+      Most transactions can be processed without fees, but users are
+      encouraged to pay a small voluntary fee for faster confirmation of
+      their transactions and to remunerate miners. When fees are
+      required, they generally don't exceed a few pennies in value. Your
+      Bitcoin client will usually try to estimate an appropriate fee
+      when required.
+
+    feetxt2: >
+      Transaction fees are used as a protection against users sending
+      transactions to overload the network. The precise manner in which
+      fees work is still being developed and will change over time.
+      Because the fee is not related to the amount of bitcoins being
+      sent, it may seem extremely low (0.0005 BTC for a 1,000 BTC
+      transfer) or unfairly high (0.004 BTC for a 0.02 BTC payment). The
+      fee is defined by attributes such as data in transaction and
+      transaction recurrence. For example, if you are receiving a large
+      number of tiny amounts, then fees for sending will be higher. Such
+      payments are comparable to paying a restaurant bill using only
+      pennies. Spending small fractions of your bitcoins rapidly may
+      also require a fee. If your activity follows the pattern of
+      conventional transactions, the fees should remain very low.
+
     poweredoff: "What if I receive a bitcoin when my computer is powered off?"
     poweredofftxt1: "This works fine. The bitcoins will appear next time you start your wallet application. Bitcoins are not actually received by the software on your computer, they are appended to a public ledger that is shared between all the devices on the network. If you are sent bitcoins when your wallet client program is not running and you later launch it, it will download blocks and catch up with any transactions it did not already know about, and the bitcoins will eventually appear as if they were just received in real time. Your wallet is only needed when you wish to spend bitcoins."
     sync: "What does \"synchronizing\" mean and why does it take so long?"
@@ -473,7 +524,16 @@ en:
     crowdfunding: "Crowdfunding"
     crowdfundingtext: "Bitcoin can be used to run Kickstarter-like crowdfunding campaigns, in which individuals pledge money to a project that is taken from them only if enough pledges are received to meet the target. Such assurance contracts are processed by the Bitcoin protocol, which prevents a transaction from taking place until all conditions have been met. <a href=\"https://en.bitcoin.it/wiki/Contracts#Example_3:_Assurance_contracts\">Learn more</a> about the technology behind crowdfunding and try <a href=\"https://www.vinumeris.com/lighthouse\">Lighthouse</a>."
     micro: "Micro payments"
-    microtext: "Bitcoin can process payments to the scale of a dollar and soon even much smaller amounts. Such payments are routine even today. Imagine listening to Internet radio paid by the second, viewing web pages with a small tip for each ad not shown, or buying bandwidth from a WiFi hotspot by the kilobyte. Bitcoin is efficient enough to make all of these ideas possible. <a href=\"https://bitcoinj.github.io/working-with-micropayments\">Learn more</a> about the technology behind Bitcoin micro payments."
+    microtext: >
+      Bitcoin can process payments to the scale of a dollar and soon
+      even much smaller amounts. Such payments are routine even today.
+      Imagine listening to Internet radio paid by the second, viewing
+      web pages with a small tip for each ad not shown, or buying
+      bandwidth from a WiFi hotspot by the kilobyte. Bitcoin is
+      efficient enough to make all of these ideas possible. <a
+      href="https://bitcoinj.github.io/working-with-micropayments">Learn
+      more</a> about the technology behind Bitcoin micro payments.
+
     mediation: "Dispute mediation"
     mediationtext: "Bitcoin can be used to develop innovative dispute mediation services using multiple signatures. Such services could make it possible for a third party to approve or reject a transaction in case of disagreement between the other parties without having control on their money. Since these services would be compatible with any user and merchant using Bitcoin, this would likely lead to free competition and higher quality standards."
     multisig: "Multi-signature accounts"


### PR DESCRIPTION
This PR continues the work started in aborted pull #972.  It is split into two commits:

1. No text changes; just wrap existing text to allow word diffing the next commit.

2. Actual text changes.

## Advantages of Bitcoin from FAQ

![screenshot-btcorg localhost 2015-07-29 21-02-34](https://cloud.githubusercontent.com/assets/61096/8973903/0d8afc42-3639-11e5-9ec9-4cadd2e3d52d.png)

## Confirmations and fees from FAQ

![screenshot-btcorg localhost 2015-07-29 21-19-23](https://cloud.githubusercontent.com/assets/61096/8973911/2aab916a-3639-11e5-8eb1-c37b56d28cb2.png)

## Micro payments from Innovation

![screenshot-btcorg localhost 2015-07-29 21-22-53](https://cloud.githubusercontent.com/assets/61096/8973914/3639a21a-3639-11e5-9f86-edcf15ae759e.png)
