### PR TITLE
event: Add Future of Fintech

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -134,6 +134,14 @@
   country: "Denmark"
   link: "https://www.money2020europe.com/"
 
+- date: 2017-06-27
+  title: "Future of Fintech"
+  venue: "Jazz at Lincoln Center"
+  address: "10 Columbus Circle"
+  city: "New York"
+  country: "NY"
+  link: "http://events.cbinsights.com/future-of-fintech"
+
 - date: 2017-07-07
   title: "London Fintech Week"
   venue: "Grange Tower Bridge Hotel"


### PR DESCRIPTION
This adds an upcoming event, the Future of Fintech to the site.

Unless others object, this will be merged on Sunday, February 12th.

// Closes #1492.