### PR TITLE
Clarify that Pubkey Scripts are called scriptPubKe

### DIFF
--- a/_data/glossary/en/pubkey-script.yaml
+++ b/_data/glossary/en/pubkey-script.yaml
@@ -10,7 +10,7 @@ required:
         A script included in outputs which sets the conditions that must
         be fulfilled for those satoshis to be spent.  Data for
         fulfilling the conditions can be provided in a signature script.
-        Called a scriptPubKey in code.
+        Pubkey Scripts are called a `scriptPubKey` in code.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - Pubkey script

--- a/_data/glossary/en/pubkey-script.yaml
+++ b/_data/glossary/en/pubkey-script.yaml
@@ -10,7 +10,7 @@ required:
         A script included in outputs which sets the conditions that must
         be fulfilled for those satoshis to be spent.  Data for
         fulfilling the conditions can be provided in a signature script.
-        Pubkey Scripts are called a `scriptPubKey` in code.
+        Pubkey Scripts are called a scriptPubKey in code.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - Pubkey script


### PR DESCRIPTION
Readers could get the impression that the script for fulfilling the conditions is called scriptPubKey in code (which is not true).