### PR TITLE
Add BrowserStack to the Contributors section

### DIFF
--- a/_templates/about-us.html
+++ b/_templates/about-us.html
@@ -66,6 +66,15 @@ id: about-us
   <p>Thomas Pryds<span>Danish</span></p>
 </div>
 
+<h3 id="service_contributors">{% translate service_contributors %}</h3>
+
+<div class="credit">
+  <p><a href="https://www.browserstack.com/">BrowserStack</a><span>Browser testing</span></p>
+  <p><a href="https://github.com/">GitHub</a><span>Repository hosting</span></p>
+  <p><a href="https://www.transifex.com/">Transifex</a><span>Translation tools</span></p>
+  <p><a href="https://travis-ci.org/">Travis CI</a><span>Continuous integration</span></p>
+</div>
+
 <h3 id="inactive-contributors">{% translate inactive_contributors %}</h3>
 
 <div class="credit">

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -23,6 +23,7 @@ en:
     maintenance: "Maintenance"
     documentation: "Documentation"
     sponsorship: "Sponsorship"
+    service_contributors: "Service Contributors"
     translation: "Translation"
     inactive_contributors: "Inactive Contributors"
     owners: "Domain Owners"


### PR DESCRIPTION
@mateuszrybin suggested we could use BrowserStack for testing the site on several devices and suggested they were offering the service free of charge to open-source projects.

After a quick email with them, they are indeed happy about providing the service in exchange for a backlink in our "About us" page. This pull request is submitting that link for review (see screenshot below).

I personally think this is a very useful tool to have, and what we're asked to provide in exchange seems very reasonable to me.

![capture du 2015-10-15 02 51 52](https://cloud.githubusercontent.com/assets/3578089/10506653/3e10946c-72e8-11e5-8d6e-b33ba5df8aaa.png)
