### PR TITLE
Gemfile.lock: Add Ruby Version and Bundle Info

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,3 +80,9 @@ DEPENDENCIES
   kramdown
   less (= 2.4.0)
   therubyracer
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.7


### PR DESCRIPTION
This adds Ruby Version and Bundle Info to `Gemfile.lock` and will be
merged once tests pass.