### PR TITLE
Update _events.yml

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -62,14 +62,6 @@
   country: "Australia"
   link: "http://www.adccasummit.com/"
 
-- date: 2015-11-30
-  title: "West Coast Bitcoin Summit"
-  venue: "JW Marriott Los Angeles L.A. LIVE"
-  address: "900 West Olympic Boulevard"
-  city: "Los Angeles"
-  country: "United States"
-  link: "https://wcbs2015.com"
-
 - date: 2015-12-03
   title: "Moneylab#2 Economies of Dissent"
   venue: "Pakhuis De Zwijger"


### PR DESCRIPTION
Remove West Coast Bitcoin Summit - per their website, the event has been cancelled - https://wcbs2015.com venue indicates that the space is not booked