### PR TITLE
exchanges: Add Bitwage

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -23,6 +23,7 @@ id: exchanges
     <p>
       <a href="https://bitsquare.io/">Bitsquare</a><br>
       <a href="https://www.bitstamp.net/">Bitstamp</a><br>
+      <a href="https://bitwage.com/">Bitwage</a><br>
       <a href="https://www.coinbase.com/">Coinbase</a><br>
       <a href="https://www.kraken.com/">Kraken</a><br>
       <a href="https://localbitcoins.com/">Local Bitcoins</a><br>


### PR DESCRIPTION
This adds Bitwage to the list of International exchanges. They allow
people to receive some or all of their wage payments, salaries, etc.,
in bitcoin.

Unless others object, this will be merged on Sunday, March 26th.