### PR TITLE
Revert "Update to Glossary Definition: Double Spend"

### DIFF
--- a/_data/glossary/en/double-spend.yaml
+++ b/_data/glossary/en/double-spend.yaml
@@ -7,10 +7,8 @@ required:
     title_max_40_characters_no_formatting: Double Spend
 
     summary_max_255_characters_no_formatting: >
-        A transaction that uses the same input as an already broadcast
-        transaction. The attempt of duplication, deceit, or conversion, 
-        will be adjudicated when only one of the transactions is recorded
-        in the blockchain.
+        A transaction that spends the same input as spent in another
+        transaction.
 
     synonyms_shown_in_glossary_capitalize_first_letter:
         - Double spend
@@ -22,7 +20,7 @@ optional:
         - double-spend
         - double-spends
         - double-spent
-        - double spending
+        - dobule spending
         - double-spending
 
     not_to_be_confused_with_capitalize_first_letter:


### PR DESCRIPTION
Reverts bitcoin-dot-org/bitcoin.org#1251