### PR TITLE
full-node: Add info on setting node to prune to reduce storage

### DIFF
--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1297,7 +1297,7 @@ Running a node in pruned mode is incompatible with `-txindex`
 and `-rescan` and disables the RPCs `importwallet`, `importaddress`,
 and `importprivkey`.
 
-To enable block pruning set `prune=<N>` on the command line or in `bitcoin.conf`,
+To enable block pruning set `prune=N` on the command line or in `bitcoin.conf`,
 where `N` is the number of MiB to allot for raw block & undo data.
 
 A value of `0` disables pruning. The minimal value above `0` is `550`. Your

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1294,7 +1294,8 @@ reduce storage requirements. This can reduce the disk usage from over 100GB to
 around 2GB.
 
 Running a node in pruned mode is incompatible with `-txindex` and `-rescan`. It
-also disables the RPC `importwallet`.
+also disables the RPC `importwallet`. Two RPCs that are available and
+potentially helpful, however, are `importprunedfunds` and `removeprunedfunds`.
 
 To enable block pruning set `prune=N` on the command line or in `bitcoin.conf`,
 where `N` is the number of MiB to allot for raw block and undo data.

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1293,7 +1293,8 @@ It is possible to configure your node to to run in pruned mode in order to
 reduce storage requirements. This can reduce the disk usage from over 100GB to
 around 2GB.
 
-Running a node in pruned mode disables the RPCs `importwallet`, `importaddress`,
+Running a node in pruned mode is incompatible with `-txindex`
+and `-rescan` and disables the RPCs `importwallet`, `importaddress`,
 and `importprivkey`.
 
 To enable block pruning set `prune=<N>` on the command line or in `bitcoin.conf`,

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1287,6 +1287,25 @@ If you have any questions about configuring Bitcoin Core, please stop by
 one of our [forums](/en/bitcoin-core/help#forums) or [live
 chatrooms](/en/bitcoin-core/help#live).
 
+### Reduce Storage
+
+It is possible to configure your node to to run in pruned mode in order to
+reduce storage requirements. This can reduce the disk usage from over 100GB to
+around 2GB.
+
+Running a node in pruned mode disables the RPCs `importwallet`, `importaddress`,
+and `importprivkey`.
+
+To enable block pruning set `prune=<N>` on the command line or in `bitcoin.conf`,
+where `N` is the number of MiB to allot for raw block & undo data.
+
+A value of `0` disables pruning. The minimal value above `0` is `550`. Your
+wallet is as secure with high values as it is with low ones. Higher values
+merely ensure that your node will not shut down upon blockchain reorganizations
+of more than 2 days - which are unlikely to happen in practice. In future
+releases, a higher value may also help the network as a whole because stored
+blocks could be served to other nodes.
+
 ### Reduce Traffic
 
 Some node operators need to deal with bandwith caps imposed by their ISPs.

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1293,9 +1293,8 @@ It is possible to configure your node to to run in pruned mode in order to
 reduce storage requirements. This can reduce the disk usage from over 100GB to
 around 2GB.
 
-Running a node in pruned mode is incompatible with `-txindex`
-and `-rescan` and disables the RPCs `importwallet`, `importaddress`,
-and `importprivkey`.
+Running a node in pruned mode is incompatible with `-txindex` and `-rescan`. It
+also disables the RPC `importwallet`.
 
 To enable block pruning set `prune=N` on the command line or in `bitcoin.conf`,
 where `N` is the number of MiB to allot for raw block and undo data.

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1298,7 +1298,7 @@ and `-rescan` and disables the RPCs `importwallet`, `importaddress`,
 and `importprivkey`.
 
 To enable block pruning set `prune=N` on the command line or in `bitcoin.conf`,
-where `N` is the number of MiB to allot for raw block & undo data.
+where `N` is the number of MiB to allot for raw block and undo data.
 
 A value of `0` disables pruning. The minimal value above `0` is `550`. Your
 wallet is as secure with high values as it is with low ones. Higher values


### PR DESCRIPTION
This PR adds additional info to the [Running a Full Node](https://bitcoin.org/en/full-node) page regarding how to configure a node to `prune` in order to reduce storage requirements:

![image](https://cloud.githubusercontent.com/assets/1130872/21583528/2d5d4c34-d04b-11e6-9a95-69c51aa0b3b2.png)

Unless others object, this will be merged on Wednesday, January 4th.