### PR TITLE
Capacity Increases FAQ: more prominently link to roadmap

### DIFF
--- a/en/bitcoin-core/capacity-increases-faq.md
+++ b/en/bitcoin-core/capacity-increases-faq.md
@@ -19,6 +19,14 @@ Other versions: [Italiano](/it/bitcoin-core/capacity-increases-faq) \| [简体�
 1. toc
 {:toc}
 
+## What is the roadmap? {#roadmap}
+
+**[Capacity increases for the Bitcoin system][roadmap]**, written by Gregory
+Maxwell and published 7 Dec 2015 to the bitcoin-dev mailing list. A
+[statement][] supporting the roadmap has been signed by developers who
+([according to GitHub][commit stats]) generated more than [90% of all
+commits][commit spreadsheet] to Bitcoin Core in 2015.
+
 ## What specific technologies are included in the roadmap, and when can we expect them?  {#roadmap-dates}
 
 New technology will be deployed when it is ready and has been tested.
@@ -359,6 +367,8 @@ To get specific suggestions on how you can help, please join the
 [bitcoin core contributor]: /en/bitcoin-core/
 [Bitcoin relay network]: http://bitcoinrelaynetwork.org/
 [code review]: https://bitcoin.org/en/development#code-review
+[commit spreadsheet]: https://docs.google.com/spreadsheets/d/15jtxuA3dVY5NUuYezZ4d_69ASUMYjqFOMxsF9ZX-BKA/edit?usp=sharing
+[commit stats]: https://github.com/bitcoin/bitcoin/graphs/contributors?from=2015-01-01&to=2015-12-31&type=c
 [estimated savings]: https://www.reddit.com/r/bitcoinxt/comments/3w1i6b/i_attended_scaling_bitcoin_hong_kong_these_are_my/cxtkaih
 [increase in total bandwidth]: https://scalingbitcoin.org/hongkong2015/presentations/DAY1/3_block_propagation_1_rosenbaum.pdf
 [libsecp256k1]: https://github.com/bitcoin/secp256k1
@@ -367,5 +377,6 @@ To get specific suggestions on how you can help, please join the
 [miners' panel]: https://youtu.be/H-ErmmDQRFs?t=1086
 [payment channel efficiency]: https://scalingbitcoin.org/hongkong2015/presentations/DAY2/1_layer2_2_dryja.pdf
 [previous soft forks]: https://github.com/bitcoin/bips/blob/master/bip-0123.mediawiki#classification-of-existing-bips
+[statement]: /en/bitcoin-core/capacity-increases
 [weak blocks and iblts]: https://www.youtube.com/watch?v=ivgxcEOyWNs&t=1h40m20s
 [q simple raise]: #size-bump


### PR DESCRIPTION
I'm told some people were confusing the FAQ itself for the roadmap; this should help remove the confusion.  This becomes the first question/answer in the document:

![2016-01-10-104013_634x193_scrot](https://cloud.githubusercontent.com/assets/61096/12222316/bea71406-b786-11e5-8a25-8ef573aa87f7.png)

