### PR TITLE
Apply more graceful mobile stylesheet to landing page icons

### DIFF
--- a/_less/ie.css
+++ b/_less/ie.css
@@ -139,30 +139,22 @@ body{
 .mainlist div{
 	zoom:1;
 	display:inline;
-	width:250px;
+	width:240px;
+	text-align:center;
 }
 .mainlist div div{
 	zoom:1;
 	display:inline;
 	line-height:1.5em;
-	text-align:left;
 	width:auto;
 }
-.mainlist div div{
-	text-align:left;
-}
-.mainlist div:first-child + div{
-	text-align:center;
-}
-.mainlist div:first-child + div + div{
-	text-align:right;
+.mainlist div div div {
+	display:block;
 }
 .mainlist .ieimg{
-	vertical-align:top;
+	display:block;
+	margin:10px auto;
 	position:relative;
-	top:4px;
-	margin-right:10px;
-	float:left;
 	height:48px;
 	width:48px;
 }

--- a/_less/rtl.less
+++ b/_less/rtl.less
@@ -133,20 +133,6 @@ h2 .rssicon{
 	margin-right:6px;
 }
 
-.mainlist>div:first-child{
-	text-align:right;
-}
-.mainlist>div:first-child+div+div{
-	text-align:left;
-}
-.mainlist>div>div>div{
-	text-align:right;
-}
-.mainlist img{
-	margin-left:10px;
-	float:right;
-}
-
 .start{
 	text-align:right;
 }
@@ -396,11 +382,6 @@ h2 .rssicon{
 		text-align:right;
 	}
 	.download div p{
-		text-align:right;
-	}
-	.mainlist>div:first-child,
-	.mainlist>div:first-child+div,
-	.mainlist>div:first-child+div+div{
 		text-align:right;
 	}
 	.start>div>div:first-child{

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -489,37 +489,28 @@ table td,table th{
 }
 .mainlist{
 	font-size:125%;
-	width:760px;
+	max-width:760px;
 	margin:30px auto;
 	display:table;
 }
 .mainlist>div{
 	display:table-cell;
-	min-width:240px;
+	width:240px;
+	min-width:200px;
+	text-align:center;
 }
 .mainlist>div>div{
 	display:inline-block;
 	line-height:1.5em;
-	text-align:left;
-}
-.mainlist>div:first-child{
-	text-align:left;
-}
-.mainlist>div:first-child+div{
-	text-align:center;
-}
-.mainlist>div:first-child+div+div{
-	text-align:right;
 }
 .mainlist>div>div>div{
 	display:inline-block;
 }
 .mainlist img{
+	display:block;
+	margin:10px auto;
 	vertical-align:top;
 	position:relative;
-	top:4px;
-	margin-right:10px;
-	float:left;
 	height:48px;
 	width:48px;
 }
@@ -2446,19 +2437,6 @@ h2 .rssicon{
 	.mainvideo img{
 		height:auto;
 	}
-	.mainlist,
-	.mainlist>div{
-		width:auto;
-		display:block;
-	}
-	.mainlist>div>div{
-		margin:10px;
-	}
-	.mainlist>div:first-child,
-	.mainlist>div:first-child+div,
-	.mainlist>div:first-child+div+div{
-		text-align:left;
-	}
 	.start>div{
 		position:static;
 	}
@@ -2709,5 +2687,17 @@ h2 .rssicon{
 	}
 	.detectmobile{
 		display:block;
+	}
+}
+
+
+@media handheld, only screen and ( max-width: 40em ), only screen and ( max-device-width: 40em ){
+	.mainlist,
+	.mainlist>div{
+		width:auto;
+		display:block;
+	}
+	.mainlist>div{
+		margin:15px auto;
 	}
 }


### PR DESCRIPTION
This addresses at least one issue mentioned on #1014 , by allowing these elements to be displayed inline on the screen until the space is really stretch enough.

I should have left equivalent space for texts, so variable-width translations should still fit correctly in the available space. At least I have verified various ones without noticing any issue.

Live preview: http://bitcointest1.us.to/en/