### PR TITLE
Remove BFGMiner link because of malware warning on Chrome

### DIFF
--- a/_templates/development.html
+++ b/_templates/development.html
@@ -117,7 +117,6 @@ Want to contribute to a different project?
 
 <ul class="devprojectlist">
   <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A wallet with enhanced security features.</li>
-  <li><a href="http://bfgminer.com">BFGMiner</a> - A modular miner.</li>
   <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Explorer">Bitcoin Explorer</a> - A command line tool, built on libbitcoin.</li>
   <li><a href="https://en.bitcoin.it/wiki/Bitcoin_Server">Bitcoin Server</a> - A full node and query server, built on libbitcoin.</li>
   <li><a href="https://github.com/bitcoin-wallet/bitcoin-wallet">Bitcoin Wallet</a> - A SPV wallet for Android and Blackberry.</li>


### PR DESCRIPTION
Remove BFGMiner link because of malware warning on Chrome