### PR TITLE
Allow build script to reuse pre-installed dependencies

### DIFF
--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -39,7 +39,7 @@ fi
 
 # Update local branch
 git reset --hard origin/master
-git clean -x -f -d
+git clean -f -d
 
 ## Whether to auto-build or force-build
 case "${1:-nil}" in
@@ -66,6 +66,9 @@ case "${1:-nil}" in
     exit 1
   ;;
 esac
+
+# Update dependencies
+bundle install --deployment --without :slow_test
 
 # Copy files to temporary directory
 rsync -rt --delete "$SITEDIR/" "$WORKDIR/"


### PR DESCRIPTION
Currently, our build script needs to download and install dependencies on every build. This probably prolongs build time unnecessarily and introduces a bit more of security risk with no apparent benefit.

This little change allows the build script to stop deleting files listed in .gitignore when fetching recent commits, therefore allowing it to keep and reuse the bundle environment in ./vendor.

Note: This small change is untested.