### PR TITLE
Add Buy Bitcoin Worldwide to Directories

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -23,6 +23,7 @@ id: resources
     <p><a href="https://airbitz.co/">{% translate linkmerchants %}</a> - airbitz.co</p>
     <p><a href="http://usebitcoins.info/">{% translate linkmerchants %}</a> - usebitcoins.info</p>
     <p><a href="http://howtobuybitcoins.info/">{% translate linkexchanges %}</a> - howtobuybitcoins.info</p>
+    <p><a href="https://www.buybitcoinworldwide.com/">{% translate linkexchanges %}</a> - buybitcoinworldwide.com</p>
     <p><a href="https://en.bitcoin.it/wiki/Category:Shopping_Cart_Interfaces">{% translate linkmerchantstools %}</a> - en.bitcoin.it</p>
     <p><a href="http://givebtc.org/index.php/bitcoin-donation-directory/">{% translate linknonprofits %}</a> - givebtc.org</p>
   </div>


### PR DESCRIPTION
This adds Buy Bitcoin Worldwide to the resources page. 

This is an important tool for new users who want to buy bitcoin in their country. The country directory is here: https://www.buybitcoinworldwide.com/en/ . It is available in 13 languages. 

Another tool that helps people buy bitcoin based on location and payment method: https://www.buybitcoinworldwide.com/coinfind/
