### PR TITLE
Conditionally build some pages differently based on environmental variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,9 @@ rvm:
   - "2.0.0"
 sudo: false
 cache: bundler
+env:
+  # http://docs.travis-ci.com/user/environment-variables/#Global-Variables
+  global:
+    - BITCOINORG_BUILD_TYPE=deployment
 
 script: make travis

--- a/README.md
+++ b/README.md
@@ -297,6 +297,27 @@ run if the API site is running slow.
 
 For a list of languages, look in the `_translations` directory.
 
+#### Publishing Previews
+
+You can publish your previews online to any static hosting service.
+[GitHub pages](https://pages.github.com/) is a free service available to
+all GitHub users that works with Bitcoin.org's site hierarchy.
+
+Before building a preview site, it is recommended that you set the
+environmental variable `BITCOINORG_BUILD_TYPE` to "preview".  This will
+enable some content that would otherwise be hidden and also create a
+robots.txt file that will help prevent the site from being indexed by
+search engines and mistaken for the actual Bitcoin.org website.
+
+In the bash shell, you can do this by running the following command line
+before building you preview:
+
+    export BITCOINORG_BUILD_TYPE=preview
+
+You can also add this line to your `~/.bashrc` file if you frequently
+build site previews so that you don't have to remember to run it for
+each shell.
+
 ## Developer Documentation
 
 Most parts of the documentation can be found in the [_includes](https://github.com/bitcoin-dot-org/bitcoin.org/tree/master/_includes)

--- a/_build/update_site.sh
+++ b/_build/update_site.sh
@@ -11,8 +11,10 @@ BUNDLE_DIR='/bitcoin.org/bundle'
 SITEDIR='/bitcoin.org/site'
 DESTDIR='build@bitcoinorgsite:/var/www/site'
 WORKDIR=`mktemp -d`
+BITCOINORG_BUILD_TYPE='deployment'
 
 export BUNDLE_DIR
+export BITCOINORG_BUILD_TYPE
 
 # Stop script in case a single command fails
 set -e

--- a/_build/update_txpreview.sh
+++ b/_build/update_txpreview.sh
@@ -11,6 +11,9 @@ WORKDIR=`mktemp -d`
 LIVEDIR=`mktemp -d`
 SITEDIR='/bitcoin.org/txpreview'
 DESTDIR='/var/www/txpreview'
+BITCOINORG_BUILD_TYPE='preview'
+
+export BITCOINORG_BUILD_TYPE
 
 # Stop script in case a single command fails
 set -e

--- a/_plugins/env.rb
+++ b/_plugins/env.rb
@@ -1,0 +1,20 @@
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+## env.rb takes select environmental variables and makes them available
+## to the site templates. Currently, only variables starting with
+## BITCOINORG_ are exported
+
+module Jekyll
+  class EnvGenerator < Generator
+    def generate(site)
+      ## If necessary, initialize env hash table
+      site.config["env"] = site.config["env"] ? site.config["env"] : {}
+
+      ## Load matching environmental variables in to array
+      ENV.keys.grep /^BITCOINORG_/ do |key|
+        site.config['env'].merge!({ key => ENV[key] })
+      end
+    end
+  end
+end

--- a/_templates/about-us.html
+++ b/_templates/about-us.html
@@ -5,6 +5,7 @@
 layout: base
 id: about-us
 ---
+{% if site.env.BITCOINORG_BUILD_TYPE %}
 <!-- Note: this file is built non-deterministically -->
 <h1>{% translate pagetitle %}</h1>
 <p class="summary">{% translate pagedesc %}</p>
@@ -83,3 +84,19 @@ id: about-us
   </div>
   {% endfor %}
 </div>
+{% else %}
+{% comment %}
+<!-- if you've cloned bitcoin.org, feel free to fill in your own About
+Us below. It would be appreciated it if you link back to Bitcoin.org,
+but please make it clear that your site is not affiliated with
+Bitcoin.org.
+
+It would also be appreciated if you would remove our names and email
+addresses from the README.md file in the top-level directory.  -->
+{% endcomment %}
+<h1>About this site</h1>
+
+This site includes content originally published on <a
+href="https://bitcoin.org">Bitcoin.org</a>, but it is not affiliated with
+Bitcoin.org.
+{% endif %}

--- a/_templates/download.html
+++ b/_templates/download.html
@@ -16,6 +16,7 @@ lin32: "linux32.tar.gz"
 lin64: "linux64.tar.gz"
 
 ---
+{% if site.env.BITCOINORG_BUILD_TYPE %}
 <!-- Note: this file exempt from check-for-subheading-anchors check -->
 
 {% capture PATH_PREFIX %}/bin/bitcoin-core-{{ site.DOWNLOAD_VERSION }}{% endcapture %}
@@ -148,3 +149,13 @@ case 'mac':
 break;
 }
 </script>
+{% else %}
+{% capture redirect %}https://bitcoin.org/{{page.lang}}/{% translate download url %}{% endcapture %}
+<meta name="robots" content="noindex">
+<script>window.location.href='{{ redirect }}';</script>
+
+<div class="redirectmsg">
+<h1>This page has been moved</h1>
+<p><a href="{{ redirect }}">{{ redirect }}</a></p>
+</div>
+{% endif %}

--- a/robots.txt
+++ b/robots.txt
@@ -1,1 +1,12 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+layout: null
+---
+{% if site.env.BITCOINORG_BUILD_TYPE == 'preview' %}
+User-agent: *
+Disallow: /
+{% else %}
 Sitemap: https://bitcoin.org/sitemap.xml
+{% endif %}


### PR DESCRIPTION
This PR has three commits:

1. A new plugin which makes environmental variables (env vars) starting with `BITCOINORG_` available as template variables.

2. A conditional to the robots.txt file that prevents the site from being indexed if an env var is set to "preview".  This is useful for @saivann and myself who host previews of the site but don't want them to appear in search engine results.  Documentation for this is also added to README.md

3. A conditional on two of the content pages that changes how they will appear on cloned versions of the site (of which there are now several besides bitcoin.com).  Specifically:

    - The Bitcoin Core download page on cloned sites redirects to the language equivalent page on Bitcoin.org
    - The About Us page has all information replaced by a single sentence: "This site includes content originally published on Bitcoin.org, but it is not affiliated with Bitcoin.org."

    It is not the goal to prevent people from cloning the site but, rather, to ensure that cloned sites have accurate information about Bitcoin Core and that the contributors to Bitcoin.org don't get blamed for clone site problems.

### Previews

The above commits mean the site can be compiled in three different states, so a separate preview is provided for each:

- **No variables set:** this is what I expect clone sites to do.  Preview of the [About Us page](http://dg0.dtrt.org/en/about-us) and the [Download page](http://dg0.dtrt.org/en/download) (should automatically redirect to Bitcoin.org).  The [robots.txt](http://dg0.dtrt.org/robots.txt) and other site pages are unaffected.

- **BITCOINORG_BUILD_TYPE=preview** this is what I expect to use myself for preview builds in the future.  The [robots.txt](http://dg1.dtrt.org/robots.txt) denies all indexing but the [About Us](http://dg1.dtrt.org/en/about-us) and [Download](http://dg1.dtrt.org/en/download) pages are unaffected, as is the rest of the site.

- **BITCOINORG_BUILD_TYPE=deployment** this is what the build script will be running from now on ([as will Travis](https://travis-ci.org/harding/bitcoin.org/builds/78823051#L82)).  Except for inconsequential additional empty lines, all content is identical to the merge base, including the [robots.txt](http://dg2.dtrt.org/robots.txt), [About Us page](http://dg2.dtrt.org/en/about-us), and [Download page](http://dg2.dtrt.org/en/download)

---

I will update both the build server build script and the translation preview server build script at merge time.