### PR TITLE
Remove fake event.

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -54,14 +54,6 @@
   country: "The Netherlands"
   link: "http://www.bitcoinference.com/Bitcoin4Beginners/Amsterdam/Beurs-van-Berlage/2016/March/16/Wednesday.html"
   
-- date: 2016-03-23
-  title: "The London Bitcoin Forum"
-  venue: "QEII Centre"
-  address: "Fleming & Whittle Broad Sanctuary"
-  city: "London"
-  country: "United Kingdom"
-  link: "https://londonbitcoinforum.co.uk"
-
 - date: 2016-04-04
   title: "Money 20/20 Europe"
   venue: "Bella Center"


### PR DESCRIPTION
See:

  https://twitter.com/coindesk/status/707248723458400256
  http://www.bitcoinerrorlog.com/2016/03/08/coindesk-promotes-london-bitcoin-forum-scam-sweeps-under-rug/
  https://www.reddit.com/r/Bitcoin/comments/49iqp5/coindesk_promotes_london_bitcoin_forum_scam/