### PR TITLE
Fix incorrect link to segwit bip

### DIFF
--- a/en/bitcoin-core/capacity-increases-faq.md
+++ b/en/bitcoin-core/capacity-increases-faq.md
@@ -355,7 +355,7 @@ To get specific suggestions on how you can help, please join the
 
 [#bitcoin-dev]: https://webchat.freenode.net/?channels=bitcoin-dev&amp;uio=d4
 [actively studied]: http://diyhpl.us/wiki/transcripts/scalingbitcoin/bitcoin-block-propagation-iblt-rusty-russell/
-[bip-segwit]: https://github.com/jl2012/bips/blob/segwit/bip-segwit.mediawiki
+[bip-segwit]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
 [BIP9]: https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
 [BIP16]: https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki
 [BIP30]: https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki

--- a/it/bitcoin-core/capacity-increases-faq.md
+++ b/it/bitcoin-core/capacity-increases-faq.md
@@ -365,7 +365,7 @@ al canale IRC [#bitcoin-dev][].
 
 [#bitcoin-dev]: https://webchat.freenode.net/?channels=bitcoin-dev&amp;uio=d4
 [actively studied]: http://diyhpl.us/wiki/transcripts/scalingbitcoin/bitcoin-block-propagation-iblt-rusty-russell/
-[bip-segwit]: https://github.com/jl2012/bips/blob/segwit/bip-segwit.mediawiki
+[bip-segwit]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
 [BIP9]: https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
 [BIP16]: https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki
 [BIP30]: https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki


### PR DESCRIPTION
Link to bip is dead, Core version updated the link in https://github.com/bitcoin-core/bitcoincore.org/commit/7bd3ad9484802dd9a623e5586f8a2da3f92a2cd6 but this page still has the dead link.