### PR TITLE
README: Add section, Earn Bitcoin for Contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Live site: [Bitcoin.org](https://bitcoin.org)
 
 Report problems or help improve the site by opening a [new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new) or [pull request](https://github.com/bitcoin-dot-org/bitcoin.org/compare).
 
+## Earn Bitcoin for Contributing
+Open issues [labeled with a "₿"](https://github.com/bitcoin-dot-org/bitcoin.org/labels/%E2%82%BF)
+have bounties on them. Viewing the issue will reveal the value of the bounty.
+Submit a pull request resolving the issue along with an accompanying note or
+comment containing a bitcoin address and automatically receive a payment in the
+amount of the bounty if it gets merged.
+
 ## How to Participate
 The following quick guides will help you get started:
 


### PR DESCRIPTION
This adds a section to the repository README letting people know it's now possible to earn bitcoin in some cases and get paid for making contributions to Bitcoin.org. In particular, I'm testing this out with some issues that have been open for over a year, and some other small ones that no one has stepped up to resolve.

These open issues are [labeled with a "₿"](https://github.com/bitcoin-dot-org/bitcoin.org/labels/%E2%82%BF), which means that they now have bounties on them. Anyone can submit a pull request resolving the issue along with an accompanying note or comment containing a bitcoin address to automatically receive a payment in the amount of the bounty if it gets merged.

This is an important experiment to run, because it will enable Bitcoin.org to potentially:
- Knock out some stale issues that have been open for a while that no one has resolved.
- Gather valuable insight on if paying bounties is beneficial to the project, and if larger bounties for more elaborate/extensive tasks might make sense (or alternatively, if it might be better to experiment with hiring people outright and pay them an hourly rate, which would be much more expensive than paying bounties, and we have a limited contributor compensation budget at the moment)
- Be more competitive with other Bitcoin websites that are spreading misinformation and have been gaining traffic in recent months because they are paying contributors for one-off tasks to enhance them

This will be merged once tests pass.

I've opened [issue #1606](https://github.com/bitcoin-dot-org/bitcoin.org/issues/1606) as a place where we can collaborate on this experiment, as well as other ways we can compensate contributors under the goal of making the site as awesome as it can be.