### PR TITLE
Added local news sites and BitcoinAverage

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -32,11 +32,18 @@ id: resources
 <div>
   <div>
     <h2 id="news"><img src="/img/icons/ico_spread.svg" class="titleicon" alt="Icon">{% translate news %}</h2>
-    {% if page.lang == 'fr' %}<p><a href="http://le-coin-coin.fr/">Le Coin Coin</a></p>{% endif %}
-    {% if page.lang == 'fr' %}<p><a href="http://www.bitcoin.fr/">Bitcoin.fr</a></p>{% endif %}
     {% if page.lang == 'bg' %}<p><a href="http://hash.bg/">Hash.bg</a></p>{% endif %}
-    {% if page.lang == 'ru' %}<p><a href="http://bitnovosti.com/">Bit•Новости</a></p>
-    <p><a href="http://coinspot.ru/">CoinSpot</a></p>{% endif %}
+    {% if page.lang == 'de' %}<p><a href="https://bitcoinblog.de/">BitcoinBlog.de</a></p>{% endif %}
+    {% if page.lang == 'fr' %}
+    <p><a href="http://le-coin-coin.fr/">Le Coin Coin</a></p>
+    <p><a href="http://www.bitcoin.fr/">Bitcoin.fr</a></p>
+    {% endif %}
+    {% if page.lang == 'pl' %}<p><a href="https://satoshi.pl/">Satoshi.pl</a></p>{% endif %}
+    {% if page.lang == 'ru' %}
+    <p><a href="http://bitnovosti.com/">Bit•Новости</a></p>
+    <p><a href="https://bits.media/">Bits Media</a></p>
+    <p><a href="http://coinspot.ru/">CoinSpot</a></p>
+    {% endif %}
     <p>{% translate linkcointelegraph %}<p>
     <p><a href="http://www.coindesk.com/">CoinDesk</a></p>
     <p><a href="http://bitcoinmagazine.com/">Bitcoin Magazine</a></p>
@@ -45,10 +52,11 @@ id: resources
   </div><div>
     <h2 id="charts"><img src="/img/icons/ico_market.svg" class="titleicon" alt="Icon">{% translate charts %}</h2>
     <p><a href="http://blockchain.info/charts">Blockchain.info</a></p>
-    <p><a href="https://www.biteasy.com/">Biteasy.com</a></p>
+    <p><a href="https://www.biteasy.com/">Biteasy</a></p>
     <p><a href="https://tradeblock.com/">Trade Block</a></p>
     <p><a href="http://bitcoincharts.com/charts/">Bitcoincharts.com</a></p>
     <p><a href="http://gobitcoin.io/{% if 'en,fr,de,it,es' contains page.lang %}{{ page.lang }}/{% endif %}">GoBitcoin.io</a></p>
+    <p><a href="https://bitcoinaverage.com/{% if 'en,fr,de,it,es,pl,ru,ht,pt,tr,uk' contains page.lang %}{{ page.lang }}/bitcoin-price/btc-to-usd{% endif %}">BitcoinAverage</a></p>
   </div>
 </div>
 <div>


### PR DESCRIPTION
Added BitcoinAverage under _Ressources->Charts_ and 3 local news sites to _News_.

- BitcoinBlog.de - Most popular German bitcoin blog
- satoshi.pl - Requested in #1372 . Looks like a decent blog
- Bits Media - Formerly BTCsec, probably the oldest Russian bitcoin site