### PR TITLE
Wallets: fix accidental wallet hiding on category change

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -389,6 +389,7 @@ function walletListener(e) {
       if (isMobile()) {
         var p = document.getElementById('walletsmobile');
         t = t.cloneNode(true);
+        t.id = 'inline_wallet_box';
         p.innerHTML = '';
         p.appendChild(t);
         scrollToNode(p);
@@ -467,6 +468,7 @@ function walletShowPlatform(platform) {
         for (var i = 0, nds = document.getElementById('walletsswitch').childNodes, n = nds.length; i < n; i++) {
           if (nds[i].nodeType !== 1) continue;
           var id = nds[i].id.split('-')[1];
+          // for wallets with multiple listings, only show one instance per view
           if (document.getElementById('wallet-' + id)) continue;
           var nd = null;
           for (var ii = 0, nn = platforms.length; ii < nn; ii++) {


### PR DESCRIPTION
Closes #1493

Preview: http://dg1.dtrt.org/en/choose-your-wallet

Currently when you load the page in a mobile browser and click on a wallet, a copy of that that wallet's entry is copied using JS to a box later in the page where you can read about the wallet details.  When you change platform, all the currently displayed wallet icons are cleared and then refilled with the icons for the newly-selected platform, with a check running that ensure each wallet is only displayed once (which is important for combination categories such as "mobile" where we don't want to show the same wallet twice just because it has an Android and iOS version).

Since the wallet details box in the mobile display wasn't cleared when you changed platform, the check that prevents duplicate wallet displays thought that wallet had already been included in the listing and so prevented it from being displayed again.

This patch fixes the problem by giving the copy of the wallet entry that goes in the wallet details box its own id, which seems to have resolved the issue and has no side effects I've seen.

I've tested on Firefox 45 ESR for Linux and Chromium for Linux, both in mobile view, and on Chrome for Android on a device.  More testing always welcome.

Thanks to @crwatkins who first reported this issue.