### PR TITLE
Remove Trezor from Choose your Wallet Page

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -398,23 +398,6 @@ wallets:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosurespv"
           privacynetwork: "checkfailprivacynetworknosupporttor"
-- trezor:
-    title: "Trezor"
-    titleshort: "Trezor"
-    compat: "hardware"
-    level: 2
-    platform:
-      hardware:
-        text: "wallettrezor"
-        link: "https://trezor.io/"
-        source: "https://github.com/trezor/"
-        screenshot: "trezor.png"
-        check:
-          control: "checkgoodcontrolfull"
-          validation: "checkneutralvalidationvariable"
-          transparency: "checkgoodtransparencydeterministic"
-          environment: "checkgoodenvironmenthardware"
-          privacy: "checkneutralprivacyvariable"
 - ledgernano:
     title: "Ledger Nano"
     titleshort: "Ledger<br>Nano"


### PR DESCRIPTION
Trezor [claims to be "ready" for UASF](https://twitter.com/slushcz/status/851502735736418304), unfortunately while I personally do support a UASF to activate Segwit, bitcoin.org does not promote wallets that attempt to alter (or follow nodes that do alter) the existing consensus without overwhelming support. In the case of a failed UASF, an altcoin is created which is not Bitcoin. 

Services that claim to support or be ready for this new altcoin don't belong on bitcoin.org. It's impossible for there to be two Bitcoin's, so bitcoin.org can't promote services that incorrectly label an altcoin as "Bitcoin" (such as a failed UASF) or services that present the user with two different Bitcoin "flavours" (as would happen in a contentious UASF) to pick from.

UASFCoin is not bitcoin, and until it becomes "bitcoin" by gaining overwhelming consensus (almost all nodes, all exchanges, all miners and all developers), then this policy will be applied to all wallets. It's very dangerous to break apart from the existing consensus, or to present the user a million different flavours of Bitcoin to choose from ("What Bitcoin version would you like? CoreCoin, UASFCoin, or BUCoin?"). There is only 1 Bitcoin and only 1 Bitcoin Blockchain, and bitcoin.org exists to serve that.

Merge scheduled for one week from now.