### PR TITLE
Dev docs: change "op code" to "opcode"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -323,9 +323,9 @@ devsearches:
     - 'WalletPassphrase': "/en/developer-reference#walletpassphrase"
     - 'WalletPassphraseChange': "/en/developer-reference#walletpassphrasechange"
 
-  ## Op codes currently implemented in Bitcoin Core master branch. After
+  ## Opcodes currently implemented in Bitcoin Core master branch. After
   ## we document them on Bitcoin.org, these links will be updated
-  "Op codes":
+  "Opcodes":
     - "OP_0 (OP_FALSE)": "https://en.bitcoin.it/wiki/Script#Constants"
     - "OP_PUSHDATA1": "https://en.bitcoin.it/wiki/Script#Constants"
     - "OP_PUSHDATA2": "https://en.bitcoin.it/wiki/Script#Constants"

--- a/_data/glossary/en/null-data-transaction.yaml
+++ b/_data/glossary/en/null-data-transaction.yaml
@@ -22,7 +22,7 @@ optional:
         - data carrier transactions
 
     not_to_be_confused_with_capitalize_first_letter:
-        - OP_RETURN (an op code used in one of the outputs in an OP_RETURN transaction)
+        - OP_RETURN (an opcode used in one of the outputs in an OP_RETURN transaction)
 
     links_html_or_markdown_style_capitalize_first_letter:
         - "[Null data transaction](/en/developer-guide#term-null-data) --- Bitcoin.org Developer Guide"

--- a/_data/glossary/en/op-code.yaml
+++ b/_data/glossary/en/op-code.yaml
@@ -4,31 +4,31 @@
 
 required:
                                            #-------------40 characters-------------#
-    title_max_40_characters_no_formatting: Op Code
+    title_max_40_characters_no_formatting: Opcode
 
     summary_max_255_characters_no_formatting: >
         Operation codes from the Bitcoin Script language which push data
         or perform functions within a pubkey script or signature script.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
-        - Op code
-        - Data-pushing op code
-        - Non-data-pushing op code
+        - Opcode
+        - Data-pushing opcode
+        - Non-data-pushing opcode
 
 optional:
     synonyms_and_pluralizations_not_shown_in_glossary:
-        - op codes
+        - opcodes
         - opcode
         - opcodes
-        - data-pushing op codes
         - data-pushing opcodes
-        - non-data-pushing op codes
+        - data-pushing opcodes
+        - non-data-pushing opcodes
         - non-data-pushing opcodes
 
     not_to_be_confused_with_capitalize_first_letter:
 
     links_html_or_markdown_style_capitalize_first_letter:
-        - "[Op codes](/en/developer-reference#op-codes) --- Bitcoin.org Developer Reference"
-        - "[List of op codes](https://en.bitcoin.it/wiki/Script) --- Bitcoin Wiki"
+        - "[Opcodes](/en/developer-reference#opcodes) --- Bitcoin.org Developer Reference"
+        - "[List of opcodes](https://en.bitcoin.it/wiki/Script) --- Bitcoin Wiki"
 
 ---

--- a/_data/glossary/en/p2sh-address.yaml
+++ b/_data/glossary/en/p2sh-address.yaml
@@ -26,7 +26,7 @@ optional:
     not_to_be_confused_with_capitalize_first_letter:
         - P2PK output (an output paying a public key directly)
         - P2PKH address, P2PKH output (an address comprising a hashed pubkey, and its corresponding output)
-        - P2SH multisig (a particular instance of P2SH where the script uses a multisig op code)
+        - P2SH multisig (a particular instance of P2SH where the script uses a multisig opcode)
 
     links_html_or_markdown_style_capitalize_first_letter:
         - "[P2SH](/en/developer-guide#term-p2sh) --- Bitcoin.org Developer Guide"

--- a/_data/glossary/en/p2sh-multisig.yaml
+++ b/_data/glossary/en/p2sh-multisig.yaml
@@ -8,7 +8,7 @@ required:
 
     summary_max_255_characters_no_formatting: >
         A P2SH output where the redeem script uses one of the multisig
-        op codes.  Up until Bitcoin Core 0.10.0, P2SH multisig scripts
+        opcodes.  Up until Bitcoin Core 0.10.0, P2SH multisig scripts
         were standard transactions, but most other P2SH scripts were
         not.
 

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/decodescript.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/decodescript.md
@@ -34,7 +34,7 @@ The `decodescript` RPC {{summary_decodeScript}}
 - n: "→<br>`asm`"
   t: "string"
   p: "Required<br>(exactly 1)"
-  d: "The redeem script in decoded form with non-data-pushing op codes listed.  May be empty"
+  d: "The redeem script in decoded form with non-data-pushing opcodes listed.  May be empty"
 
 - n: "→<br>`type`"
   t: "string"

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/gettxout.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/gettxout.md
@@ -75,7 +75,7 @@ The `gettxout` RPC {{summary_getTxOut}}
 - n: "→ →<br>`asm`"
   t: "string"
   p: "Required<br>(exactly 1)"
-  d: "The pubkey script in decoded form with non-data-pushing op codes listed"
+  d: "The pubkey script in decoded form with non-data-pushing opcodes listed"
 
 - n: "→ →<br>`hex`"
   t: "string (hex)"

--- a/_includes/devdoc/guide_contracts.md
+++ b/_includes/devdoc/guide_contracts.md
@@ -60,7 +60,7 @@ OP_2 [A's pubkey] [B's pubkey] [C's pubkey] OP_3 OP_CHECKMULTISIG
 
 {% autocrossref %}
 
-(Op codes to push the public keys onto the stack are not shown.)
+(Opcodes to push the public keys onto the stack are not shown.)
 
 `OP_2` and `OP_3` push the actual numbers 2 and 3 onto the
 stack. `OP_2`
@@ -100,7 +100,7 @@ OP_0 [A's signature] [B's or C's signature] [serialized redeem script]
 
 {% autocrossref %}
 
-(Op codes to push the signatures and redeem script onto the stack are
+(Opcodes to push the signatures and redeem script onto the stack are
 not shown. `OP_0` is a workaround for an off-by-one error in the original
 implementation which must be preserved for compatibility.  Note that
 the signature script must provide signatures in the same order as the

--- a/_includes/devdoc/guide_transactions.md
+++ b/_includes/devdoc/guide_transactions.md
@@ -369,7 +369,7 @@ can be used to require multiple signatures before a UTXO can be spent.
 
 In multisig pubkey scripts, called m-of-n, *m* is the *minimum* number of signatures
 which must match a public key; *n* is the *number* of public keys being
-provided. Both *m* and *n* should be op codes `OP_1` through `OP_16`,
+provided. Both *m* and *n* should be opcodes `OP_1` through `OP_16`,
 corresponding to the number desired.
 
 Because of an off-by-one error in the original Bitcoin implementation
@@ -454,7 +454,7 @@ in a P2SH output, the network sees only the hash, so it will accept the
 output as valid no matter what the redeem script says.
 This allows payment to non-standard scripts, and as of Bitcoin Core
 0.11, almost all valid redeem scripts can be spent. The exception is
-scripts that use unassigned [NOP op codes][]; these op codes are
+scripts that use unassigned [NOP opcodes][]; these opcodes are
 reserved for future soft forks and can only be relayed or mined by nodes
 that don't follow the standard mempool policy.
 
@@ -481,8 +481,8 @@ conditions:
   currently non-standard.
 
 * The transaction's signature script must only push data to the script
-  evaluation stack. It cannot push new OP codes, with the exception of
-  OP codes which solely push data to the stack.
+  evaluation stack. It cannot push new opcodes, with the exception of
+  opcodes which solely push data to the stack.
 
 * The transaction must not include any outputs which receive fewer than
   1/3 as many satoshis as it would take to spend it in a typical input.

--- a/_includes/devdoc/ref_p2p_networking.md
+++ b/_includes/devdoc/ref_p2p_networking.md
@@ -1003,12 +1003,12 @@ example, TXIDs will be in internal byte order).
   section is individually compared to the filter.
 
 * **Signature Script Data:** each element pushed onto the stack by a
-  data-pushing op code in a signature script from this transaction is
+  data-pushing opcode in a signature script from this transaction is
   individually compared to the filter.  This includes data elements
   present in P2SH redeem scripts when they are being spent.
 
 * **PubKey Script Data:** each element pushed onto the the stack by a
-  data-pushing op code in any pubkey script from this transaction is
+  data-pushing opcode in any pubkey script from this transaction is
   individually compared to the filter. (If a pubkey script element
   matches the filter, the filter will be immediately updated if the
   `BLOOM_UPDATE_ALL` flag was set; if the pubkey script is in the P2PKH

--- a/_includes/devdoc/ref_transactions.md
+++ b/_includes/devdoc/ref_transactions.md
@@ -9,14 +9,14 @@ http://opensource.org/licenses/MIT.
 
 The following subsections briefly document core transaction details.
 
-#### OP Codes
+#### OpCodes
 {% include helpers/subhead-links.md %}
 
 {% autocrossref %}
 
-The op codes used in the pubkey scripts of standard transactions are:
+The opcodes used in the pubkey scripts of standard transactions are:
 
-* Various data pushing op codes from 0x00 to 0x4e (1--78). These aren't
+* Various data pushing opcodes from 0x00 to 0x4e (1--78). These aren't
   typically shown in examples, but they must be used to push
   signatures and public keys onto the stack. See the link below this list
   for a description.
@@ -67,18 +67,18 @@ The op codes used in the pubkey scripts of standard transactions are:
 
 * [`OP_RETURN`][op_return]{:#term-op-return}{:.term} terminates the script in failure when executed.
 
-A complete list of OP codes can be found on the Bitcoin Wiki [Script
+A complete list of opcodes can be found on the Bitcoin Wiki [Script
 Page][wiki script], with an authoritative list in the `opcodetype` enum
 of the Bitcoin Core [script header file][core script.h]
 
 ![Warning icon](/img/icons/icon_warning.svg)
 **<span id="signature_script_modification_warning">Signature script modification warning</span>:**
 Signature scripts are not signed, so anyone can modify them. This
-means signature scripts should only contain data and data-pushing op
-codes which can't be modified without causing the pubkey script to fail.
-Placing non-data-pushing op codes in the signature script currently
+means signature scripts should only contain data and data-pushing opcodes
+which can't be modified without causing the pubkey script to fail.
+Placing non-data-pushing opcodes in the signature script currently
 makes a transaction non-standard, and future consensus rules may forbid
-such transactions altogether. (Non-data-pushing op codes are already
+such transactions altogether. (Non-data-pushing opcodes are already
 forbidden in signature scripts when spending a P2SH pubkey script.)
 
 ![Warning icon](/img/icons/icon_warning.svg)
@@ -341,7 +341,7 @@ has the following format.
 | 32       | hash (null)        | char[32]             | A 32-byte null, as a coinbase has no previous outpoint.
 | 4        | index (UINT32_MAX) | uint32_t             | 0xffffffff, as a coinbase has no previous outpoint.
 | *Varies* | script bytes       | compactSize uint     | The number of bytes in the coinbase script, up to a maximum of 100 bytes.
-| *Varies* (4) | height         | script               | The [block height][/en/glossary/coinbase]{:#term-coinbase-block-height}{:.term} of this block as required by BIP34.  Uses script language: starts with a data-pushing op code that indicates how many bytes to push to the stack followed by the block height as a little-endian unsigned integer.  This script must be as short as possible, otherwise it may be rejected.<br/><br/>  The data-pushing op code will be 0x03 and the total size four bytes until block 16,777,216 about 300 years from now.
+| *Varies* (4) | height         | script               | The [block height][/en/glossary/coinbase]{:#term-coinbase-block-height}{:.term} of this block as required by BIP34.  Uses script language: starts with a data-pushing opcode that indicates how many bytes to push to the stack followed by the block height as a little-endian unsigned integer.  This script must be as short as possible, otherwise it may be rejected.<br/><br/>  The data-pushing opcode will be 0x03 and the total size four bytes until block 16,777,216 about 300 years from now.
 | *Varies* | coinbase script    | *None*               | The [coinbase field][/en/glossary/coinbase]{:#term-coinbase-field}{:.term}: Arbitrary data not exceeding 100 bytes minus the (4) height bytes.  Miners commonly place an extra nonce in this field to update the block header merkle root during hashing.
 | 4        | sequence           | uint32_t             | Sequence number.
 

--- a/_includes/helpers/vars.md
+++ b/_includes/helpers/vars.md
@@ -164,7 +164,7 @@ bitcoins even if this parameter is set to `1` or higher.{% endcapture %}
 - n: "{{DEPTH}} → → → →<br>`asm`"
   t: "string"
   p: "Required<br>(exactly 1)"
-  d: "The signature script in decoded form with non-data-pushing op codes listed"
+  d: "The signature script in decoded form with non-data-pushing opcodes listed"
 
 - n: "{{DEPTH}} → → → →<br>`hex`"
   t: "string (hex)"
@@ -209,7 +209,7 @@ bitcoins even if this parameter is set to `1` or higher.{% endcapture %}
 - n: "{{DEPTH}} → → → →<br>`asm`"
   t: "string"
   p: "Required<br>(exactly 1)"
-  d: "The pubkey script in decoded form with non-data-pushing op codes listed"
+  d: "The pubkey script in decoded form with non-data-pushing opcodes listed"
 
 - n: "{{DEPTH}} → → → →<br>`hex`"
   t: "string (hex)"

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -7,7 +7,7 @@ http://opensource.org/licenses/MIT.
 [bitcoin URI]: /en/developer-guide#term-bitcoin-uri "A URI which allows receivers to encode payment details so spenders don't have to manually enter addresses and other details"
 [certificate chain]: /en/developer-examples#term-certificate-chain "A chain of certificates connecting a individual's leaf certificate to the certificate authority's root certificate"
 [coinbase block height]: /en/developer-reference#term-coinbase-block-height "The current block's height encoded into the first bytes of the coinbase field"
-[data-pushing op code]: https://en.bitcoin.it/wiki/Script#Constants "Any op code from 0x01 to 0x4e which pushes data on to the script evaluation stack"
+[data-pushing opcode]: https://en.bitcoin.it/wiki/Script#Constants "Any opcode from 0x01 to 0x4e which pushes data on to the script evaluation stack"
 [fiat]: /en/developer-guide#term-fiat "National currencies such as the dollar or euro"
 [intermediate certificate]: /en/developer-examples#term-intermediate-certificate "A intermediate certificate authority certificate which helps connect a leaf (receiver) certificate to a root certificate authority"
 [key index]: /en/developer-guide#term-key-index "An index number used in the HD wallet formula to generate child keys from a parent key"
@@ -21,8 +21,8 @@ http://opensource.org/licenses/MIT.
 [msg_block]: /en/developer-reference#term-msg_block "The block header hash data type identifier of an inventory on the P2P network"
 [msg_filtered_block]: /en/developer-reference#term-msg_block "An alternative to the block header hash data type identifier of an inventory on the P2P network used to request a merkle block"
 [network]: /en/developer-guide#term-network "The Bitcoin P2P network which broadcasts transactions and blocks"
-[op_checkmultisig]: /en/developer-reference#term-op-checkmultisig "Op code which returns true if one or more provided signatures (m) sign the correct parts of a transaction and match one or more provided public keys (n)"
-[op_checksig]: /en/developer-reference#term-op-checksig "Op code which returns true if a signature signs the correct parts of a transaction and matches a provided public key"
+[op_checkmultisig]: /en/developer-reference#term-op-checkmultisig "Opcode which returns true if one or more provided signatures (m) sign the correct parts of a transaction and match one or more provided public keys (n)"
+[op_checksig]: /en/developer-reference#term-op-checksig "Opcode which returns true if a signature signs the correct parts of a transaction and matches a provided public key"
 [op_dup]: /en/developer-reference#term-op-dup "Operation which duplicates the entry below it on the stack"
 [op_equal]: /en/developer-reference#term-op-equal "Operation which returns true if the two entries below it on the stack are equivalent"
 [op_equalverify]: /en/developer-reference#term-op-equalverify "Operation which terminates the script in failure unless the two entries below it on the stack are equivalent"
@@ -376,7 +376,7 @@ http://opensource.org/licenses/MIT.
 [mozrootstore]: https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/
 [native irc client]: https://en.wikipedia.org/wiki/List_of_IRC_clients
 [netcat]: https://en.wikipedia.org/wiki/Netcat
-[nop op codes]: https://en.bitcoin.it/wiki/Script#Reserved_words
+[nop opcodes]: https://en.bitcoin.it/wiki/Script#Reserved_words
 [offline transactions]: http://bitcoin.stackexchange.com/a/34122/21052
 [open a pull request]: https://github.com/bitcoin-dot-org/bitcoin.org#working-with-github
 [open an issue]: https://github.com/bitcoin-dot-org/bitcoin.org/issues/new

--- a/_posts/2015-03-05-quarterly-report-decjanfeb2015.md
+++ b/_posts/2015-03-05-quarterly-report-decjanfeb2015.md
@@ -412,8 +412,8 @@ following three major goals during the next quarter:
       providing definitions for the over 150 specialized terms and
       synonyms used in Bitcoin development
 
-    * Documentation for at least the most common op codes, and possibly
-      all the enabled op codes. This section will be essentially a more
+    * Documentation for at least the most common opcodes, and possibly
+      all the enabled opcodes. This section will be essentially a more
       detailed version of the [Bitcoin Wiki script
       page](https://en.bitcoin.it/wiki/Script)
 

--- a/_posts/2015-04-14-new-glossary.md
+++ b/_posts/2015-04-14-new-glossary.md
@@ -22,7 +22,7 @@ Bitcoin Foundation][], we've added two major new features to the
 A new [glossary section][] has been added to the Bitcoin.org Developer
 Documentation, and with it comes a fully-Javascript search engine that
 helps you look up glossary entries, Bitcoin Core RPCs, Bitcoin BIPs,
-Script-language op codes, and Bitcoin P2P protocol messages.
+Script-language opcodes, and Bitcoin P2P protocol messages.
 
 ## Developer glossary main page
 
@@ -69,7 +69,7 @@ they appear in the search:
 
 * Glossary entries (Bitcoin.org)
 * RPCs  (Bitcoin.org)
-* Op codes (Bitcoin Wiki)
+* Opcodes (Bitcoin Wiki)
 * BIPs (just notable and non-withdrawn BIPs; GitHub.com BIPs repo)
 * Bitcoin P2P protocol messages (Bitcoin.org)
 

--- a/en/developer-glossary.html
+++ b/en/developer-glossary.html
@@ -70,7 +70,7 @@ page](/en/vocabulary).</span>
   {% when 'b' %}
    See also: [Bitcoin Improvement Proposals (BIPs)](https://github.com/bitcoin/bips#readme)
   {% when 'o' %}
-   See also: [Op codes](https://en.bitcoin.it/wiki/Script#Words)
+   See also: [Opcodes](https://en.bitcoin.it/wiki/Script#Words)
   {% when 'p' %}
    See also: [P2P protocol messages](/en/developer-reference#data-messages)
   {% when 'r' %}


### PR DESCRIPTION
As suggested by @laanwj in #1068

I checked, and I couldn't find any images on the site that used "op code", so this is a pure text replacement (done semi-manually to ensure correctness, not with sed).