### PR TITLE
contributors: Fix broken test

### DIFF
--- a/_plugins/contributors.rb
+++ b/_plugins/contributors.rb
@@ -59,7 +59,7 @@ module Jekyll
         x['name'] = name
         x['contributions'] = c['contributions']
         # Set avatar_url when available
-        if c.has_key?('avatar_url') and c['avatar_url'].is_a?(String) and /^https:\/\/avatars\.githubusercontent\.com\/u\/[0-9]{1,10}\?v=[0-9]{1,2}$/.match(c['avatar_url'])
+        if c.has_key?('avatar_url') and c['avatar_url'].is_a?(String) and /^https:\/\/avatars1\.githubusercontent\.com\/u\/[0-9]{1,10}\?v=[0-9]{1,2}$/.match(c['avatar_url'])
           x['avatar_url'] = c['avatar_url'] + '&amp;size=16'
         end
         # Set login when available

--- a/_plugins/contributors.rb
+++ b/_plugins/contributors.rb
@@ -58,10 +58,6 @@ module Jekyll
         x = {}
         x['name'] = name
         x['contributions'] = c['contributions']
-        # Set avatar_url when available
-        if c.has_key?('avatar_url') and c['avatar_url'].is_a?(String) and /^https:\/\/avatars1\.githubusercontent\.com\/u\/[0-9]{1,10}\?v=[0-9]{1,2}$/.match(c['avatar_url'])
-          x['avatar_url'] = c['avatar_url'] + '&amp;size=16'
-        end
         # Set login when available
         if c.has_key?('login') and c['login'].is_a?(String) and /^[A-Za-z0-9\-]{1,150}$/.match(c['login'])
           x['login'] = c['login']

--- a/_templates/about-us.html
+++ b/_templates/about-us.html
@@ -93,7 +93,6 @@ id: about-us
 <div class="contributors">
   {% for c in site.sitecontributors %}
   <div>
-    <div>{% if c.avatar_url %}<img src="{{c.avatar_url}}" alt="icon" />{% else %}<img alt="icon" />{% endif %}</div>
     <div><a{% if c.login %} href="https://github.com/{{c.login}}"{% endif %}>{{ c.name | htmlescape }}</a></div>
     <div>({{ c.contributions }})</div>
   </div>

--- a/_templates/development.html
+++ b/_templates/development.html
@@ -97,7 +97,6 @@ improvement in mind?  Here are a few ideas:
   <div class="contributors">
     {% for c in site.corecontributors %}
     <div>
-      <div>{% if c.avatar_url %}<img src="{{c.avatar_url}}" alt="icon" />{% else %}<img alt="icon" />{% endif %}</div>
       <div><a{% if c.login %} href="https://github.com/{{c.login}}"{% endif %}>{{ c.name | htmlescape }}</a></div>
       <div>({{ c.contributions }})</div>
     </div>


### PR DESCRIPTION
GitHub recently made a change on their end to the URLs with which
profile images are stored. As a result, this has caused the profile
images on the About Us page to break, and tests to fail.

This PR resolves the issue.