### PR TITLE
Added JP/KR exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -110,6 +110,7 @@ id: exchanges
     <h3 id="japan"><img src="/img/flags/JP.png" alt="Japanese flag">Japan</h3>
     <p>
       <a href="https://bitflyer.jp/">bitFlyer</a><br>
+      <a href="https://www.btcbox.co.jp/">BtcBox</a><br>
       <a href="https://coincheck.com/">Coincheck</a>
     </p>
   </div>
@@ -140,6 +141,8 @@ id: exchanges
   <div>
     <h3 id="south-korea"><img src="/img/flags/KR.png" alt="South Korean flag">South Korea</h3>
     <p>
+      <a href="https://www.bithumb.com/">Bithumb</a><br>
+      <a href="https://coinone.co.kr/">Coinone</a><br>
       <a href="https://www.korbit.co.kr/">Korbit</a>
     </p>
   </div>


### PR DESCRIPTION
I added a few Japanese and Korean exchanges.

I think for some exchanges the country classification needs to be changed. Paymium, Bitcoin.de and Rocked Trading are open to all SEPA supporting countries and have multilingual sites. Maybe a EU/Euro category would make sense.

While Bitwage is a great service I would not consider it an exchange or a way to buy/sell bitcoin.