### PR TITLE
Added CCN.la to Resources.html

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -37,6 +37,7 @@ id: resources
     <p><a href="http://coinspot.ru/">CoinSpot</a></p>{% endif %}
     <p>{% translate linkcointelegraph %}<p>
     <p><a href="http://www.coindesk.com/">CoinDesk</a></p>
+    <p><a href="http://www.cryptocoinsnews.com/">CryptoCoinsNews</a></p>
     <p><a href="http://bitcoinmagazine.com/">Bitcoin Magazine</a></p>
     {% if page.lang == 'ru' %}<p><a href="http://coinfox.ru/">CoinFOX</a></p>{% endif %}
     {% if page.lang == 'en' %}<p><a href="http://coinfox.info/">CoinFOX</a></p>{% endif %}


### PR DESCRIPTION
CCN  has covered Bitcoin news since the middle of 2013. June, July, or August. Don't recall. Not long after CoinDesk got started. 
