### PR TITLE
Wallets: show up to 14 wallets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ pre-build-tests-fast: check-for-non-ascii-urls check-for-wrong-filename-assignme
     check-for-missing-copyright-licenses \
     check-bundle \
     check-for-english-in-en-dir \
-    check-for-consistent-bitcoin-core-titles
+    check-for-consistent-bitcoin-core-titles \
+    check-for-too-many-wallets-on-one-platform
+
 
 ## Post-build tests which, aggregated together, take less than 10 seconds to run on a typical PC
 post-build-tests-fast: check-for-build-errors ensure-each-svg-has-a-png check-for-liquid-errors \
@@ -259,7 +261,7 @@ check-bundle:
 ## Ensure all the dependencies are installed. If you build without this
 ## check, you'll get confusing error messages when your deps aren't up
 ## to date
-	$S ! bundle check | grep -v "The Gemfile's dependencies are satisfied"
+	$S ! bundle check | egrep -v "(Resolving dependencies...|The Gemfile's dependencies are satisfied)"
 
 travis-background-keepalive:
 	$S { while ps aux | grep -q '[m]ake' ; do echo "Ignore me: Travis CI keep alive" ; sleep 1m ; done ; } &
@@ -284,3 +286,10 @@ check-for-consistent-bitcoin-core-titles:
 ## Ensure all page titles in the en/bitcoin-core/ hierarchy mention
 ## Bitcoin Core
 	$S grep -r -L '^title:.*Bitcoin Core' en/bitcoin-core/ | eval $(ERROR_ON_OUTPUT)
+
+check-for-too-many-wallets-on-one-platform:
+	$S for platform in desktop windows mac linux mobile android ios blackberry windowsphone web hardware \
+	   ; do count=$$( grep -c "compat:.*$$platform" _templates/choose-your-wallet.html ) \
+	   ; if [ $$count -gt 14 ] \
+	   ; then echo "ERROR: too many wallets in $$platform platform.  Remove one or change layout" \
+	   ; fi ; done

--- a/_less/screen.less
+++ b/_less/screen.less
@@ -1694,7 +1694,7 @@ button.active {
 }
 
 .wallets{
-	width:605px;
+	width:705px;
 	height:250px;
 	text-align:left;
 	position:relative;
@@ -1714,7 +1714,7 @@ button.active {
 	vertical-align:top;
 	font-size:16px;
 }
-.wallets>div:nth-child(1n+13){
+.wallets>div:nth-child(1n+15){
 	display:none;
 }
 .wallets>div>a{

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -116,7 +116,7 @@ wallets:
 - electrum:
     title: "Electrum"
     titleshort: "Electrum"
-    compat: "desktop windows mac linux android"
+    compat: "desktop windows mac linux mobile android"
     level: 2
     platform:
       desktop:
@@ -139,7 +139,7 @@ wallets:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosurecentralized"
           privacynetwork: "checkpassprivacynetworksupporttorproxy"
-      android:
+      mobile:
         text: "walletelectrum"
         link: "https://play.google.com/store/apps/details?id=org.electrum.electrum"
         source: "https://github.com/spesmilo/electrum"

--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -116,7 +116,7 @@ wallets:
 - electrum:
     title: "Electrum"
     titleshort: "Electrum"
-    compat: "desktop windows mac linux"
+    compat: "desktop windows mac linux android"
     level: 2
     platform:
       desktop:
@@ -803,7 +803,7 @@ wallets:
 - coinspace:
     title: "Coin.Space"
     titleshort: "Coin.Space"
-    compat: "mobile web android windowsphone"
+    compat: "mobile web android windowsphone ios"
     level: 3
     platform:
       mobile:
@@ -1215,7 +1215,7 @@ wallets:
   <span></span>
   <div>
     <h2>{{ wallet[1].title }}</h2>
-    <div>{% for os in platform.os %}<img src="/img/os/{{ os }}.png" alt="{% translate platform{{os}} %}" title="{% translate platform{{os}} %}" />{% endfor %}</div>
+    <div>{% for os in platform.os %}<img src="/img/os/{{ os }}.png" alt="{% translate platform{{os}} %}" title="{% translate platform{{os}} %}" />{% unless wallet[1].compat contains os %}{% die platform not listed in compat field %}{% endunless %}{% endfor %}</div>
     <div>{% if platform.link == 'bitcoincore' %}<a href="/{{ page.lang }}/{% translate download url %}">{% translate walletdownload %}</a>{% elsif platform.link contains 'play.google.com' or platform.link contains 'itunes.apple.com' or platform.link contains 'chrome.google.com' %}<a href="{{ platform.link }}">{% translate walletdownload %}</a>{% else %}<a href="{{ platform.link }}">{% translate walletvisit %}</a>{% endif %}{% if platform.source %}<a href="{{ platform.source }}">{% translate walletsourcecode %}</a>{% endif %}</div>
     <div ontouchstart="walletScoreListener(event);" onclick="walletScoreListener(event);">
       {% for check in platform.check %}{% if check[0] == 'privacy' and platform.privacycheck %}


### PR DESCRIPTION
Closes #1569

Preview: http://dg0.dtrt.org/en/choose-your-wallet

This uses @Mirobit's suggestion from the above issue to expand the display to show up to 14 wallets at a time, which is the maximum number of entries we have in any category except for the main page (which contais 18 wallets).

![2017-05-09-15_08_33_610912063](https://cloud.githubusercontent.com/assets/61096/25868014/719694ae-34c9-11e7-8e24-484cee79f61f.png)

I've tested on Firefox 45 ESR for Linux, Chromium for Linux, and Chrome for Android.  Testing on other browsers appreciated.

In addition, wallet additions made after this PR is merged will cause a test to fail if any category begins to contain more than 14 wallets.  That way we shouldn't be surprised by wallets not being shown in the future.  We can discuss what to do about the problem then.

As part of the above, I made minor fixes to the entries for Electrum and Coin.Space that caused not all of their information to be displayed all of the time.  I added setting up JSON schema checker to my low-priority todo list so we can catch more of these sort of problems with automated testing in the future.