### PR TITLE
Added a new Bitcoin forum and eliminated two disused

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -14,8 +14,7 @@ id: community
     <h2 id="forums"><img src="/img/icons/ico_invoice.svg" class="titleicon" alt="Icon">{% translate forums %}</h2>
     {% if page.lang == 'bg' %}<p><a href="http://bitcoinbg.eu/forum/">BitcoinBG.eu</a></p>{% endif %}
     {% if page.lang == 'bg' %}<p><a href="http://hash.bg/forum/">Hash.bg</a></p>{% endif %}
-    {% if page.lang == 'es' %}<p><a href="http://forobitco.in/">ForoBitco.in en Español</a></p>{% endif %}
-    {% if page.lang == 'es' %}<p><a href="http://www.forobtc.com/">Foro Bitcoin en Español</a></p>{% endif %}
+    {% if page.lang == 'es' %}<p><a href="https://forobits.com/">Foro de Bitcoin en Español</a></p>{% endif %}
     {% if page.lang == 'pl' %}<p><a href="https://forum.bitcoin.pl/">Polski portal bitcoin.pl</a></p>{% endif %}
     {% if page.lang == 'ro' %}<p><a href="http://forum.bitcoin.ro/">Forumul comunitatii Bitcoin Romania</a></p>{% endif %}
     {% if page.lang == 'fr' %}<p><a href="http://www.cryptofr.com">Forum CryptoFR</a></p>{% endif %}


### PR DESCRIPTION
First of all, I remove in this request two forums of community, the first is forobtc.com that don't have any hosting or website running. The second one is forobitco.in only used at now for spaming cloud mining, faucet referals and tiered link building.
The second thing I did was add a new alternative forum in Spanish about bitcoin and other decentralized applications.
