### PR TITLE
added links for bitaccess BTM network as well as Bitcoin ATM industry directory site. 

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -28,6 +28,7 @@ id: exchanges
       <a href="https://www.kraken.com/">Kraken</a><br>
       <a href="https://localbitcoins.com/">Local Bitcoins</a><br>
       <a href="https://xapo.com/">Xapo</a>
+      <a href="https://xapo.com/">Bitaccess BTM Network</a>
     </p>
   </div>
   <div>
@@ -58,6 +59,7 @@ id: exchanges
   <div>
     <h3 id="canada"><img src="/img/flags/CA.png" alt="Canadian flag">Canada</h3>
     <p>
+      <a href="https://www.bitaccess.co/">Bitaccess</a><br>
       <a href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a><br>
       <a href="https://quickbt.com/">QuickBT</a>
     </p>
@@ -174,3 +176,4 @@ id: exchanges
 
 <div class="introlink">Visit <a href="https://www.buybitcoinworldwide.com/">Buy Bitcoin Worldwide</a> for
     user reviews on some of the above exchanges.</div>
+<div class="introlink">For information about local bitcoin ATMs, you can visit <a href="https://www.coinatmradar.com/">Coin ATM Radar</a></div>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -28,7 +28,7 @@ id: exchanges
       <a href="https://www.kraken.com/">Kraken</a><br>
       <a href="https://localbitcoins.com/">Local Bitcoins</a><br>
       <a href="https://xapo.com/">Xapo</a>
-      <a href="https://xapo.com/">Bitaccess BTM Network</a>
+      <a href="https://www.bitaccess.co/">Bitaccess BTM Network</a>
     </p>
   </div>
   <div>


### PR DESCRIPTION
https://www.bitaccess.co is the home page of bitaccess BTMs and Canadian BItcoin brokerage.

https://coinatmradar.com/ is the industry go-to industry site for finding local bitcoin atms from multiple manufacturers.