### PR TITLE
resources: Remove Bitcoin Foundation

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -12,7 +12,6 @@ id: resources
 <div>
   <div>
     <h2 id="useful"><img src="/img/icons/ico_simple.svg" class="titleicon" alt="Icon">{% translate useful %}</h2>
-    <p><a href="https://bitcoinfoundation.org/">Bitcoin Foundation</a></p>
     <p>{% translate linkwiki %}</p>
     <p><a href="https://www.weusecoins.com/">WeUseCoins.com</a></p>
     <p><a href="http://www.bitcoinmining.com/">BitcoinMining.com</a></p>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -757,7 +757,7 @@ en:
     donation: "Donation"
     donationtxt: "The easiest way to help is to <a href=\"https://bitcoinfoundation.org/about/donate/\">donate</a> a few bitcoins to the Bitcoin Foundation. Or you can help directly fund any project related to Bitcoin that you believe will be helpful in the future."
     nonprofit: "Organizations"
-    nonprofittxt: "The <a href=\"https://bitcoinfoundation.org/\">Bitcoin Foundation</a> and many other <a href=\"#community##[community.non-profit]\">non-profit organizations</a> are dedicated to protecting and promoting Bitcoin. You can help these groups by joining them and taking part in their projects, discussions and events."
+    nonprofittxt: "Many <a href=\"#community##[community.non-profit]\">non-profit organizations</a> are dedicated to protecting and promoting Bitcoin. You can help these groups by joining them and taking part in their projects, discussions and events."
     spread: "Spread"
     spreadtxt: "Speak about Bitcoin to interested people. Write about it on your blog. Tell your favorite shops you would like to pay with Bitcoin. Help keeping <a href=\"http://usebitcoins.info/\">merchant directories</a> up to date. Or be creative and make yourself a nice Bitcoin T-shirt."
     wiki: "Documentation"


### PR DESCRIPTION
At present on our [Resources page](https://bitcoin.org/en/resources), the first link is to the [Bitcoin
Foundation](https://bitcoinfoundation.org/). That website has fallen into disrepair and is currently
broken.

Each day new users are discovering Bitcoin for the first time,
along with others who are learning more about it via Bitcoin.org. This
PR removes the link to the Bitcoin Foundation, for now, so we aren't
providing a top resource pointing to a broken web page:

![image](https://cloud.githubusercontent.com/assets/1130872/20834637/063b00da-b85c-11e6-82da-bfaf2ad726ac.png)
