### PR TITLE
Added Inside Bitcoins New York to events page

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -117,3 +117,11 @@
   city: "Copenhagen"
   country: "Denmark"
   link: "https://www.money2020europe.com/"
+
+- date: 2016-04-10
+  title: "Inside Bitcoins New York"
+  venue: "Javits Convention Center"
+  address: "655 W 34th St"
+  city: "New York"
+  country: "United States"
+  link: "http://insidebitcoins.com/new-york/2016?utm_source=bitcoinorg&utm_medium=eventlisting&utm_campaign=bitcoinorgeventlistingibny"


### PR DESCRIPTION
[Inside Bitcoins New York](http://insidebitcoins.com/new-york/2016)