### PR TITLE
download: Note Ubuntu PPA as Unofficial

### DIFF
--- a/_templates/download.html
+++ b/_templates/download.html
@@ -80,6 +80,7 @@ lin64: "x86_64-linux-gnu.tar.gz"
         <img src="/img/os/med_ubuntu.svg" alt="ubuntu">
         <span>
           <a href="https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin">Ubuntu (PPA)</a>
+            <span>Note: Unofficial</span>
         </span>
       </div>
     </div>


### PR DESCRIPTION
This fixes #1506 and provides additional clarity to the Ubuntu link by
adding a note that the PPA is Unofficial:

![image](https://cloud.githubusercontent.com/assets/1130872/22854449/77f7914c-f034-11e6-8589-2977c04836db.png)

Unless others object, this will be merged on Wednesday, February 15th.

cc: @harding @pixdigit