### PR TITLE
Core: mention separation of concerns from Bitcoin.org

### DIFF
--- a/_includes/layout/base-core/footer-license.html
+++ b/_includes/layout/base-core/footer-license.html
@@ -1,0 +1,10 @@
+{% comment %}
+This file is licensed under the MIT License (MIT) available on
+http://opensource.org/licenses/MIT.
+{% endcomment %}
+
+<div class="footerlicense">© Bitcoin Project 2009-{{ site.time | date: '%Y' }} {% translate footer layout %}<br>
+Bitcoin Core pages on Bitcoin.org are <a
+href="/en/bitcoin-core/about-site">maintained separately</a> from the
+rest of the site.
+</div>

--- a/_includes/layout/base-core/footer-menu.html
+++ b/_includes/layout/base-core/footer-menu.html
@@ -1,0 +1,16 @@
+{% comment %}
+This file is licensed under the MIT License (MIT) available on
+http://opensource.org/licenses/MIT.
+{% endcomment %}
+
+<div class="footermenu">
+  <a href="/en/alerts" class="statusmenu{% if site.STATUS == 1 %} alert{% endif %}">Network Status</a>
+  <a href="/{{ page.lang }}/{% translate legal url %}">{% translate menu-legal layout %}</a>
+  {% case page.lang %}
+  {% when 'id' or 'da' or 'de' or 'es' or 'fr' or 'it' or 'hu' or 'nl' or 'pl' or 'pt_BR' or 'ro' or 'sl' or 'sv' or 'tr' or 'el' or 'bg' or 'ru' or 'uk' or 'ar' or 'fa' or 'hi' or 'ko' or 'ja' or 'zh_CN' or 'zh_TW' %}
+  <a href="/en/privacy">Privacy Policy</a>
+  {% else %}
+  <a href="/{{ page.lang }}/{% translate privacy url %}">{% translate menu-privacy layout %}</a>
+  {% endcase %}
+  <a href="/en/bitcoin-core/about-site">About</a>
+</div>

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -307,6 +307,7 @@ http://opensource.org/licenses/MIT.
 [bcc pulls]: https://github.com/bitcoin/bitcoin/pulls
 [bcc tor]: https://en.bitcoin.it/wiki/Tor
 [bcc tor hs]: https://en.bitcoin.it/wiki/Tor#Hidden_services
+[core github tag]: https://github.com/bitcoin-dot-org/bitcoin.org/labels/Core
 [BFGMiner]: https://github.com/luke-jr/bfgminer
 [Bitcoin beginners]: http://www.reddit.com/r/bitcoinbeginners
 [Bitcoin Core]: https://bitcoin.org/en/download
@@ -388,6 +389,7 @@ http://opensource.org/licenses/MIT.
 [protobuf]: https://developers.google.com/protocol-buffers/
 [python-bitcoinlib]: https://github.com/petertodd/python-bitcoinlib
 [python-blkmaker]: https://gitorious.org/bitcoin/python-blkmaker
+[Satoshi Nakamoto]: https://en.bitcoin.it/wiki/Satoshi_Nakamoto
 [setup tor]: https://www.torproject.org/
 [SHA256]: https://en.wikipedia.org/wiki/SHA-2
 [Stratum mining protocol]: http://mining.bitcoin.cz/stratum-mining

--- a/_layouts/base-core.html
+++ b/_layouts/base-core.html
@@ -40,9 +40,8 @@ use the base template -->
   {% endif %}
   {% include layout/base-core/content.html %}
   <div class="footer">
-    {% include layout/base/footer-menu.html %}
-    {% include layout/base/footer-sponsor.html %}
-    {% include layout/base/footer-license.html %}
+    {% include layout/base-core/footer-menu.html %}
+    {% include layout/base-core/footer-license.html %}
   </div>
 </div>
 

--- a/en/bitcoin-core/about-site.md
+++ b/en/bitcoin-core/about-site.md
@@ -1,0 +1,51 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+layout: base-core
+lang: en
+id: bitcoin-core-about-site
+columns: 1
+title: About Site - Bitcoin Core
+breadcrumbs:
+  - bitcoin
+  - bcc
+  - About site
+---
+# About the Bitcoin Core pages on Bitcoin.org
+
+Bitcoin.org hosts several pages about Bitcoin Core as well as the
+[Bitcoin Core downloads][bcc download], but the Bitcoin.org and Bitcoin
+Core open source projects are run by separate teams.
+
+## History
+
+Bitcoin.org was originally used by [Satoshi Nakamoto][] to host his
+[Bitcoin paper][bitcoinpdf]. Soon after, it began linking to
+downloadable versions of the original Bitcoin software, making it the
+homepage for the Bitcoin program.
+
+New educational content about Bitcoin was added to Bitcoin.org over
+time, but that home page remained even when the name of the original
+program was changed to Bitcoin Core.
+
+In the years since, the amount of content on Bitcoin.org has continued
+to increase.  There's more content about Bitcoin Core than ever before
+and also more content about other Bitcoin software and resources.
+
+## Separation of concerns
+
+As of Dec 2015, Bitcoin.org has 876 pages in 25 different languages,
+but fewer than 100 of those pages belong to Bitcoin Core. The Bitcoin
+Core project has no control over those non-Core pages or any polices
+enacted on them.
+
+Likewise, content provided through the Bitcoin Core pages is not
+necessarily endorsed or supported by the Bitcoin.org contributors.
+
+## Maintenance
+
+Pull requests and issues directly relating to Bitcoin Core are tagged as
+*[Core][core github tag]* in the Bitcoin.org repository.
+
+{% include references.md %}


### PR DESCRIPTION
This commit makes two changes.  First it modifies the footer on the Bitcoin Core pages:

![2015-12-29-012709_611x97_scrot](https://cloud.githubusercontent.com/assets/61096/12030382/e3a69a7a-adcb-11e5-972a-83c49aa13e5e.png)

This drops the [Press](https://bitcoin.org/en/press) page and the [Blog](https://bitcoin.org/en/blog) page and changes the About link to the page described below.  Beneath the copyright statement, a short message tells readers that the Bitcoin Core pages are not a normal part of the site; the link here also points to the page described below.

The second change is a new page that describes the relationship between Bitcoin Core and Bitcoin.org in detail:

![2015-12-29-012731_655x900_scrot](https://cloud.githubusercontent.com/assets/61096/12030414/731d9ba4-adcc-11e5-870c-761deca1d907.png)

All the text in both changes is just draft text, so please feel free to make suggestions.  In addition, I'm open to combing this with #1186 if a more visible disclaimer is desired for the main page.  What I tried to aim for with this PR is a short and unobtrusive disclaimer on every Bitcoin Core page as well as a separate page where we could go into depth about the separation between the two projects.

Related to this PR, I also created a new tag for the site for Bitcoin Core issues to help people (like me) who want to focus on them: https://github.com/bitcoin-dot-org/bitcoin.org/labels/Core