### PR TITLE
added instructions for setting up bitcoind on OS X

### DIFF
--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1107,10 +1107,47 @@ automatically started minimized in the task bar.
 #### Bitcoin Core Daemon {#osx-daemon}
 {:.no_toc}
 
-If you can provide instructions and screenshots for running the latest
-version of Bitcoin Core daemon on OS X Yosemite, please [open an
-issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new) and we'll tell
-you what we need.
+The Bitcoin Core daemon (bitcoind) is not included in the .dmg file you may have downloaded to install Bitcoin-QT. Bitcoind, along with its support binaries, is instead included in the OS X .tar.gz file listed on the official Bitcoin Core download page. To download this file using Terminal, execute the following command:
+
+    curl -O https://bitcoin.org/bin/bitcoin-core-0.11.0/bitcoin-0.11.0-osx64.tar.gz
+
+{{verifyReleaseSignatures}}
+
+Extract bitcoind and its support binaries from the archive we just downloaded by running this command in Terminal:
+
+    tar -zxvf bitcoin-0.11.0-osx64.tar.gz
+
+Now we'll move the executables into your default path to make running and stopping bitcoind easier. To move the executables, run these commands (note that we have to use `sudo` to perform these commands since we are modifying directories owned by root):
+
+    sudo mkdir -p /usr/local/bin
+    sudo cp bitcoin-0.11.0/bin/bitcoin* /usr/local/bin/.
+
+To clean up the directory we've been working in, run:
+
+    rm -rf bitcoin-0.11.0*
+
+Before we can run bitcoind, we need to make sure that it has a place to store the blockchain and a config file that contains a username and password for the daemon. The commands below will set up your bitcoin directory and give bitcoind a default username and a random password (you do not need to remember the password for standard operation).
+
+    mkdir ~/Library/Application\ Support/Bitcoin
+    touch ~/Library/Application\ Support/Bitcoin/bitcoin.conf
+    chmod 600 ~/Library/Application\ Support/Bitcoin/bitcoin.conf
+    echo "rpcuser=bitcoinrpc" >> ~/Library/Application\ Support/Bitcoin/bitcoin.conf
+    echo "rpcpassword=$(cat /dev/urandom | env LC_CTYPE=C tr -dc a-zA-Z0-9 | head -c45)" >> ~/Library/Application\ Support/Bitcoin/bitcoin.conf
+
+You should now be able to start up your full node by running `bitcoind -daemon` in any Terminal window. If you need to stop bitcoind for any reason, the command is `bitcoin-cli stop`
+
+<div class="box" markdown="1">
+*Optional: Start Your Node At Login*
+
+Starting your node automatically each time you login to your computer makes it easy for you to contribute to the network. The easiest way to do this is to tell Bitcoin Core Daemon to start at login. In OS X, the way to start background programs at login is using a Launch Agent. Here is how to install a Launch Agent for Bitcoin Core daemon on your machine:
+
+    mkdir ~/Library/LaunchAgents
+    curl https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/init/org.bitcoin.bitcoind.plist > ~/Library/LaunchAgents/org.bitcoin.bitcoind.plist
+
+The next time you login to your desktop, Bitcoin Core daemon will be automatically started.
+</div>
+
+{{installFinished}}
 
 ## Network Configuration
 

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1109,22 +1109,22 @@ automatically started minimized in the task bar.
 
 The Bitcoin Core daemon (bitcoind) is not included in the .dmg file you may have downloaded to install Bitcoin-QT. Bitcoind, along with its support binaries, is instead included in the OS X .tar.gz file listed on the official Bitcoin Core download page. To download this file using Terminal, execute the following command:
 
-    curl -O https://bitcoin.org/bin/bitcoin-core-0.11.0/bitcoin-0.11.0-osx64.tar.gz
+    curl -O https://bitcoin.org/bin/bitcoin-core-{{site.DOWNLOAD_VERSION}}/bitcoin-{{site.DOWNLOAD_VERSION}}-osx64.tar.gz
 
 {{verifyReleaseSignatures}}
 
 Extract bitcoind and its support binaries from the archive we just downloaded by running this command in Terminal:
 
-    tar -zxvf bitcoin-0.11.0-osx64.tar.gz
+    tar -zxf bitcoin-{{site.DOWNLOAD_VERSION}}-osx64.tar.gz
 
 Now we'll move the executables into your default path to make running and stopping bitcoind easier. To move the executables, run these commands (note that we have to use `sudo` to perform these commands since we are modifying directories owned by root):
 
     sudo mkdir -p /usr/local/bin
-    sudo cp bitcoin-0.11.0/bin/bitcoin* /usr/local/bin/.
+    sudo cp bitcoin-{{site.DOWNLOAD_VERSION}}/bin/bitcoin* /usr/local/bin/.
 
 To clean up the directory we've been working in, run:
 
-    rm -rf bitcoin-0.11.0*
+    rm -rf bitcoin-{{site.DOWNLOAD_VERSION}}*
 
 Before we can run bitcoind, we need to make sure that it has a place to store the blockchain and a config file that contains a username and password for the daemon. The commands below will set up your bitcoin directory and give bitcoind a default username and a random password (you do not need to remember the password for standard operation).
 


### PR DESCRIPTION
The launch agent part of this guide is still waiting on [this PR](https://github.com/bitcoin/bitcoin/pull/6621)