### PR TITLE
OP_RETURN can accept 80 bytes

### DIFF
--- a/_data/glossary/en/null-data-transaction.yaml
+++ b/_data/glossary/en/null-data-transaction.yaml
@@ -7,7 +7,7 @@ required:
     title_max_40_characters_no_formatting: Null Data (OP_RETURN) Transaction
 
     summary_max_255_characters_no_formatting: >
-        A standard transaction type which allows adding 40 bytes of
+        A standard transaction type which allows adding 80 bytes of
         arbitrary data to the block chain up to once per transaction.
 
     synonyms_shown_in_glossary_capitalize_first_letter:

--- a/_includes/devdoc/guide_transactions.md
+++ b/_includes/devdoc/guide_transactions.md
@@ -434,7 +434,7 @@ to the block chain in more harmful ways.)
 {% endautocrossref %}
 
 ~~~
-Pubkey Script: OP_RETURN <0 to 40 bytes of data>
+Pubkey Script: OP_RETURN <0 to 80 bytes of data>
 (Null data scripts cannot be spent, so there's no signature script.)
 ~~~
 


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/5286 increased `MAX_OP_RETURN_RELAY` to 80 bytes.