### PR TITLE
Add BitVol to Resources/Charts

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -60,6 +60,7 @@ id: resources
     <p><a href="https://bitcoincharts.com/charts/">Bitcoincharts.com</a></p>
     <p><a href="https://gobitcoin.io/{% if 'en,fr,de,it,es' contains page.lang %}{{ page.lang }}/{% endif %}">GoBitcoin.io</a></p>
     <p><a href="https://bitcoinaverage.com/{% if 'en,fr,de,it,es,pl,ru,ht,pt,tr,uk' contains page.lang %}{{ page.lang }}/bitcoin-price/btc-to-usd{% endif %}">BitcoinAverage</a></p>
+    <p><a href="https://bitvol.info/">Bitcoin Volatility Index</a></p>
   </div>
 </div>
 <div>


### PR DESCRIPTION
Hello.

I think this website would be an useful addition for the Charts page. It calculates the [historical volatility](http://www.ivolatility.com/help/2.html) of the Bitcoin price using the [Coindesk API](http://www.coindesk.com/api/) (which will change to BitcoinAverage soon && more features will be added). Volatility is a very important metric as Bitcoin is slowing moving towards stability that can be seen in traditional fiat currencies, and was used as an argument against Bitcoin in the past.

I would like to hear other people's input. Any suggestions for the [website ](https://bitvol.info)are also very welcome!