### PR TITLE
ref_p2p_networking: Fix protocol version

### DIFF
--- a/_includes/devdoc/ref_p2p_networking.md
+++ b/_includes/devdoc/ref_p2p_networking.md
@@ -1175,7 +1175,7 @@ single field, the nonce.
 
 | Bytes | Name  | Data Type | Description
 |-------|-------|-----------|---------------
-| 8     | nonce | uint64_t  | *Added in protocol version 60000 as described by BIP31.* <br><br>Random nonce assigned to this `ping` message.  The responding `pong` message will include this nonce to identify the `ping` message to which it is replying.
+| 8     | nonce | uint64_t  | *Added in protocol version 60001 as described by BIP31.* <br><br>Random nonce assigned to this `ping` message.  The responding `pong` message will include this nonce to identify the `ping` message to which it is replying.
 
 The annotated hexdump below shows a `ping` message. (The message
 header has been omitted.)


### PR DESCRIPTION
An incorrect protocol version was referenced. It should be `60001`, not
`60000`.

This will be merged as soon as tests pass.

// Closes #1548 