### PR TITLE
community: Remove Fundatia Bitcoin Romania

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -172,25 +172,19 @@ id: community
     </p>
   </div>
   <div>
-    <h3 id="romania"><img src="/img/flags/RO.png" alt="Romanian flag">Romania</h3>
-    <p>
-      <a href="https://fundatiabitcoin.ro/">Fundatia Bitcoin Romania</a>
-    </p>
-  </div>
-  <div>
     <h3 id="russia"><img src="/img/flags/RU.png" alt="Russian flag">Russia</h3>
     <p>
       <a href="https://ccfr.info/">Crypto Currencies Foundation Russia</a>
     </p>
   </div>
-</div>
-<div>
   <div>
     <h3 id="ukraine"><img src="/img/flags/UA.png" alt="Ukrainian flag">Ukraine</h3>
     <p>
       <a href="https://www.bitcoinua.org/">Bitcoin Foundation Ukraine</a>
     </p>
   </div>
+</div>
+<div>
   <div>
     <h3 id="slovenia"><img src="/img/flags/SI.png" alt="Slovenian flag">Slovenia</h3>
     <p>
@@ -203,8 +197,6 @@ id: community
       <a href="http://www.bitcoinforeningen.se/">Svenska Bitcoinföreningen</a>
     </p>
   </div>
-</div>
-<div>
   <div>
     <h3 id="switzerland"><img src="/img/flags/CH.png" alt="Swiss flag">Switzerland</h3>
     <p>


### PR DESCRIPTION
Resolves #1546

Context from @odv:
```
Hello!

I was browsing bitcoin.org and noticed a spam link listed in the
Community section, under Romania called Fundatia Bitcoin Romania.
https://bitcoin.org/en/community#romania

If you go to that page, below the first post, there is a masked
advertisement for a romanian webcam studio and two other posts about a
particular person that got rich by selling flowers. I won't list his
name here but he's quite a known scammer in the romanian internet space.
If you check out his twitter handle he has a lot of retweets about
romanian webcam studios which to me makes it pretty clear that he's
behind this site too.

The Nov 17 and Nov 24 posts have a link to another site that has just
one posts, again, about that same individual. If you query
http://rotld.ro/engleza/index_en.html fundatiabitcoin.ro and the other 2
spam domains with just one post are owned by the same entity.

I personally think this site should be deleted. It brings absolutely no
value to the Bitcoin Community, especially the Romanian one and could
later be used to scam Romanian users.

Since I'm brand new here, I also want to thank everybody that
contributed to this project.
```

This will be merged once tests pass.