### PR TITLE
GreenBits now supports Tor for both SPV and GreenAddress bc data/sign

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -544,7 +544,7 @@ wallets:
         privacycheck:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosureaccount"
-          privacynetwork: "checkfailprivacynetworknosupporttor"
+          privacynetwork: "checkpassprivacynetworksupporttorproxy"
 - mycelium:
     title: "Mycelium"
     titleshort: "Mycelium"


### PR DESCRIPTION
As of release [1.87](https://github.com/greenaddress/GreenBits/releases/tag/r1.87) of September 4th 2016 (now 1.93) GreenBits supports generic socks5 and explicit onion support with Orbot.

This PR updates the GreenBits wallet listing with the current released status.