### PR TITLE
Enable Google analytics

### DIFF
--- a/_includes/layout/base/html-head.html
+++ b/_includes/layout/base/html-head.html
@@ -16,5 +16,15 @@ http://opensource.org/licenses/MIT.
 {% if page.lang == 'bg' or page.lang == 'el' or page.lang == 'ko' or page.lang == 'hi' or page.lang == 'pl' or page.lang == 'sl' or page.lang == 'ro' or page.lang == 'ru' or page.lang == 'tr' or page.lang == 'uk' or page.lang == 'zh_CN' or page.lang == 'zh_TW' %}{% lesscss sans.less %}{% endif %}
 <script type="text/javascript" src="/js/base.js"></script>
 {% if page.id != 'download' %}<script type="text/javascript" src="/js/main.js"></script>{% endif %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-46627233-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
 <link rel="shortcut icon" href="/favicon.png">
 <link rel="apple-touch-icon-precomposed" href="/img/icons/logo_ios.png"/>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -642,9 +642,9 @@ en:
     title: "Privacy - Bitcoin"
     pagetitle: "Privacy"
     datacollect: "Data collected"
-    datacollecttxt: "Bitcoin.org collects anonymized server logs. These logs include IP addresses with replaced last byte, time of the visit, requested page, user agent and referer url. Bitcoin.org does not collect data using cookies."
+    datacollecttxt: "Bitcoin.org collects anonymized server logs. These logs include IP addresses with replaced last byte, time of the visit, requested page, user agent and referer url. Bitcoin.org uses Google Analytics to get visitor traffic information. Google Analytics collects cookies, IP addresses, operating system information, and screen resolution. Bitcoin.org does not have direct access to the information collected by Google Analytics."
     datause: "Usage of data"
-    datausetxt: "Collected data may be used to provide transparent public stats."
+    datausetxt: "Collected data may be used to provide transparent public stats. Data collected through Google Analytics may be used to accurately determine the number of visitors to the site, and traffic sources. Data obtained through Google Analytics may be publicly shared with potential advertising partners for business purposes."
   protect-your-privacy:
     title: "Protect your privacy - Bitcoin"
     pagetitle: "Protect your privacy"


### PR DESCRIPTION
Adds Google Analytics to the site so that visitor numbers and behavior can be accurately measured. This is necessary as Bitcoin.org is currently looking to work with new advertising partners to help fund the site's expenses.