### PR TITLE
alert: Drop current alert notification

### DIFF
--- a/_alerts/2016-11-01-alert-retirement.md
+++ b/_alerts/2016-11-01-alert-retirement.md
@@ -4,7 +4,7 @@
 
 title: "Alert System Retirement"
 shorturl: "alert-retirement"
-active: true
+active: false
 banner: "Alert system is being retired (click here to read)"
 bannerclass: "info"
 ---


### PR DESCRIPTION
Now that 0.14.0 has been released, this ends the notification about the
retirement of the alert system, which has been running and displaying on
the tops of all pages on Bitcoin.org for the last 4 months (to give
everyone advance notice).

Unless others object, this will be merged on Sunday, March 12th.