### PR TITLE
add info about minrelaytxfee default increase

### DIFF
--- a/_releases/0.11.1.md
+++ b/_releases/0.11.1.md
@@ -122,6 +122,17 @@ only eliminates the cheap and irritating DOS attack.
 Marcin Andrychowicz, Stefan Dziembowski, Daniel Malinowski, Łukasz Mazurek
 http://fc15.ifca.ai/preproceedings/bitcoin/paper_9.pdf
 
+Minimum relay fee default increase
+-----------------------------------
+
+The default for the `-minrelaytxfee` setting has been increased from `0.00001`
+to `0.00005`.
+
+This is necessitated by the current transaction flooding, causing
+outrageous memory usage on nodes due to the mempool ballooning. This is a
+temporary measure, bridging the time until a dynamic method for determining
+this fee is merged (which will be in 0.12).
+
 0.11.1 Change log
 =================
 
@@ -144,6 +155,8 @@ git merge commit are mentioned.
 - #6789 `b4ad73f` Update miniupnpc to 1.9.20151008
 - #6785 `b4dc33e` Backport to v0.11: In (strCommand == "tx"), return if AlreadyHave()
 - #6412 `0095b9a` Test whether created sockets are select()able
+- #6795 `4dbcec0` net: Disable upnp by default
+- #6793 `e7bcc4a` Bump minrelaytxfee default
 
 Credits
 =======


### PR DESCRIPTION
added information from the bitcoin-dev email regarding the increase of the default for the minrelaytxfee.