### PR TITLE
Show documentation link in header menu for all languages

### DIFF
--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -18,7 +18,7 @@ http://opensource.org/licenses/MIT.
     <ul>
       <li{% if page.id == 'resources' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate resources url %}">{% translate menu-resources layout %}</a></li>
       <li{% if page.id == 'community' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate community url %}">{% translate menu-community layout %}</a></li>
-      {% if page.lang == 'en' %}<li{% if page.id == 'developer-documentation' %} class="active"{% endif %}><a href="/en/developer-documentation">Documentation</a></li>{% endif %}
+      <li{% if page.id == 'developer-documentation' %} class="active"{% endif %}><a href="/en/developer-documentation">Documentation{% if page.lang != 'en' %} (EN){% endif %}</a></li>
       <li{% if page.id == 'vocabulary' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate vocabulary url %}">{% translate menu-vocabulary layout %}</a></li>
       <li{% if page.id == 'events' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate events url %}">{% translate menu-events layout %}</a></li>
       {% if page.lang == 'en' %}


### PR DESCRIPTION
Not sure if this is useful but so far there is only a link from the _developers introduction page_ to the _Documentation_ for non English languages.
With this commit the _Documentation_ link is always display in the _Resources_ menu and _(EN)_ is added for non English languages.

![devmenu](https://cloud.githubusercontent.com/assets/13236924/21198082/3c4a54b4-c23e-11e6-9366-af3ae4069019.jpg)
