### PR TITLE
Undo removal of end of header in #1121

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -749,6 +749,8 @@ wallets:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosureaccount"
           privacynetwork: "checkpassprivacynetworksupporttorproxy"
+---
+
 <!-- Note: this file exempt from check-for-subheading-anchors check -->
 
 <h1>{% translate pagetitle %}</h1>


### PR DESCRIPTION
#1121 removed a separator indicating the end of the header information, resulting in a [broken page](https://bitcoin.org/en/choose-your-wallet)