### PR TITLE
Update instructions to starting up regtest

### DIFF
--- a/_includes/example_testing.md
+++ b/_includes/example_testing.md
@@ -57,6 +57,14 @@ environment.
 Bitcoin server starting
 {% endhighlight %}
 
+Create a file in the .bitcoin directory names bitcoin.conf. Populate with
+the following:
+
+~~~
+rpcuser=anyuser
+rpcpassword=anypswd
+~~~
+
 {% autocrossref %}
 
 Start `bitcoind` in regtest mode to create a private block chain.


### PR DESCRIPTION
Using Regtest mode as documented fails, you must first define rpcuser and rpcpassword before executing the generate 101 command.