### PR TITLE
Add new upcoming events

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -126,6 +126,14 @@
   country: "United Kingdom"
   link: "https://www.coinfestuk.org"
 
+- date: 2017-05-08
+  title: "The Blockchain NZ 2017"
+  venue: "Viaduct Event Centre"
+  address: "161 Halsey St"
+  city: "Auckland"
+  country: "New Zealand"
+  link: "http://www.theblockchain.nz/"
+
 - date: 2017-05-19
   title: "Bitcoin Conference Prague"
   venue: "Angelo Hotel Prague"

--- a/_events.yml
+++ b/_events.yml
@@ -102,6 +102,14 @@
   country: "Australia"
   link: "http://www.questevents.com.au/apac-blockchain-conference-2017"
 
+- date: 2017-03-16
+  title: "Oral Arguments on the Status of the BitLicense"
+  venue: "New York State Supreme Court"
+  address: "71 Thomas Street, Room 204, Part 46"
+  city: "New York"
+  country: "United States"
+  link: "https://www.meetup.com/Article-78-Against-NYDFS/events/238080585"
+
 - date: 2017-03-17
   title: "BlockchainUA Conference Kyiv"
   venue: "Conference Hall, Oasis, Ultramarine, 3rd floor"

--- a/_events.yml
+++ b/_events.yml
@@ -103,6 +103,14 @@
   link: "http://www.questevents.com.au/apac-blockchain-conference-2017"
 
 - date: 2017-03-16
+  title: "An Introduction to Cryptocurrencies, Bitcoin & Blockchain"
+  venue: "Holiday Inn Express"
+  address: "Birmingham Rd, WS14 0QP"
+  city: "Lichfield"
+  country: "United Kingdom"
+  link: "https://www.eventbrite.co.uk/e/an-introduction-to-crypto-currencies-bitcoin-the-blockchain-tickets-32417523686"
+
+- date: 2017-03-16
   title: "Oral Arguments on the Status of the BitLicense"
   venue: "New York State Supreme Court"
   address: "71 Thomas Street, Room 204, Part 46"


### PR DESCRIPTION
This adds a few new upcoming events to the [events page](https://bitcoin.org/en/events):

+ http://www.theblockchain.nz/
+ https://www.meetup.com/Article-78-Against-NYDFS/events/238080585
+ https://www.eventbrite.co.uk/e/an-introduction-to-crypto-currencies-bitcoin-the-blockchain-tickets-32417523686

This will be merged once tests pass.
