### PR TITLE
Drop inactive sponsorship banner

### DIFF
--- a/_includes/layout/base/footer-sponsor.html
+++ b/_includes/layout/base/footer-sponsor.html
@@ -4,5 +4,5 @@ http://opensource.org/licenses/MIT.
 {% endcomment %}
 
 <div class="footersponsor">
-  <div><span>{% translate sponsor layout %}</span> <a href="https://bitcoinfoundation.org/"><img src="/img/brand/bitcoinfoundation.png" alt="Bitcoin Foundation"></a></div>
+  <!--<div><span>{% translate sponsor layout %}</span> <a href="https://bitcoinfoundation.org/"><img src="/img/brand/bitcoinfoundation.png" alt="Bitcoin Foundation"></a></div>-->
 </div>


### PR DESCRIPTION
Current sponsorship will end on September 1th.

It is not decided yet if the Foundation will renew it's support (which I'd be happy with as far as I'm concerned). In the mean time, the sponsorship banner can be put on hold.

Note; This pull request should not be merged until September 1th.