### PR TITLE
Add disclaimer to bitcoin-core index page

### DIFF
--- a/en/bitcoin-core/index.md
+++ b/en/bitcoin-core/index.md
@@ -115,6 +115,6 @@ if ( $( window ).width() > 400 && $( window ).height() > 600 ) {
 
 #### Disclaimer
 
-"Bitcoin Core" is a separate project from bitcoin.org and the views expressed by this website and its owners, are not necessarily the views expressed by the Bitcoin Core project or its developers.
+"Bitcoin Core" is a separate project from bitcoin.org, and the views expressed by this website and its owners are not necessarily the views expressed by the Bitcoin Core project or its developers.
 
 {% include references.md %}

--- a/en/bitcoin-core/index.md
+++ b/en/bitcoin-core/index.md
@@ -113,4 +113,8 @@ if ( $( window ).width() > 400 && $( window ).height() > 600 ) {
 }
 </script>
 
+#### Disclaimer
+
+"Bitcoin Core" is a separate project from bitcoin.org and the views expressed by this website and its owners, are not necessarily the views expressed by the Bitcoin Core project or its developers.
+
 {% include references.md %}


### PR DESCRIPTION
There is some confusion in the community that Bitcoin Core and bitcoin.org are the same project
and thus share the same policy and views. This disclaimer is to make it clear that Bitcoin Core is
a separate project and just occupy /bitcoin-core on the website for the main purpose of hosting
downloads.