### PR TITLE
events: Add Blockchain Expo, Fix formatting of USA & Incorrect Country

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -3,7 +3,7 @@
   venue: "Las Vegas Convention Center"
   address: "3150 Paradise Road"
   city: "Las Vegas, NV"
-  country: "USA"
+  country: "United States"
   link: "http://thedigitalmoneyforum.com/"
 
 - date: 2017-01-07
@@ -11,7 +11,7 @@
   venue: "Santa Clara Conventional Center, Great America Ballroom"
   address: "5001 Great America Pkwy"
   city: "Santa Clara"
-  country: "USA"
+  country: "United States"
   link: "https://www.eventbrite.com/e/the-blockchain-fintech-summit-of-silicon-valley-tickets-29506617086"
 
 - date: 2017-01-12
@@ -171,7 +171,7 @@
   venue: "Jazz at Lincoln Center"
   address: "10 Columbus Circle"
   city: "New York"
-  country: "NY"
+  country: "United States"
   link: "http://events.cbinsights.com/future-of-fintech"
 
 - date: 2017-07-07

--- a/_events.yml
+++ b/_events.yml
@@ -189,3 +189,11 @@
   city: "Kiev"
   country: "Ukraine"
   link: "https://bitcoinconf.com.ua/en"
+
+- date: 2017-11-29
+  title: "Blockchain Expo"
+  venue: "Santa Clara Convention Center"
+  address: "5001 Great America Pkwy, Santa Clara, 95054"
+  city: "Santa Clara"
+  country: "United States"
+  link: "http://blockchain-expo.com/northamerica/"


### PR DESCRIPTION
This PR:

- Adds a new event, The Blockchain Expo
- Fixes formatting of USA across some different event entries for consistency
- Fixes an event that had an incorrect country associated with it

Unless others object, this will be merged on Sunday, March 5th.

Closes #1521 .