### PR TITLE
Update to Glossary Definition: Double Spend

### DIFF
--- a/_data/glossary/en/double-spend.yaml
+++ b/_data/glossary/en/double-spend.yaml
@@ -7,8 +7,10 @@ required:
     title_max_40_characters_no_formatting: Double Spend
 
     summary_max_255_characters_no_formatting: >
-        A transaction that spends the same input as spent in another
-        transaction.
+        A transaction that uses the same input as an already broadcast
+        transaction. An attempt of duplication, deceit, or conversion, 
+        will be adjudicated when only one of the transactions is recorded
+        in the block-chain.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - Double spend

--- a/_data/glossary/en/double-spend.yaml
+++ b/_data/glossary/en/double-spend.yaml
@@ -10,7 +10,7 @@ required:
         A transaction that uses the same input as an already broadcast
         transaction. An attempt of duplication, deceit, or conversion, 
         will be adjudicated when only one of the transactions is recorded
-        in the block-chain.
+        in the blockchain.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - Double spend

--- a/_data/glossary/en/double-spend.yaml
+++ b/_data/glossary/en/double-spend.yaml
@@ -8,7 +8,7 @@ required:
 
     summary_max_255_characters_no_formatting: >
         A transaction that uses the same input as an already broadcast
-        transaction. An attempt of duplication, deceit, or conversion, 
+        transaction. The attempt of duplication, deceit, or conversion, 
         will be adjudicated when only one of the transactions is recorded
         in the blockchain.
 
@@ -22,7 +22,7 @@ optional:
         - double-spend
         - double-spends
         - double-spent
-        - dobule spending
+        - double spending
         - double-spending
 
     not_to_be_confused_with_capitalize_first_letter:


### PR DESCRIPTION
Please see the following issue for context: #1248 
TLDR: I believe the definition for "double-spend" should not contain the words "spend" or "spent" 
and should be more specific and clear to differentiate from the pre-Bitcoin definition of double-spend.

I am not proficient in Github or programming in general, so hopefully this pull request is 
appropriate and done correctly. If this is successful, I will also attempt to create a new glossary term
for "spend/spent" and others that may be helpful.
