### PR TITLE
Remove givebtc.org from resources

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -24,7 +24,6 @@ id: resources
     <p><a href="http://usebitcoins.info/">{% translate linkmerchants %}</a> - usebitcoins.info</p>
     <p><a href="http://howtobuybitcoins.info/">{% translate linkexchanges %}</a> - howtobuybitcoins.info</p>
     <p><a href="https://en.bitcoin.it/wiki/Category:Shopping_Cart_Interfaces">{% translate linkmerchantstools %}</a> - en.bitcoin.it</p>
-    <p><a href="http://givebtc.org/index.php/bitcoin-donation-directory/">{% translate linknonprofits %}</a> - givebtc.org</p>
   </div>
 </div>
 <div>
@@ -60,7 +59,6 @@ id: resources
     <p><a href="http://letstalkbitcoin.com/">Let's Talk Bitcoin</a></p>
     <p><a href="http://www.bitcoin.kn/">Bitcoin Knowledge Podcast</a></p>
     <p><a href="https://www.khanacademy.org/economics-finance-domain/core-finance/money-and-banking/bitcoin/v/bitcoin-what-is-it">Khan Academy</a></p>
-    <p><a href="http://www.givebtc.org/GiveBTC_-_Handbook_for_Non_Profits.pdf">The Bitcoin Handbook for Non-Profits</a></p>
   </div>
 </div>
 </div>


### PR DESCRIPTION
On the resources page (https://bitcoin.org/en/resources) directories section the link for givebtc.org redirects to http://bitcoinembassy.ca