### PR TITLE
Alerts: drop banner for UPnP vulnerability

### DIFF
--- a/_alerts/2015-10-12-upnp-vulnerability.md
+++ b/_alerts/2015-10-12-upnp-vulnerability.md
@@ -4,9 +4,9 @@
 
 title: "Vulnerability in UPnP library used by Bitcoin Core"
 shorturl: "upnp-vulnerability"
-active: true
-banner: "WARNING: serious vulnerability in UPnP library used by Bitcoin Core (click here to read)"
-bannerclass: "alert"
+active: false
+#banner: "WARNING: serious vulnerability in UPnP library used by Bitcoin Core (click here to read)"
+#bannerclass: "alert"
 ---
 
 ## Summary


### PR DESCRIPTION
The red banner at the top of the site went up on Oct 12th.  I suggest we take it down on Sunday, Nov 1st.

The alert notice text will still be available at all the same URLs on the site as before, so anyone who is still catching up on their bitcoin-dev email from two weeks ago will still be able to read it.

CC: @laanwj 