### PR TITLE
Add my contact info to README; Update self to Active

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@
   help us [review wallet submissions][].
 
 * [Translate Bitcoin.org into another language][] using [Transifex][] or
-  help review new and updated translations. **Translation coordinator
-  needed** to answer translator questions and help process
-  reviews---email <dave@dtrt.org> for details.
+  help review new and updated translations.
 
 * Add Bitcoin events to the [events page][] either by [editing `_events.yml`][edit events]
   according to the [event instructions][] or by filling in a [pre-made

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
   and click the *Watch* button to get notifications by email and on your
   GitHub home page.
 
-    Alternatively, email volunteer coordinator Dave Harding
-    <dave@dtrt.org> with a short list of your interests and skills, and
-    he'll email you when there's an issue or PR that could use your
-    attention.
+    Alternatively, email volunteer coordinators Will Binns
+    <will@cryptopelago.com> or Dave Harding <dave@dtrt.org> with a short list
+    of your interests and skills, and they will email you when there's an
+    issue or PR that could use your attention.
 
 * Help [write new documentation][] for the [developer
   documentation pages][] or [full node page][], or **review [PRs

--- a/README.md
+++ b/README.md
@@ -767,8 +767,8 @@ Optional criteria (some could become requirements):
 
 *Before adding a wallet,* please make sure your wallet meets all of the
 Basic Requirements listed above, or open a [new issue][] to request an
-exemption or policy change. Feel free to email Dave Harding
-<dave@dtrt.org> if you have any questions.
+exemption or policy change. Feel free to email Will Binns <will@cryptopelago.com>
+or Dave Harding <dave@dtrt.org> if you have any questions.
 
 Wallets can be added in `_templates/choose-your-wallet.html`. Entries are ordered by levels and new wallets must be added after the last wallet on the same level.
 

--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ is the particular version:
 The following people can publish alerts on Bitcoin.org.  Their email
 addresses are on the linked GitHub profiles.
 
+- Will Binns, [@wbnns](https://github.com/wbnns), wbnns on Freenode
 - Saïvann Carignan, [@saivann](https://github.com/saivann), saivann on Freenode
 - Dave Harding, [@harding](https://github.com/harding), harding on Freenode
 - Wladimir van der Laan, [@laanwj](https://github.com/laanwj), wumpus on Freenode

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
   the help of writers, editors, graphic artists, web designers, and anyone
   else to enhance Bitcoin.org's [current content][] or to add new
   content. See the **list of [recommended starter projects][]** or email
-  volunteer coordinator Dave Harding <dave@dtrt.org> to start a
-  conversation about how you can help Bitcoin.org.
+  volunteer coordinators Will Binns <will@cryptopelago.com> or Dave Harding <dave@dtrt.org>
+  to start a conversation about how you can help Bitcoin.org.
 
 You can always report problems or help improve bitcoin.org by opening a [new issue][] or [pull request][] on [GitHub][].
 

--- a/_templates/about-us.html
+++ b/_templates/about-us.html
@@ -40,6 +40,7 @@ id: about-us
 <h3 id="maintenance">{% translate maintenance %}</h3>
 
 <div class="credit">
+  <p><a href="https://github.com/wbnns/">Will Binns</a><span>Website maintainer</span></p>
   <p><a href="https://github.com/crwatkins">Craig Watkins</a><span>Wallet maintainer</span></p>
 </div>
 
@@ -77,7 +78,6 @@ id: about-us
 <div class="credit">
   <p><a href="https://github.com/saivann/">Saïvann Carignan</a><span>Website maintainer</span></p>
   <p>Greg Sanders<span>Documentation writing</span></p>
-  <p><a href="https://github.com/wbnns">Will Binns</a><span>Miscellaneous</span></p>
   <p><a href="https://github.com/harding">David A. Harding</a><span>Documentation writing</span></p>
 </div>
 


### PR DESCRIPTION
This PR updates the README to include my contact information and also updates myself to Active on the About page.

Unless others object, this will be merged on Sunday, December 18th.