### PR TITLE
Add Inside Bitcoins Seoul to events page

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -94,6 +94,14 @@
   country: "United States"
   link: "http://www.imtconferences.com/mtbit/"
 
+- date: 2015-12-10
+  title: "Inside Bitcoins Seoul"
+  venue: "Korea International Exhibition Center (KINTEX)"
+  address: "2600, Daehwa-dong, Ilsanseo-gu, Goyang-si, Gyeonggi-do"
+  city: "Seoul"
+  country: "South Korea"
+  link: "http://insidebitcoins.com/seoul/2015?utm_source=bitcoinorg&utm_medium=eventlisting&utm_campaign=bitcoinorgeventlistingibseoul"
+
 - date: 2015-12-14
   title: "Inside Bitcoins San Diego"
   venue: "San Diego Convention Center"


### PR DESCRIPTION
[Inside Bitcoins Seoul](http://insidebitcoins.com/seoul/2015?utm_source=bitcoinorg&utm_medium=eventlisting&utm_campaign=bitcoinorgeventlistingibseoul)