### PR TITLE
exchanges: Remove Huobi and OKCoin

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -65,8 +65,6 @@ id: exchanges
     <h3 id="china"><img src="/img/flags/CN.png" alt="Chinese flag">China</h3>
     <p>
       <a href="https://www.btcchina.com/">BTCC</a><br>
-      <a href="https://www.huobi.com/">Huobi</a><br>
-      <a href="https://www.okcoin.com/">OKCoin</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
This removes Huobi and OKCoin from the Exchanges page for the interim in light of:
http://www.coindesk.com/two-chinas-biggest-exchanges-stop-bitcoin-withdrawals/

This will be merged once tests pass.