### PR TITLE
update iTunes account for GreenAddress iOS app

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -689,7 +689,7 @@ wallets:
           privacynetwork: "checkpassprivacynetworksupporttorproxy"
       ios:
         text: "walletgreenaddress"
-        link: "https://itunes.apple.com/us/app/greenaddress/id889740745?ls=1&amp;mt=8"
+        link: "https://itunes.apple.com/app/id1206035886"
         source: "https://github.com/greenaddress/WalletCordova"
         screenshot: "greenaddressandroid.png"
         os:


### PR DESCRIPTION
This PR changes the iTunes account we use for the GreenAddress app on iOS.

The app is otherwise unchanged (though we also added the testnet version now to the new iTunes account)