### PR TITLE
Update quotes on Press page

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -2132,8 +2132,9 @@ h2 .rssicon{
 .press-quotes p{
 	display:inline-block;
 	vertical-align:top;
-	width:400px;
+	width:380px;
 	margin:0 0 20px 20px;
+        padding-left: 20px;
 }
 .press-quotes p:nth-child(1n+9){
 	display:none;

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -2169,6 +2169,9 @@ h2 .rssicon{
 	font-size:180%;
 	content:"”";
 }
+.press-quotes p.final {
+	width: 100%;
+}
 
 /*Styles specific to printing*/
 

--- a/_templates/press.html
+++ b/_templates/press.html
@@ -13,6 +13,7 @@ dialogs:
   materialquote: "Quotes"
   materialquotemore: "Show more quotes..."
   material_even_more_quotes: "For even more quotes about Bitcoin, please see <a href=\"https://en.wikiquote.org/wiki/Bitcoin\">WikiQuote.</a>"
+  material_source: "source"
   quotesatoshi: "With e-currency based on cryptographic proof, without the need to trust a third party middleman, money can be secure and transactions effortless."
   quotetonygallippi: "Bitcoin is Money Over Internet Protocol."
   quotedankaminsky: "Entire classes of bugs are missing."
@@ -34,7 +35,7 @@ dialogs:
   quotetuurdemeester: "The Babyboomers gave us the personal computer, Generation X gave us the Internet, and now Generation Y is building a new financial paradigm."
   quoterichardbrown: "Had you asked me five years ago, I would just say it was impossible. Bitcoin and cryptocurrencies solved this problem of coming to a consensus globally where you don't trust anybody else."
   quotefredwilson: "We believe that Bitcoin represents something fundamental and powerful ... It reminds us of SMTP, HTTP, RSS, and BitTorrent in its architecture and openness."
-  quotejohndonohoe: "Digital currency is going to be a very powerful thing."
+  quotejohndonohoe: "[Digital currency is going to be] a very powerful thing."
   quotefrancoisrvelde: "It represents a remarkable conceptual and technical achievement, which may well be used by existing financial institutions (which could issue their own bitcoins) or even by governments themselves."
 
 ---
@@ -240,23 +241,23 @@ What is Bitcoin - Weusecoins<br>
 <h2 id="quotes">{{ page.dialogs.materialquote }}</h2>
 <div>
 <p><span>{{ page.dialogs.quotechrisdixon }}</span><span><a href="https://en.wikipedia.org/wiki/Chris_Dixon">Chris Dixon</a>, Technology Investor</span></p>
-<p><span>{{ page.dialogs.quotewencescasares }}</span><span><a href="https://en.wikipedia.org/wiki/Wences_Casares">Wences Casares</a>, Technology Entrepreneur</span></p>
+<p><span>{{ page.dialogs.quotewencescasares }}</span><span><a href="https://en.wikipedia.org/wiki/Wences_Casares">Wences Casares</a>, Technology Entrepreneur (<a href="http://techcrunch.com/2013/04/11/bitcoin/">{{page.dialogs.material_source}}</a>)</span></p>
 <p><span>{{ page.dialogs.quotetonygallippi }}</span><span><a href="https://en.wikipedia.org/wiki/Tony_Gallippi">Tony Gallippi</a>, BitPay CEO</span></p>
-<p><span>{{ page.dialogs.quotedankaminsky }}</span><span><a href="https://en.wikipedia.org/wiki/Dan_Kaminsky">Dan Kaminsky</a>, Security Researcher</span></p>
-<p><span>{{ page.dialogs.quotejeremyliew }}</span><span><a href="https://en.wikipedia.org/wiki/Lightspeed_Ventures">Jeremy Liew</a>, Lightspeed Venture Partners</span></p>
-<p><span>{{ page.dialogs.quotejohndonohoe }}</span><a href="https://en.wikipedia.org/wiki/John_Donahoe">John Donohoe</a>, former Ebay CEO<span></span></p>
-<p><span>{{ page.dialogs.quotetylerwinklevoss }}</span><span><a href="https://en.wikipedia.org/wiki/Tyler_Winklevoss">Tyler Winklevoss</a>, Entrepreneur</span></p>
-<p><span>{{ page.dialogs.quotesatoshi }}</span><span><a href="https://en.wikipedia.org/wiki/Satoshi_Nakamoto">Satoshi Nakamoto</a>, Bitcoin Developer</span></p>
-<p><span>{{ page.dialogs.quotebillgates }}</span><span><a href="https://en.wikipedia.org/wiki/Bill_Gates">Bill Gates</a>, Executive Chairman, Microsoft<br><a href="https://en.wikipedia.org/wiki/Eric_Schmidt">Eric Schmidt</a>, Executive Chairman, Google</span></p>
-<p><span>{{ page.dialogs.quotegavinandresen }}</span><span><a href="https://en.wikipedia.org/wiki/Gavin_Andresen">Gavin Andresen</a>, Chief Scientist, The Bitcoin Foundation</span></p>
-<p><span>{{ page.dialogs.quotepaulbuchheit }}</span><span><a href="https://en.wikipedia.org/wiki/Paul_Buchheit">Paul Buchheit</a>, Creator of GMail, Google (<a href="https://twitter.com/paultoo/status/328969714283995136">source</a>)</span></p>
-<p><span>{{ page.dialogs.quoteandyskelton }}</span><span>Andy Skelton, Developer, WordPress</span></p>
+<p><span>{{ page.dialogs.quotedankaminsky }}</span><span><a href="https://en.wikipedia.org/wiki/Dan_Kaminsky">Dan Kaminsky</a>, Security Researcher (<a href="https://bitcointalk.org/index.php?topic=34458.0">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotejeremyliew }}</span><span><a href="https://en.wikipedia.org/wiki/Lightspeed_Ventures">Jeremy Liew</a>, Lightspeed Venture Partners (<a href="http://techcrunch.com/2013/04/11/bitcoin/">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotejohndonohoe }}</span><a href="https://en.wikipedia.org/wiki/John_Donahoe">John Donohoe</a>, former Ebay CEO (<a href="http://techcrunch.com/2013/11/03/ebay-ceo-john-donahoe-is-bullish-on-digital-currency-and-hes-keeping-tabs-on-bitcoin/">{{page.dialogs.material_source}}</a>)<span></span></p>
+<p><span>{{ page.dialogs.quotetylerwinklevoss }}</span><span><a href="https://en.wikipedia.org/wiki/Tyler_Winklevoss">Tyler Winklevoss</a>, Entrepreneur (<a href="http://dealbook.nytimes.com/2013/04/11/as-big-investors-emerge-bitcoin-gets-ready-for-its-close-up/">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotesatoshi }}</span><span><a href="https://en.wikipedia.org/wiki/Satoshi_Nakamoto">Satoshi Nakamoto</a>, Bitcoin Developer (<a href="http://p2pfoundation.ning.com/forum/topics/bitcoin-open-{{page.dialogs.material_source}}">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotebillgates }}</span><span><a href="https://en.wikipedia.org/wiki/Bill_Gates">Bill Gates</a>, Executive Chairman, Microsoft (<a href="http://video.foxbusiness.com/v/2359385547001/mungerbuffett-disagree-on-corporate-tax-rates/?#sp=show-clips">{{page.dialogs.material_source}}</a>)<br><a href="https://en.wikipedia.org/wiki/Eric_Schmidt">Eric Schmidt</a>, Executive Chairman, Google (<a href="http://video.cnbc.com/gallery/?video=3000163361&play=1%5B1%5D">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotegavinandresen }}</span><span><a href="https://en.wikipedia.org/wiki/Gavin_Andresen">Gavin Andresen</a>, Chief Scientist, The Bitcoin Foundation (<a href="https://www.youtube.com/watch?v=0S4dSXTnfms">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotepaulbuchheit }}</span><span><a href="https://en.wikipedia.org/wiki/Paul_Buchheit">Paul Buchheit</a>, Creator of GMail, Google (<a href="https://twitter.com/paultoo/status/328969714283995136">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quoteandyskelton }}</span><span>Andy Skelton, Developer, WordPress (<a href="https://en.blog.wordpress.com/2012/11/15/pay-another-way-bitcoin/">{{page.dialogs.material_source}}</a>)</span></p>
 <p><span>{{ page.dialogs.quotetuurdemeester }}</span><span>Tuur Demeester, Author, MacroTrends</span></p>
 <p><span>{{ page.dialogs.quoterichardbrown }}</span><span>Richard Brown, Executive architect, IBM</span></p>
-<p><span>{{ page.dialogs.quotefredwilson }}</span><span><a href="https://en.wikipedia.org/wiki/Fred_Wilson_%28financier%29">Fred Wilson</a>, Co-Founder of Union Square Ventures</span></p>
-<p><span>{{ page.dialogs.quotefrancoisrvelde }}</span><span>François R. Velde, Economist, Federal Reserve</span></p>
-<p><span>{{ page.dialogs.quotenavalravikant }}</span><span><a href="https://en.wikipedia.org/wiki/AngelList">Naval Ravikant</a>, Founder of Angellist</span></p>
-<p><span>{{ page.dialogs.quotebrianforde }}</span><span>Brian Forde, Director of Digital Currency, MIT Media Lab (<a href="http://www.forbes.com/sites/gregoryferenstein/2015/07/29/former-obama-tech-advisor-explains-how-bitcoin-could-transform-government-in-5-quotes/">source</a>)</span></p>
+<p><span>{{ page.dialogs.quotefredwilson }}</span><span><a href="https://en.wikipedia.org/wiki/Fred_Wilson_%28financier%29">Fred Wilson</a>, Co-Founder of Union Square Ventures (<a href="http://www.businessinsider.com/fred-wilson-heres-why-im-investing-in-bitcoin-2013-5">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotefrancoisrvelde }}</span><span>François R. Velde, Economist, Federal Reserve (<a href="http://www.nytimes.com/2013/11/24/your-money/a-bitcoin-puzzle-heads-its-excitement-tails-its-anxiety.html">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotenavalravikant }}</span><span><a href="https://en.wikipedia.org/wiki/AngelList">Naval Ravikant</a>, Founder of Angellist (<a href="https://gigaom.com/2013/09/10/as-bitcoin-hype-settles-down-real-possibilities-start-to-emerge/">{{page.dialogs.material_source}}</a>)</span></p>
+<p><span>{{ page.dialogs.quotebrianforde }}</span><span>Brian Forde, Director of Digital Currency, MIT Media Lab (<a href="http://www.forbes.com/sites/gregoryferenstein/2015/07/29/former-obama-tech-advisor-explains-how-bitcoin-could-transform-government-in-5-quotes/">{{page.dialogs.material_source}}</a>)</span></p>
 
 <p class="final"><i>{{page.dialogs.material_even_more_quotes}}</i></p>
 </div>

--- a/_templates/press.html
+++ b/_templates/press.html
@@ -12,6 +12,7 @@ dialogs:
   materialvideomore: "More videos"
   materialquote: "Quotes"
   materialquotemore: "Show more quotes..."
+  material_even_more_quotes: "For even more quotes about Bitcoin, please see <a href=\"https://en.wikiquote.org/wiki/Bitcoin\">WikiQuote.</a>"
   quotesatoshi: "With e-currency based on cryptographic proof, without the need to trust a third party middleman, money can be secure and transactions effortless."
   quotetonygallippi: "Bitcoin is Money Over Internet Protocol."
   quotedankaminsky: "Entire classes of bugs are missing."
@@ -251,7 +252,10 @@ What is Bitcoin - Weusecoins<br>
 <p><span>{{ page.dialogs.quotefrancoisrvelde }}</span><span>François R. Velde, Economist, Federal Reserve</span></p>
 <p><span>{{ page.dialogs.quotenavalravikant }}</span><span>Naval Ravikant, Founder of Angellist</span></p>
 <p><span>{{ page.dialogs.quotemaxkeiser }}</span><span>Max Keiser, Journalist &amp; TV Host</span></p>
+
+<p class="final"><i>{{page.dialogs.material_even_more_quotes}}</i></p>
 </div>
+
 <a href="#" onclick="materialShow(event);" ontouchstart="materialShow(event);">{{ page.dialogs.materialquotemore }}</a>
 
 </div>

--- a/_templates/press.html
+++ b/_templates/press.html
@@ -20,11 +20,16 @@ dialogs:
   quotejeremyliew: "The potential for disruption is enormous."
   quotewencescasares: "Right now Bitcoin feels like the Internet before the browser."
   quotetylerwinklevoss: "We have elected to put our money and faith in a mathematical framework that is free of politics and human error."
-  quotemaxkeiser: "It's the cheapest way to move money around."
+  quotepaulbuchheit: "Bitcoin may be the TCP/IP of money."
   quotebillgates: "Bitcoin is a technological tour de force."
   quotegavinandresen: "You can basically put a bank in your pocket... That's pretty amazing."
   quotenavalravikant: "All the things that gold does, Bitcoin kind of does better."
-  quotetimothylee: "Bitcoin allows wealth to be reduced to pure information and transmitted costlessly around the world—something nobody knew how to do before 2009. Its applications won’t be immediately obvious, especially to ordinary users."
+  quotebrianforde: >
+    Digital currencies have immense potential to improve human welfare
+    by strengthening the capacity of governments to deliver more
+    responsive services and secure the rights of their citizens to
+    property, identity and increased financial inclusion.
+
   quoteandyskelton: "PayPal alone blocks access from over 60 countries ... Whatever the reason, we don’t think an individual blogger from Haiti, Ethiopia, or Kenya should have diminished access to the blogosphere because of payment issues they can’t control."
   quotetuurdemeester: "The Babyboomers gave us the personal computer, Generation X gave us the Internet, and now Generation Y is building a new financial paradigm."
   quoterichardbrown: "Had you asked me five years ago, I would just say it was impossible. Bitcoin and cryptocurrencies solved this problem of coming to a consensus globally where you don't trust anybody else."
@@ -244,14 +249,14 @@ What is Bitcoin - Weusecoins<br>
 <p><span>{{ page.dialogs.quotesatoshi }}</span><span>Satoshi Nakamoto, Bitcoin Developer</span></p>
 <p><span>{{ page.dialogs.quotebillgates }}</span><span>Bill Gates, Executive Chairman, Microsoft<br>Eric Schmidt, Executive Chairman, Google</span></p>
 <p><span>{{ page.dialogs.quotegavinandresen }}</span><span>Gavin Andresen, Chief Scientist, The Bitcoin Foundation</span></p>
-<p><span>{{ page.dialogs.quotetimothylee }}</span><span>Timothy B. Lee, Reporter, The Washington Post</span></p>
+<p><span>{{ page.dialogs.quotepaulbuchheit }}</span><span>Paul Buchheit, Creator of GMail, Google (<a href="https://twitter.com/paultoo/status/328969714283995136">source</a>)</span></p>
 <p><span>{{ page.dialogs.quoteandyskelton }}</span><span>Andy Skelton, Developer, WordPress</span></p>
 <p><span>{{ page.dialogs.quotetuurdemeester }}</span><span>Tuur Demeester, Author, MacroTrends</span></p>
 <p><span>{{ page.dialogs.quoterichardbrown }}</span><span>Richard Brown, Executive architect, IBM</span></p>
 <p><span>{{ page.dialogs.quotefredwilson }}</span><span>Fred Wilson, Co-Founder of Union Square Ventures</span></p>
 <p><span>{{ page.dialogs.quotefrancoisrvelde }}</span><span>François R. Velde, Economist, Federal Reserve</span></p>
 <p><span>{{ page.dialogs.quotenavalravikant }}</span><span>Naval Ravikant, Founder of Angellist</span></p>
-<p><span>{{ page.dialogs.quotemaxkeiser }}</span><span>Max Keiser, Journalist &amp; TV Host</span></p>
+<p><span>{{ page.dialogs.quotebrianforde }}</span><span>Brian Forde, Director of Digital Currency, MIT Media Lab (<a href="http://www.forbes.com/sites/gregoryferenstein/2015/07/29/former-obama-tech-advisor-explains-how-bitcoin-could-transform-government-in-5-quotes/">source</a>)</span></p>
 
 <p class="final"><i>{{page.dialogs.material_even_more_quotes}}</i></p>
 </div>

--- a/_templates/press.html
+++ b/_templates/press.html
@@ -239,23 +239,23 @@ What is Bitcoin - Weusecoins<br>
 
 <h2 id="quotes">{{ page.dialogs.materialquote }}</h2>
 <div>
-<p><span>{{ page.dialogs.quotechrisdixon }}</span><span>Chris Dixon, Technology Investor</span></p>
-<p><span>{{ page.dialogs.quotewencescasares }}</span><span>Wences Casares, Technology Entrepreneur</span></p>
-<p><span>{{ page.dialogs.quotetonygallippi }}</span><span>Tony Gallippi, BitPay CEO</span></p>
-<p><span>{{ page.dialogs.quotedankaminsky }}</span><span>Dan Kaminsky, Security Researcher</span></p>
-<p><span>{{ page.dialogs.quotejeremyliew }}</span><span>Jeremy Liew, Lightspeed Venture Partners</span></p>
-<p><span>{{ page.dialogs.quotejohndonohoe }}</span>John Donohoe, Ebay CEO<span></span></p>
-<p><span>{{ page.dialogs.quotetylerwinklevoss }}</span><span>Tyler Winklevoss, Entrepreneur</span></p>
-<p><span>{{ page.dialogs.quotesatoshi }}</span><span>Satoshi Nakamoto, Bitcoin Developer</span></p>
-<p><span>{{ page.dialogs.quotebillgates }}</span><span>Bill Gates, Executive Chairman, Microsoft<br>Eric Schmidt, Executive Chairman, Google</span></p>
-<p><span>{{ page.dialogs.quotegavinandresen }}</span><span>Gavin Andresen, Chief Scientist, The Bitcoin Foundation</span></p>
-<p><span>{{ page.dialogs.quotepaulbuchheit }}</span><span>Paul Buchheit, Creator of GMail, Google (<a href="https://twitter.com/paultoo/status/328969714283995136">source</a>)</span></p>
+<p><span>{{ page.dialogs.quotechrisdixon }}</span><span><a href="https://en.wikipedia.org/wiki/Chris_Dixon">Chris Dixon</a>, Technology Investor</span></p>
+<p><span>{{ page.dialogs.quotewencescasares }}</span><span><a href="https://en.wikipedia.org/wiki/Wences_Casares">Wences Casares</a>, Technology Entrepreneur</span></p>
+<p><span>{{ page.dialogs.quotetonygallippi }}</span><span><a href="https://en.wikipedia.org/wiki/Tony_Gallippi">Tony Gallippi</a>, BitPay CEO</span></p>
+<p><span>{{ page.dialogs.quotedankaminsky }}</span><span><a href="https://en.wikipedia.org/wiki/Dan_Kaminsky">Dan Kaminsky</a>, Security Researcher</span></p>
+<p><span>{{ page.dialogs.quotejeremyliew }}</span><span><a href="https://en.wikipedia.org/wiki/Lightspeed_Ventures">Jeremy Liew</a>, Lightspeed Venture Partners</span></p>
+<p><span>{{ page.dialogs.quotejohndonohoe }}</span><a href="https://en.wikipedia.org/wiki/John_Donahoe">John Donohoe</a>, former Ebay CEO<span></span></p>
+<p><span>{{ page.dialogs.quotetylerwinklevoss }}</span><span><a href="https://en.wikipedia.org/wiki/Tyler_Winklevoss">Tyler Winklevoss</a>, Entrepreneur</span></p>
+<p><span>{{ page.dialogs.quotesatoshi }}</span><span><a href="https://en.wikipedia.org/wiki/Satoshi_Nakamoto">Satoshi Nakamoto</a>, Bitcoin Developer</span></p>
+<p><span>{{ page.dialogs.quotebillgates }}</span><span><a href="https://en.wikipedia.org/wiki/Bill_Gates">Bill Gates</a>, Executive Chairman, Microsoft<br><a href="https://en.wikipedia.org/wiki/Eric_Schmidt">Eric Schmidt</a>, Executive Chairman, Google</span></p>
+<p><span>{{ page.dialogs.quotegavinandresen }}</span><span><a href="https://en.wikipedia.org/wiki/Gavin_Andresen">Gavin Andresen</a>, Chief Scientist, The Bitcoin Foundation</span></p>
+<p><span>{{ page.dialogs.quotepaulbuchheit }}</span><span><a href="https://en.wikipedia.org/wiki/Paul_Buchheit">Paul Buchheit</a>, Creator of GMail, Google (<a href="https://twitter.com/paultoo/status/328969714283995136">source</a>)</span></p>
 <p><span>{{ page.dialogs.quoteandyskelton }}</span><span>Andy Skelton, Developer, WordPress</span></p>
 <p><span>{{ page.dialogs.quotetuurdemeester }}</span><span>Tuur Demeester, Author, MacroTrends</span></p>
 <p><span>{{ page.dialogs.quoterichardbrown }}</span><span>Richard Brown, Executive architect, IBM</span></p>
-<p><span>{{ page.dialogs.quotefredwilson }}</span><span>Fred Wilson, Co-Founder of Union Square Ventures</span></p>
+<p><span>{{ page.dialogs.quotefredwilson }}</span><span><a href="https://en.wikipedia.org/wiki/Fred_Wilson_%28financier%29">Fred Wilson</a>, Co-Founder of Union Square Ventures</span></p>
 <p><span>{{ page.dialogs.quotefrancoisrvelde }}</span><span>François R. Velde, Economist, Federal Reserve</span></p>
-<p><span>{{ page.dialogs.quotenavalravikant }}</span><span>Naval Ravikant, Founder of Angellist</span></p>
+<p><span>{{ page.dialogs.quotenavalravikant }}</span><span><a href="https://en.wikipedia.org/wiki/AngelList">Naval Ravikant</a>, Founder of Angellist</span></p>
 <p><span>{{ page.dialogs.quotebrianforde }}</span><span>Brian Forde, Director of Digital Currency, MIT Media Lab (<a href="http://www.forbes.com/sites/gregoryferenstein/2015/07/29/former-obama-tech-advisor-explains-how-bitcoin-could-transform-government-in-5-quotes/">source</a>)</span></p>
 
 <p class="final"><i>{{page.dialogs.material_even_more_quotes}}</i></p>

--- a/_templates/press.html
+++ b/_templates/press.html
@@ -22,7 +22,6 @@ dialogs:
   quotewencescasares: "Right now Bitcoin feels like the Internet before the browser."
   quotetylerwinklevoss: "We have elected to put our money and faith in a mathematical framework that is free of politics and human error."
   quotepaulbuchheit: "Bitcoin may be the TCP/IP of money."
-  quotebillgates: "Bitcoin is a technological tour de force."
   quotegavinandresen: "You can basically put a bank in your pocket... That's pretty amazing."
   quotenavalravikant: "All the things that gold does, Bitcoin kind of does better."
   quotebrianforde: >
@@ -248,7 +247,6 @@ What is Bitcoin - Weusecoins<br>
 <p><span>{{ page.dialogs.quotejohndonohoe }}</span><a href="https://en.wikipedia.org/wiki/John_Donahoe">John Donohoe</a>, former Ebay CEO (<a href="http://techcrunch.com/2013/11/03/ebay-ceo-john-donahoe-is-bullish-on-digital-currency-and-hes-keeping-tabs-on-bitcoin/">{{page.dialogs.material_source}}</a>)<span></span></p>
 <p><span>{{ page.dialogs.quotetylerwinklevoss }}</span><span><a href="https://en.wikipedia.org/wiki/Tyler_Winklevoss">Tyler Winklevoss</a>, Entrepreneur (<a href="http://dealbook.nytimes.com/2013/04/11/as-big-investors-emerge-bitcoin-gets-ready-for-its-close-up/">{{page.dialogs.material_source}}</a>)</span></p>
 <p><span>{{ page.dialogs.quotesatoshi }}</span><span><a href="https://en.wikipedia.org/wiki/Satoshi_Nakamoto">Satoshi Nakamoto</a>, Bitcoin Developer (<a href="http://p2pfoundation.ning.com/forum/topics/bitcoin-open-{{page.dialogs.material_source}}">{{page.dialogs.material_source}}</a>)</span></p>
-<p><span>{{ page.dialogs.quotebillgates }}</span><span><a href="https://en.wikipedia.org/wiki/Bill_Gates">Bill Gates</a>, Executive Chairman, Microsoft (<a href="http://video.foxbusiness.com/v/2359385547001/mungerbuffett-disagree-on-corporate-tax-rates/?#sp=show-clips">{{page.dialogs.material_source}}</a>)<br><a href="https://en.wikipedia.org/wiki/Eric_Schmidt">Eric Schmidt</a>, Executive Chairman, Google (<a href="http://video.cnbc.com/gallery/?video=3000163361&play=1%5B1%5D">{{page.dialogs.material_source}}</a>)</span></p>
 <p><span>{{ page.dialogs.quotegavinandresen }}</span><span><a href="https://en.wikipedia.org/wiki/Gavin_Andresen">Gavin Andresen</a>, Chief Scientist, The Bitcoin Foundation (<a href="https://www.youtube.com/watch?v=0S4dSXTnfms">{{page.dialogs.material_source}}</a>)</span></p>
 <p><span>{{ page.dialogs.quotepaulbuchheit }}</span><span><a href="https://en.wikipedia.org/wiki/Paul_Buchheit">Paul Buchheit</a>, Creator of GMail, Google (<a href="https://twitter.com/paultoo/status/328969714283995136">{{page.dialogs.material_source}}</a>)</span></p>
 <p><span>{{ page.dialogs.quoteandyskelton }}</span><span>Andy Skelton, Developer, WordPress (<a href="https://en.blog.wordpress.com/2012/11/15/pay-another-way-bitcoin/">{{page.dialogs.material_source}}</a>)</span></p>


### PR DESCRIPTION
This PR makes changes to the quotes section of the Press page.  It is, I hope, the last PR related to the changes started in aborted PR #972.  There are several commits:

1. Fix a CSS-based bug that prevents display of the open-quote on the left column.  This can be seen on the live site: https://bitcoin.org/en/press#quotes

2. Add a link to the [Bitcoin WikiQuotes](https://en.wikiquote.org/wiki/Bitcoin) page for even more quotes.  Although this page doesn't currently have many more quotes than we do, I hope that by linking to it, we'll encourage more people to contribute to it.

3. Replace quotes from Max Keiser and Timothy Lee with quotes from Paul Buchheit (GMail creator) and Brian Forde (MIT DCI director).  The replaced quotes described Bitcoin as, respectively, "cheapest" and "costless", which is only true if you exclude certain other payment systems (like physical cash) and network costs (like mining and verification).

4. Link the names of the quoted persons to the English Wikipedia articles about them.  If no English Wikipedia article was available, I did not link anything.

5. Link quotes to the source where the quote first appeared (as best as I could determine).  I couldn't find the source for some quotes, so no link was added in those cases.  I also corrected one quote based on the linked source quote.

6. Remove the quote that both Bill Gates and Eric Schmidt said.  The quote on Bitcoin.org is, "Bitcoin is a technological tour de force", but I feel that this is misleading given the qualifications they each put into the rest of the original quotes (as linked in the preceding commit):

    - (Schmidt) "Bitcoin is a technological tour de force, but what I don't know ultimately is whether it's going to be legal because almost all money structures need legality..."

    - (Gates) "It's a techno tour de force, but that's an area where governments are going to maintain a dominant role."

    I think they're approving of the block chain/POW consensus but not of the monetary aspect.  Since Bitcoin.org is promoting both aspects, I don't think it's fair of us to use their quotes.

After these commits, the fully-expanded section looks like:

![screenshot-btcorg localhost 2015-07-30 18-53-53](https://cloud.githubusercontent.com/assets/61096/8997177/718ee790-36ec-11e5-8527-fc5d08090978.png)
