### PR TITLE
Remove CryptoCoinsNews from News Resources

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -35,7 +35,6 @@ id: resources
     <p><a href="http://coinspot.ru/">CoinSpot</a></p>{% endif %}
     <p>{% translate linkcointelegraph %}<p>
     <p><a href="http://www.coindesk.com/">CoinDesk</a></p>
-    <p><a href="http://www.cryptocoinsnews.com/">CryptoCoinsNews</a></p>
     <p><a href="http://bitcoinmagazine.com/">Bitcoin Magazine</a></p>
     <p><a href="http://coinjournal.net/">CoinJournal</a></p>
     {% if page.lang == 'ru' %}<p><a href="https://bitcointalk.org/index.php?board=128.0">Биткойн Форум / Новости</a></p>{% else %}<p><a href="https://bitcointalk.org/index.php?board=77.0">BitcoinTalk press links</a></p>{% endif %}


### PR DESCRIPTION
I'm not sure why this site was added. It doesn't offer much of anything that you wouldn't find on the more established sites. There is little to no unique/original content, and there is apparently no fact checking before something is published. Latest example is an article claiming Phil Potter is a Bitcoin core dev while also getting his Bitfinex job title wrong (among other errors): https://www.cryptocoinsnews.com/bitfinex-cso-theres-chinese-political-effort-delay-block-segwit/