### PR TITLE
Just added CoinFOX info for /resources

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -33,6 +33,9 @@ id: resources
     {% if page.lang == 'fr' %}<p><a href="http://le-coin-coin.fr/">Le Coin Coin</a></p>{% endif %}
     {% if page.lang == 'fr' %}<p><a href="http://www.bitcoin.fr/">Bitcoin.fr</a></p>{% endif %}
     {% if page.lang == 'bg' %}<p><a href="http://hash.bg/">Hash.bg</a></p>{% endif %}
+    {% if page.lang == 'en' %}<p><a href="http://www.coinfox.info/">CoinFOX</a></p>
+    {% if page.lang == 'ru' %}<p><a href="http://www.coinfox.ru/">CoinFOX</a></p>
+    {% if page.lang == 'es' %}<p><a href="http://www.coinfox.es/">CoinFOX</a></p>
     {% if page.lang == 'ru' %}<p><a href="http://bitnovosti.com/">Bit•Новости</a></p>
     <p><a href="http://coinspot.ru/">CoinSpot</a></p>{% endif %}
     <p>{% translate linkcointelegraph %}<p>


### PR DESCRIPTION
Just added CoinFOX info for https://bitcoin.org/ru/resources (News sector)

http://www.coinfox.info (ENG), http://www.coinfox.ru (RU) and http://www.coinfox.es (ES) for https://bitcoin.org/ru/resources