### PR TITLE
Allow code samples to overflow on mobiles in the documentation

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1003,7 +1003,7 @@ div.post {
         padding-top: 20px;
 }
 
-.highlight  { background: #ffffff; }
+.highlight  { background: transparent; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */
@@ -2202,6 +2202,18 @@ h2 .rssicon{
 	h1,
 	h2{
 		text-align:center;
+	}
+	.toccontent .multicode,
+	.toccontent .multicode pre,
+	.toccontent pre{
+		display: table; /* Triggers a block formating context so the container expands with the content */
+	}
+	.toccontent .multicode,
+	.toccontent pre{
+		padding:10px;
+	}
+	.toccontent .multicode pre{
+		padding:0;
 	}
 	.titleicon,
 	.warningicon{


### PR DESCRIPTION
Live preview: http://bitcointest1.us.to/en/

Some code samples cannot be read on mobiles. Although this solution isn't ideal as it makes the code overflow outside of the page, my impression is that it's better than cutting the content altogether.