### PR TITLE
Remove btcmexico.org from community page

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -151,12 +151,6 @@ id: community
     </p>
   </div>
   <div>
-    <h3 id="mexico"><img src="/img/flags/MX.png" alt="Mexican flag">Mexico</h3>
-    <p>
-      <a href="http://www.btcmexico.org/">Fundación Satoshi Nakamoto</a>
-    </p>
-  </div>
-  <div>
     <h3 id="netherlands"><img src="/img/flags/NL.png" alt="Dutch flag">Netherlands</h3>
     <p>
       <a href="http://stichtingbitcoin.nl/">Stichting Bitcoin Nederland</a><br>


### PR DESCRIPTION
On the community page (https://bitcoin.org/en/community#mexico), the
‘Fundación Satoshi Nakamoto’  website does not load and should be
removed.