### PR TITLE
glossary: Fix typo in number of fields

### DIFF
--- a/_data/glossary/en/input.yaml
+++ b/_data/glossary/en/input.yaml
@@ -7,7 +7,7 @@ required:
     title_max_40_characters_no_formatting: Input, Transaction Input, TxIn
 
     summary_max_255_characters_no_formatting: >
-        An input in a transaction which contains four fields: an
+        An input in a transaction which contains three fields: an
         outpoint, a signature script, and a sequence number.  The
         outpoint references a previous output and the signature script
         allows spending it.


### PR DESCRIPTION
This resolves an issue where the number of fields for an input was
incorrectly worded as four instead of three.

This will be merged once tests pass.

// Resolves #1542