### PR TITLE
Remove hover effect for subhead links (Developer Reference)

### DIFF
--- a/_less/screen.less
+++ b/_less/screen.less
@@ -860,11 +860,7 @@ h1 span.fa, h2 span.fa, h3 span.fa, h4 span.fa, h5 span.fa, h6 span.fa {
 	color:#63a4e1;
 }
 .toccontent .subhead-links{
-	visibility: hidden;
 	padding-top: 7px;
-}
-.toccontent:hover .subhead-links{
-	visibility: visible;
 }
 .toccontent a:link.term,
 .toccontent a:visited.term,


### PR DESCRIPTION
I think the hover effect for subhead links (Edit | History | Report Issue | Discuss) is distracting and unnecessary.