### PR TITLE
events: Add Bitcoin Brunch on Intl Day of Privacy

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -54,6 +54,14 @@
   country: "United Kingdom"
   link: "http://www.economist.com/events-conferences/emea/finance-disrupted"
 
+- date: 2017-01-28
+  title: "Bitcoin Brunch @ International Day of Privacy"
+  venue: "Urban Chef"
+  address: "Koningstraat 50/51"
+  city: "Arnhem Bitcoincity"
+  country: "The Netherlands"
+  link: "https://www.ArnhemBitcoinstad.nl"
+
 - date: 2017-02-14
   title: "Event Horizon"
   venue: "Hofburg Palace"


### PR DESCRIPTION
This adds an upcoming Bitcoin Brunch event in The Netherlands:
https://www.arnhembitcoinstad.nl/#usergroup

Unless others object, this will be merged on Wednesday, January 25th.

// Closes #1486 