### PR TITLE
Add Bitrefill to "Vouchers" section

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -70,6 +70,7 @@ id: resources
     <p><a href="https://www.youtube.com/watch?v=6pWblf8COH4">The Bitcoin Phenomenon</a></p>
   </div><div>
     <h2 id="vouchers"><img src="/img/icons/ico_voucher.svg" class="titleicon" alt="Icon">{% translate vouchers %}</h2>
+    <p><a href="https://www.bitrefill.com/">Bitrefill</a></p>
     <p><a href="https://foldapp.com/">Fold</a></p>
     <p><a href="https://gyft.com/bitcoin/">Gyft</a></p>
     <p><a href="https://opendime.com/">Opendime</a></p>


### PR DESCRIPTION
Bitrefill sells vouchers and refills of prepaid phones used by 75% of mobile users worldwide. This is one of the most common purchases for bitcoin users all over the world. Supports > 150 countries, in many of which this is the only thing that can be purchased with bitcoin today.