### PR TITLE
remove Coinfox from resources.html

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -38,6 +38,7 @@ id: resources
     <p><a href="http://www.coindesk.com/">CoinDesk</a></p>
     <p><a href="http://bitcoinmagazine.com/">Bitcoin Magazine</a></p>
     <p><a href="http://coinjournal.net/">CoinJournal</a></p>
+    {% if page.lang == 'ru' %}<p><a href="https://bitcointalk.org/index.php?board=128.0">Биткойн Форум / Новости</a></p>{% else %}<p><a href="https://bitcointalk.org/index.php?board=77.0">BitcoinTalk press links</a></p>{% endif %}
   </div><div>
     <h2 id="charts"><img src="/img/icons/ico_market.svg" class="titleicon" alt="Icon">{% translate charts %}</h2>
     <p><a href="http://blockchain.info/charts">Blockchain.info</a></p>

--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -38,10 +38,6 @@ id: resources
     <p><a href="http://www.coindesk.com/">CoinDesk</a></p>
     <p><a href="http://bitcoinmagazine.com/">Bitcoin Magazine</a></p>
     <p><a href="http://coinjournal.net/">CoinJournal</a></p>
-    {% if page.lang == 'ru' %}<p><a href="http://coinfox.ru/">CoinFOX</a></p>{% endif %}
-    {% if page.lang == 'en' %}<p><a href="http://coinfox.info/">CoinFOX</a></p>{% endif %}
-    {% if page.lang == 'es' %}<p><a href="http://coinfox.es/">CoinFOX</a></p>{% endif %}
-    {% if page.lang == 'ru' %}<p><a href="https://bitcointalk.org/index.php?board=128.0">Биткойн Форум / Новости</a></p>{% else %}<p><a href="https://bitcointalk.org/index.php?board=77.0">BitcoinTalk press links</a></p>{% endif %}
   </div><div>
     <h2 id="charts"><img src="/img/icons/ico_market.svg" class="titleicon" alt="Icon">{% translate charts %}</h2>
     <p><a href="http://blockchain.info/charts">Blockchain.info</a></p>


### PR DESCRIPTION
Coinfox doesn't really offer any added value. It's just blogspam with rewrites of articles by myself and others. Recent example: http://www.coinfox.info/news/5057-cory-fields-health-bitcoin is a rewrite of http://coinjournal.net/mits-cory-fields-contentiousness-in-bitcoin-is-sign-of-good-health/ where the featured image is copied.
The business model of coinfox seems to be taking the top posts from the previous day on /r/bitcoin, rewriting them, and reposting them the next day.