### PR TITLE
docs: Fix broken link when adding an event

### DIFF
--- a/docs/adding-events-release-notes-and-alerts.md
+++ b/docs/adding-events-release-notes-and-alerts.md
@@ -21,8 +21,8 @@ this format:
 
 Events that have a [Meetup.com](http://www.meetup.com/) page with a
 publicly-viewable address and "Bitcoin" in the event title should
-already be displayed on the [events page][]. (Please open a [new
-issue][] if a Bitcoin meetup event isn't displayed.)
+already be displayed on the [events page](https://bitcoin.org/en/events).
+(Please open a [new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?title=New%20event&body=%20%20%20%20-%20date%3A%20YYYY-MM-DD%0A%20%20%20%20%20%20title%3A%20%22%22%0A%20%20%20%20%20%20venue%3A%20%22%22%0A%20%20%20%20%20%20address%3A%20%22%22%0A%20%20%20%20%20%20city%3A%20%22%22%0A%20%20%20%20%20%20country%3A%20%22%22%0A%20%20%20%20%20%20link%3A%20%22%22) if a Bitcoin meetup event isn't displayed.)
 
 ### Release Notes
 


### PR DESCRIPTION
This fixes an issue in the documentation for Bitcoin.org, on how to add
an event to the site. The link to the Events page as well as the event
template needed to be updated.

This will be merged once tests pass.