### PR TITLE
Dev Docs: clarify null data conditions

### DIFF
--- a/_data/glossary/en/null-data-transaction.yaml
+++ b/_data/glossary/en/null-data-transaction.yaml
@@ -7,8 +7,10 @@ required:
     title_max_40_characters_no_formatting: Null Data (OP_RETURN) Transaction
 
     summary_max_255_characters_no_formatting: >
-        A standard transaction type which allows adding 80 bytes of
-        arbitrary data to the block chain up to once per transaction.
+        A transaction type relayed and mined by default in Bitcoin Core
+        0.9.0 and later that adds arbitrary data to a provably
+        unspendable pubkey script that full nodes don't have to store in
+        their UTXO database.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - Null data transaction

--- a/_data/glossary/en/null-data-transaction.yaml
+++ b/_data/glossary/en/null-data-transaction.yaml
@@ -7,7 +7,7 @@ required:
     title_max_40_characters_no_formatting: Null Data (OP_RETURN) Transaction
 
     summary_max_255_characters_no_formatting: >
-        A standard transaction type which allows adding 40 bytes of
+        A standard transaction type which allows adding 80 bytes of
         arbitrary data to the block chain up to once per transaction.
 
     synonyms_shown_in_glossary_capitalize_first_letter:

--- a/_includes/devdoc/guide_transactions.md
+++ b/_includes/devdoc/guide_transactions.md
@@ -434,7 +434,7 @@ to the block chain in more harmful ways.)
 {% endautocrossref %}
 
 ~~~
-Pubkey Script: OP_RETURN <0 to 40 bytes of data>
+Pubkey Script: OP_RETURN <0 to 80 bytes of data>
 (Null data scripts cannot be spent, so there's no signature script.)
 ~~~
 

--- a/_includes/devdoc/guide_transactions.md
+++ b/_includes/devdoc/guide_transactions.md
@@ -426,17 +426,42 @@ Signature script: <sig>
 
 {% autocrossref %}
 
-[Null data][/en/glossary/null-data-transaction]{:#term-null-data}{:.term} pubkey scripts let you add a small amount of arbitrary data to the block
-chain in exchange for paying a transaction fee, but doing so is discouraged.
-(Null data is a standard pubkey script type only because some people were adding data
-to the block chain in more harmful ways.)
+[Null data][/en/glossary/null-data-transaction]{:#term-null-data}{:.term}
+transaction type relayed and mined by default in Bitcoin Core 0.9.0 and
+later that adds arbitrary data to a provably unspendable pubkey script
+that full nodes don't have to store in their UTXO database. It is
+preferable to use null data transactions over transactions that bloat
+the UTXO database because they cannot be automatically pruned; however,
+it is usually even more preferable to store data outside transactions
+if possible.
+
+Consensus rules allow null data outputs up to the maximum allowed pubkey
+script size of 10,000 bytes provided they follow all other consensus
+rules, such as not having any data pushes larger than 520 bytes.
+
+Bitcoin Core 0.9.x to 0.10.x will, by default, relay and mine null data
+transactions with up to 40 bytes in a single data push and only one null
+data output that pays exactly 0 satoshis:
 
 {% endautocrossref %}
 
 ~~~
-Pubkey Script: OP_RETURN <0 to 80 bytes of data>
+Pubkey Script: OP_RETURN <0 to 40 bytes of data>
 (Null data scripts cannot be spent, so there's no signature script.)
 ~~~
+
+Bitcoin Core 0.11.x increases this default to 80 bytes, with the other
+rules remaining the same.
+
+It is expected that Bitcoin Core 0.12.0 (not released yet) will default
+to relaying and mining null data outputs with up to 83 bytes with any
+number of data pushes, provided the total byte limit is not exceeded.
+There must still only be a single null data output and it must still pay
+exactly 0 satoshis.
+
+The `-datacarriersize` Bitcoin Core configuration option allows you to
+set the maximum number of bytes in null data outputs that you will relay
+or mine.
 
 #### Non-Standard Transactions
 {% include helpers/subhead-links.md %}


### PR DESCRIPTION
PR #1129 pointed out that the null data transaction details were out of date.  Other comments on that PR asked that the tx type be better explained.  I submitted a PR to the repository of that PR which provided what I think was a better explanation, but I haven't heard from that author in two months, so I'm submitting it separately here.