### PR TITLE
README: Change Bitcoin Symbol to 'Bounty'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Live site: [Bitcoin.org](https://bitcoin.org)
 Report problems or help improve the site by opening a [new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new) or [pull request](https://github.com/bitcoin-dot-org/bitcoin.org/compare).
 
 ## Earn Bitcoin for Contributing
-Open issues [labeled with a "₿"](https://github.com/bitcoin-dot-org/bitcoin.org/labels/%E2%82%BF)
+Open issues [labeled with "Bounty"](https://github.com/bitcoin-dot-org/bitcoin.org/labels/Bounty)
 have bounties on them. Viewing the issue will reveal the value of the bounty.
 Submit a pull request resolving the issue along with an accompanying note or
 comment containing a bitcoin address and automatically receive a payment in the


### PR DESCRIPTION
This updates the Bitcoin symbol to "Bounty" based on [feedback from achow101](https://github.com/bitcoin-dot-org/bitcoin.org/issues/1606#issuecomment-302941982) and will be merged once tests pass.

cc: @achow101