### PR TITLE
Updating 'alert system retirement' page.

### DIFF
--- a/_alerts/2016-11-01-alert-retirement.md
+++ b/_alerts/2016-11-01-alert-retirement.md
@@ -11,13 +11,14 @@ active: false
 
 ## Updates
 
-* **January 19th 2017**: The Final alert has been broadcast. This final alert essentially disables the alert system by overriding all 
+* **January 19th 2017**: The Final alert has been broadcast. This final alert essentially disables the alert system by overriding all
 alerts, preventing other alerts from being broadcast, and displays the static message "Alert Key Compromised". The Alert Key
 will be published in the coming months.
+* **March 8th 2017**: Bitcoin Core 0.14 released with hard-coded [final alert](https://bitcoin.org/en/release/v0.14.0#final-alert).
 
 ## Summary
 
-The network wide Alert system is being retired. **_No Bitcoins are at risk and this warning may be safely ignored._** 
+The network wide Alert system is being retired. **_No Bitcoins are at risk and this warning may be safely ignored._**
 Upgrade to the newest version of your wallet software to no longer see the alert.
 
 ## Reasons for Retirement
@@ -36,11 +37,11 @@ still must have handling for the Alert system because it is network wide. Someth
 not be imposed on the entire network.
 
 The Alert system has also lost its usefulness. It is no longer necessary to use it to inform users about problematic network
-events as users can easily get their information from any major Bitcoin news outlet. 
+events as users can easily get their information from any major Bitcoin news outlet.
 
 ## The Retirement Plan
 
-Retirement of the Alert system consists of a pre-final alert (this alert) which will warn about the impending retirement, a 
+Retirement of the Alert system consists of a pre-final alert (this alert) which will warn about the impending retirement, a
 final maximum sequence alert which cannot be overridden and displays a static "Alert Key Compromised" message, and the
 publishing of the Alert key itself. The final alert will be hard coded into Bitcoin Core 0.14 to ensure that all old nodes
 receive the final alert.
@@ -49,15 +50,15 @@ receive the final alert.
 |---|---|---|
 |Pre-final Alert Posts|Posts on Bitcoin.org, various forums, and various mailing lists that the Alert system will be retired|2016-11-01|
 |Pre-final Alert|The alert itself warning that the Alert system will be retired|2016-11-02|
-|Final Alert|Max sequence Alert to disable the Alert system|2017 (Will coincide with Bitcoin Core 0.14 Release Candidate process)|
+|Final Alert|Max sequence Alert to disable the Alert system|2017-01-19|
 |Alert key released|The Alert key will be made publicly available|1-2 months after the Final Alert|
 
 ## Software without the Alert system
 
-Most major Bitcoin wallets have already removed the alert system in the most recent releases. The software listed below 
+Most major Bitcoin wallets have already removed the alert system in the most recent releases. The software listed below
 are guaranteed to have removed/disabled the Alert system or allow you to disable it.
 
-* Bitcoin Core 0.13.1, 0.13.0, 0.12.1
+* Bitcoin Core 0.12.1+
 * Bitcoin Core 0.10.3, 0.11.x, and 0.12.x can disable alerts with `-alerts=0`
 * Armory 0.94.1+
 

--- a/_alerts/2016-11-01-alert-retirement.md
+++ b/_alerts/2016-11-01-alert-retirement.md
@@ -11,10 +11,12 @@ active: false
 
 ## Updates
 
-* **January 19th 2017**: The Final alert has been broadcast. This final alert essentially disables the alert system by overriding all
+* **January 19, 2017**: The Final alert has been broadcast. This final alert essentially disables the alert system by overriding all
 alerts, preventing other alerts from being broadcast, and displays the static message "Alert Key Compromised". The Alert Key
 will be published in the coming months.
-* **March 8th 2017**: Bitcoin Core 0.14 released with hard-coded [final alert](https://bitcoin.org/en/release/v0.14.0#final-alert).
+* **March 8, 2017**: Bitcoin Core 0.14 released with hard-coded [final alert](https://bitcoin.org/en/release/v0.14.0#final-alert).
+* **May 1, 2017**: Postpone release date of Alert key. Older clients may contain Alert handling code which is exploitable using the alert key, therefore the public release of the key has been temporarily postponed until considered safe.
+
 
 ## Summary
 
@@ -51,7 +53,7 @@ receive the final alert.
 |Pre-final Alert Posts|Posts on Bitcoin.org, various forums, and various mailing lists that the Alert system will be retired|2016-11-01|
 |Pre-final Alert|The alert itself warning that the Alert system will be retired|2016-11-02|
 |Final Alert|Max sequence Alert to disable the Alert system|2017-01-19|
-|Alert key released|The Alert key will be made publicly available|Older clients may contain Alert handling code which is exploitable using the alert key, therefore the public release of the key has been temporarily postponed until considered safe.|
+|Alert key release|The Alert key will be made publicly available|Postponed until further notice.|
 
 ## Software without the Alert system
 

--- a/_alerts/2016-11-01-alert-retirement.md
+++ b/_alerts/2016-11-01-alert-retirement.md
@@ -51,7 +51,7 @@ receive the final alert.
 |Pre-final Alert Posts|Posts on Bitcoin.org, various forums, and various mailing lists that the Alert system will be retired|2016-11-01|
 |Pre-final Alert|The alert itself warning that the Alert system will be retired|2016-11-02|
 |Final Alert|Max sequence Alert to disable the Alert system|2017-01-19|
-|Alert key released|The Alert key will be made publicly available|1-2 months after the Final Alert|
+|Alert key released|The Alert key will be made publicly available|Older clients may contain Alert handling code which is exploitable using the alert key, therefore the public release of the key has been temporarily postponed until considered safe.|
 
 ## Software without the Alert system
 


### PR DESCRIPTION
If there is a known date for the alert key being published, I'm happy to add that too.
The date column states "_1-2 months after the Final Alert_" which has already passed. :-/