### PR TITLE
Bitcoin Core: add banner redirecting some pages to BitcoinCore.org

### DIFF
--- a/_includes/layout/base-core/pagetop-moved-notice.html
+++ b/_includes/layout/base-core/pagetop-moved-notice.html
@@ -1,0 +1,10 @@
+{% comment %}
+This file is licensed under the MIT License (MIT) available on
+http://opensource.org/licenses/MIT.
+{% endcomment %}
+
+{% if page.moved_url %}
+<div class="banner-message success">
+  <a href="{{page.moved_url}}"><span>{% translate banner-core-moved layout %}</span></a>
+</div>
+{% endif %}

--- a/_includes/layout/base-core/pagetop-moved-notice.html
+++ b/_includes/layout/base-core/pagetop-moved-notice.html
@@ -4,7 +4,7 @@ http://opensource.org/licenses/MIT.
 {% endcomment %}
 
 {% if page.moved_url %}
-<div class="banner-message success">
+<div class="banner-message minor">
   <a href="{{page.moved_url}}"><span>{% translate banner-core-moved layout %}</span></a>
 </div>
 {% endif %}

--- a/_layouts/base-core.html
+++ b/_layouts/base-core.html
@@ -19,6 +19,7 @@ use the base template -->
 <body>
 {% include layout/base/pagetop-detect-mobile.html %}
 {% include layout/base/pagetop-alert.html %}
+{% include layout/base-core/pagetop-moved-notice.html %}
 
 <div class="head"><div>
   {% include layout/base/head-language-dropdown.html %}

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -172,6 +172,10 @@ table td,table th{
 .banner-message.info a{
 	background-color:#0d579b;
 }
+.banner-message.minor a{
+	background-color: yellow;
+        color: black;
+}
 .banner-message a span{
 	display:block;
 	margin:auto;

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -845,6 +845,10 @@ en:
     menu-support-bitcoin: "Support Bitcoin"
     menu-vocabulary: Vocabulary
     menu-you-need-to-know: "You need to know"
+    banner-core-moved: |
+      This page has moved to the new Bitcoin Core
+      website (click here to be redirected)
+
     banner-translate: "Translations for this language are outdated. <a href=\"https://github.com/bitcoin-dot-org/bitcoin.org#translation\">Click here to help translate bitcoin.org in your language</a>."
     footer: "Released under the <a href=\"http://opensource.org/licenses/mit-license.php\" target=\"_blank\">MIT license</a>"
     sponsor: "A community website sponsored by"

--- a/de/bitcoin-core/2016-01-07-statement.md
+++ b/de/bitcoin-core/2016-01-07-statement.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - 2016-01-07 Statement
+
+moved_url: https://bitcoincore.org/de/2016/01/07/stellungnahme-der-bitcoin-core-entwickler/
 ---
 # Stellungnahme der Bitcoin Core Entwickler 2016-01-07
 

--- a/en/bitcoin-core/2016-01-07-statement.md
+++ b/en/bitcoin-core/2016-01-07-statement.md
@@ -11,6 +11,7 @@ breadcrumbs:
   - bitcoin
   - bcc
   - 2016-01-07 Statement
+moved_url: https://bitcoincore.org/en/2016/01/07/statement
 ---
 # Statement from Bitcoin Core 2016-01-07
 

--- a/en/bitcoin-core/capacity-increases-faq.md
+++ b/en/bitcoin-core/capacity-increases-faq.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - Capacity increases FAQ
+
+moved_url: https://bitcoincore.org/en/2015/12/23/capacity-increases-faq/
 ---
 # Capacity increases FAQ
 

--- a/en/bitcoin-core/capacity-increases.md
+++ b/en/bitcoin-core/capacity-increases.md
@@ -11,6 +11,7 @@ breadcrumbs:
   - bitcoin
   - bcc
   - Capacity increases
+moved_url: https://bitcoincore.org/en/2015/12/21/capacity-increase
 ---
 # Capacity increases for the Bitcoin system
 

--- a/en/bitcoin-core/index.md
+++ b/en/bitcoin-core/index.md
@@ -92,6 +92,7 @@ breadcrumbs:
 {% endcapture %}
 {% assign array_releases = text_releases | strip_newlines | split: '::' %}
 
+  - 2016-01-09 - [New Bitcoin Core website](https://bitcoincore.org)
   - 2016-01-07 - [Project Statement](/en/bitcoin-core/2016-01-07-statement)
   - 2015-12-21 - Capacity increases for the Bitcoin system: [Statement](/en/bitcoin-core/capacity-increases) & [FAQ](/en/bitcoin-core/capacity-increases-faq)
 {% comment %}<!-- show the latest three releases -->{% endcomment %}

--- a/es/bitcoin-core/2016-01-07-statement.md
+++ b/es/bitcoin-core/2016-01-07-statement.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - 2016-01-07 Statement
+
+moved_url: "https://bitcoincore.org/es/2016/01/07/declaraci%C3%B3n/"
 ---
 # Declaración de Bitcoin Core
 

--- a/it/bitcoin-core/capacity-increases-faq.md
+++ b/it/bitcoin-core/capacity-increases-faq.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - Capacity increases FAQ
+
+moved_url: https://bitcoincore.org/it/2015/12/23/capacity-increases-faq/
 ---
 # Domande frequenti sugli aumenti di capacità
 

--- a/it/bitcoin-core/capacity-increases.md
+++ b/it/bitcoin-core/capacity-increases.md
@@ -11,6 +11,7 @@ breadcrumbs:
   - bitcoin
   - bcc
   - Capacity increases
+moved_url: https://bitcoincore.org/it/2015/12/21/capacity-increase/
 ---
 # Aumenti di capacità per il sistema Bitcoin
 

--- a/ru/bitcoin-core/2016-01-07-statement.md
+++ b/ru/bitcoin-core/2016-01-07-statement.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - 2016-01-07 Statement
+
+moved_url: "https://bitcoincore.org/ru/2016/01/07/c%D0%BE%D0%BE%D0%B1%D1%89%D0%B5%D0%BD%D0%B8%D0%B5-%D0%BE%D1%82-bitcoin-core/"
 ---
 # Сообщение от Bitcoin Core 2016-01-07
 

--- a/zh_CN/bitcoin-core/2016-01-07-statement.md
+++ b/zh_CN/bitcoin-core/2016-01-07-statement.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - 2016-01-07 Statement
+
+moved_url: "https://bitcoincore.org/zh_CN/2016/01/07/bitcoin-core-%E5%A3%B0%E6%98%8E/"
 ---
 # Bitcoin Core 声明 -- 2016-01-07
 

--- a/zh_CN/bitcoin-core/capacity-increases-faq.md
+++ b/zh_CN/bitcoin-core/capacity-increases-faq.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - Capacity increases FAQ
+
+moved_url: "https://bitcoincore.org/zh_CN/2015/12/21/%E7%B3%BB%E7%BB%9F%E6%89%A9%E5%B1%95%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E8%A7%A3%E7%AD%94/"
 ---
 # 系统扩展常见问题解答
 

--- a/zh_CN/bitcoin-core/capacity-increases.md
+++ b/zh_CN/bitcoin-core/capacity-increases.md
@@ -11,6 +11,7 @@ breadcrumbs:
   - bitcoin
   - bcc
   - Capacity increases
+moved_url: "https://bitcoincore.org/zh_CN/2015/12/21/%E6%AF%94%E7%89%B9%E5%B8%81%E7%B3%BB%E7%BB%9F%E6%89%A9%E5%B1%95/"
 ---
 # 比特币系统扩展
 

--- a/zh_TW/bitcoin-core/2016-01-07-statement.md
+++ b/zh_TW/bitcoin-core/2016-01-07-statement.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - 2016-01-07 Statement
+
+moved_url: "https://bitcoincore.org/zh_TW/2016/01/07/bitcoin-core-%E8%81%B2%E6%98%8E/"
 ---
 # Bitcoin Core 聲明 -- 2016-01-07
 

--- a/zh_TW/bitcoin-core/capacity-increases-faq.md
+++ b/zh_TW/bitcoin-core/capacity-increases-faq.md
@@ -11,6 +11,8 @@ breadcrumbs:
   - bitcoin
   - bcc
   - Capacity increases FAQ
+
+moved_url: "https://bitcoincore.org/zh_TW/2015/12/21/%E7%B3%BB%E7%B5%B1%E6%93%B4%E5%B1%95%E5%B8%B8%E8%A6%8B%E5%95%8F%E9%A1%8C%E8%A7%A3%E7%AD%94/"
 ---
 # 系統擴展常見問題解答
 

--- a/zh_TW/bitcoin-core/capacity-increases.md
+++ b/zh_TW/bitcoin-core/capacity-increases.md
@@ -11,6 +11,7 @@ breadcrumbs:
   - bitcoin
   - bcc
   - Capacity increases
+moved_url: "https://bitcoincore.org/zh_TW/2015/12/21/%E6%AF%94%E7%89%B9%E5%B9%A3%E7%B3%BB%E7%B5%B1%E6%93%B4%E5%B1%95/"
 ---
 # 比特幣系統擴展
 


### PR DESCRIPTION
This is an alternative to #1205 that adds banners to pages that are now mirrored on BitcoinCore.org.  The banners look like this and redirect to the specific page:

![2016-01-16-193839_1220x418_scrot](https://cloud.githubusercontent.com/assets/61096/12375287/fe11cd28-bc88-11e5-9b22-ebaf2951770c.png)

In addition, a link is added to the News on the main Bitcoin.org Bitcoin Core page pointing to the new website:

![2016-01-16-194303_584x146_scrot](https://cloud.githubusercontent.com/assets/61096/12375293/6a929996-bc89-11e5-9a35-40b250ea57d3.png)

Full preview: http://dg2.dtrt.org/en/bitcoin-core/