### PR TITLE
add HSTS preload requirement for wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ Basic requirements:
 - No concerning bug is found when testing the wallet
 - Website supports HTTPS and 301 redirects HTTP requests
 - SSL certificate passes [Qualys SSL Labs SSL test](https://www.ssllabs.com/ssltest/)
-- Website serving executable code or requiring authentication uses HSTS with a max-age of at least 180 days and is included in the [HSTS preload list](https://hstspreload.appspot.com/)
+- Website serving executable code or requiring authentication uses HSTS with a max-age of at least 180 days
 - The identity of CEOs and/or developers is public
 - Avoid address reuse by using a new change address for each transaction
 - If private keys or encryption keys are stored online:
@@ -751,6 +751,7 @@ Optional criteria (some could become requirements):
 - Does not show "received from" Bitcoin addresses in the UI
 - Uses deterministic ECDSA nonces (RFC 6979)
 - Provides a bug reporting policy on the website
+- Website serving executable code or requiring authentication is included in the [HSTS preload list](https://hstspreload.appspot.com/)
 - If user has no access over its private keys:
   - Full reserve audit(s)
   - Insurance(s) against failures on their side

--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ Basic requirements:
 - No concerning bug is found when testing the wallet
 - Website supports HTTPS and 301 redirects HTTP requests
 - SSL certificate passes [Qualys SSL Labs SSL test](https://www.ssllabs.com/ssltest/)
-- Website serving executable code or requiring authentication uses HSTS with a max-age of at least 180 days
+- Website serving executable code or requiring authentication uses HSTS with a max-age of at least 180 days and is included in the [HSTS preload list](https://hstspreload.appspot.com/)
 - The identity of CEOs and/or developers is public
 - Avoid address reuse by using a new change address for each transaction
 - If private keys or encryption keys are stored online:


### PR DESCRIPTION
Requiring HSTS preloading reduces the risk of MITM attacks for users who have not previously visited a particular site before and is especially useful for preventing downgrade attacks on TOR users or users who use browsers without persistent storage. bitcoin.org itself currently doesn't use HSTS preloading and it would be a good idea to enable it there as well.
