### PR TITLE
Backend: cache events and contributor listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ehthumbs.db
 Thumbs.db
 .bundle
 vendor
+_cache

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ build:
 	  | egrep -v 'sha256sums.txt' \
 	  | sort \
 	  | xargs -d '\n' sha256sum > _site/sha256sums.txt
-	$S git show --oneline > _site/commit.txt
+	$S git log -1 --format="%H" > _site/commit.txt
 
 ## Jekyll annoyingly returns success even when it emits errors and
 ## exceptions, so we'll grep its output for error strings


### PR DESCRIPTION
When making changes to the site, Saïvann and I often diff the resulting HTML output with output from earlier known-good commits.  One problem with this method is that the HTML output isn't fully deterministic---some of it comes from external sites and can change massively between two builds that are only minutes apart, making reading the diff unpleasant and less useful than it could be.

This commit caches that external data between builds so that two builds on the same computer are very nearly deterministic.  As evidence, at the end of this message I offer inline the full diff of two sequential builds both on this commit.

Cached Meetup.com events, Bitcoin Core contributor listings, and Bitcoin.org contributor listings are retained for 24 hours before being refreshed.  Cached Geo-location data for conferences is retained until the _events.yml file is updated.  Caches are updated based on file timestamps, so they can be manipulated using `touch` or simply deleted to fetch new data.

This commit includes one small miscellaneous change to the Makefile to reduce the size of the /commit.txt file.  (The replaced command didn't work the way I thought it did; this command produces the correct output.)

```diff
diff -ru _site_a/en/rss/blog.xml _site/en/rss/blog.xml
--- _site_a/en/rss/blog.xml	2015-09-06 18:52:46.785203305 -0400
+++ _site/en/rss/blog.xml	2015-09-06 19:07:01.027678049 -0400
@@ -5,8 +5,8 @@
     <description>News about Bitcoin.org</description>
     <link>//</link>
     <atom:link href="//en/rss/blog.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Sun, 06 Sep 2015 18:45:28 -0400</pubDate>
-    <lastBuildDate>Sun, 06 Sep 2015 18:45:28 -0400</lastBuildDate>
+    <pubDate>Sun, 06 Sep 2015 18:59:39 -0400</pubDate>
+    <lastBuildDate>Sun, 06 Sep 2015 18:59:39 -0400</lastBuildDate>
     <generator>Jekyll v1.3.0</generator>
     
       <item>
diff -ru _site_a/sha256sums.txt _site/sha256sums.txt
--- _site_a/sha256sums.txt	2015-09-06 18:52:47.465211621 -0400
+++ _site/sha256sums.txt	2015-09-06 19:07:01.727686654 -0400
@@ -325,7 +325,7 @@
 34e1e82c7810f261baec99a73c0327c0a05a46d2869ed57840130daf5ea5fddd  _site/en/release/v0.9.3.html
 63b90f09f0def9780a9da8eeef0e4430e147b156314a0a1931ef17afa38920a5  _site/en/resources.html
 ea62e46ad3c8fc96824074ba21abc9bad9df2b145d2b230ae84a69b0d5ca8035  _site/en/rss/alerts.rss
-9f772391bb916ebd273d5e9d03d4d45b87f3d4f0a3440effc0537c10163f47d5  _site/en/rss/blog.xml
+4b6f77955753228f295068092928b87db7ea43a87c71b7f767c1ee7e2106ff7a  _site/en/rss/blog.xml
 49f3438da26309fc3c20522dae6cab65efb3c502327df6693933239fc53fe1c2  _site/en/rss/releases.rss
 d2b7db6b8bada8f96aeb505e0b284a28b83fda625c91aac48684dfde73cfd35e  _site/en/secure-your-wallet.html
 5e77e94a36c5698486b0d1fc383a7a7f874131d5be0b38973d6548758c89ba5c  _site/en/support-bitcoin.html
```