### PR TITLE
Events plugin: stop requesting events from Meetup.com

### DIFF
--- a/_plugins/events.rb
+++ b/_plugins/events.rb
@@ -1,8 +1,8 @@
 # This file is licensed under the MIT License (MIT) available on
 # http://opensource.org/licenses/MIT.
 
-#events.rb set site.conferences and site.meetups arrays based
-#on events in _events/ and meetups on bitcoin.meetups.com .
+#events.rb sets the site.conferences array based
+#on events in _events/
 #This is later used to populate the events map and display the
 #list in chronological order, in the RSS file and events pages.
 
@@ -15,83 +15,6 @@ require 'cgi'
 module Jekyll
 
   class EventPageGenerator < Generator
-
-    def meetups
-      meetups = []
-      # Call Meetup API with a key-signed request
-      begin
-        data = JSON.parse(open("http://api.meetup.com/2/open_events?omit=description&status=upcoming&radius=25.0&topic=bitcoin&and_text=False&limited_events=False&desc=False&offset=0&format=json&page=500&time=0m%2C3m&sig_id=133622112&sig=cd874bc2c84f96d989f823880889bda2f5e4cdc5","User-Agent"=>"Ruby/#{RUBY_VERSION}").read)
-      # Prevent any error to stop the build process, return an empty array instead
-      rescue
-        print 'Meetup API Call Failed!'
-        return meetups
-      end
-      if !data.is_a?(Hash) or !data.has_key?('results') or !data['results'].is_a?(Array)
-        print 'Meetup API Call Failed!'
-        return meetups
-      end
-      if data['results'].length > 1000
-        print 'Meetup API exceeding the 1000 results limit!'
-        return meetups
-      end
-      # Loop in returned results array
-      for m in data['results']
-        # Skip meetups with incomplete data
-        next if !m.has_key?('time') or ( !m['time'].is_a?(String) and !m['time'].is_a?(Integer) and !m['time'].is_a?(Float) )
-        next if !m.has_key?('utc_offset') or ( !m['utc_offset'].is_a?(String) and !m['utc_offset'].is_a?(Integer) and !m['utc_offset'].is_a?(Float) )
-        next if !m.has_key?('group') or !m['group'].is_a?(Hash)
-        next if !m['group'].has_key?('name') or ( !m['group']['name'].is_a?(String) and !m['group']['name'].is_a?(Integer) and !m['group']['name'].is_a?(Float) )
-        next if !m.has_key?('venue') or !m['venue'].is_a?(Hash)
-        next if !m['venue'].has_key?('name') or ( !m['venue']['name'].is_a?(String) and !m['venue']['name'].is_a?(Integer) and !m['venue']['name'].is_a?(Float) )
-        next if !m['venue'].has_key?('address_1') or ( !m['venue']['address_1'].is_a?(String) and !m['venue']['address_1'].is_a?(Integer) and !m['venue']['address_1'].is_a?(Float) )
-        next if !m['venue'].has_key?('city') or ( !m['venue']['city'].is_a?(String) and !m['venue']['city'].is_a?(Integer) and !m['venue']['city'].is_a?(Float) )
-        next if !m['venue'].has_key?('country') or ( !m['venue']['country'].is_a?(String) and !m['venue']['country'].is_a?(Integer) and !m['venue']['country'].is_a?(Float) )
-        next if !m['venue'].has_key?('lat') or ( !m['venue']['lat'].is_a?(String) and !m['venue']['lat'].is_a?(Integer) and !m['venue']['lat'].is_a?(Float) )
-        next if !m['venue'].has_key?('lon') or ( !m['venue']['lon'].is_a?(String) and !m['venue']['lon'].is_a?(Integer) and !m['venue']['lon'].is_a?(Float) )
-        next if !m.has_key?('event_url') or ( !m['event_url'].is_a?(String) and !m['event_url'].is_a?(Integer) and !m['event_url'].is_a?(Float) )
-        # Assign variables
-        time = m['time'].to_s
-        utcoffset = m['utc_offset'].to_s
-        title = m['group']['name'].to_s
-        venue = m['venue']['name'].to_s
-        address = m['venue']['address_1'].to_s
-        city = m['venue']['city'].to_s
-        country = m['venue']['country'].to_s
-        link = m['event_url'].to_s
-        lat = m['venue']['lat'].to_s
-        lon = m['venue']['lon'].to_s
-        # Skip meetups with malformed data
-        next if !/^[0-9]{1,15}$/.match(time)
-        next if !/^-?[0-9]{1,10}$/.match(utcoffset)
-        next if !/^.{1,150}$/.match(title)
-        next if !/^.{1,150}$/.match(venue)
-        next if !/^.{1,150}$/.match(address)
-        next if !/^.{1,150}$/.match(city)
-        next if !/^[a-zA-Z]{2}$/.match(country)
-        next if !/^http:\/\/www.meetup.com\/.{1,150}$/.match(link)
-        next if !/^-?[0-9]{1,2}(\.[0-9]{1,15})?$/.match(lat) or ( lat.to_f < -90 and lat.to_f > 90 )
-        next if !/^-?[0-9]{1,3}(\.[0-9]{1,15})?$/.match(lon) or ( lon.to_f < -180 and lon.to_f > 180 )
-        next if lon.to_f == 0 and lat.to_f == 0
-	# Ignore events that don't mention "Bitcoin" in their title
-        next if !/bitcoin/i.match(title)
-        # Format variables
-        time = Time.at((time.to_i + utcoffset.to_i) / 1000)
-        time.utc
-        date = time.year.to_s + '-' + time.month.to_s.rjust(2,'0') + '-' + time.day.to_s.rjust(2,'0')
-        country = country.upcase
-        geoloc = {'lat' => lat, 'lon' => lon}
-        # Use address_2 and state when available
-        if m['venue'].has_key?('address_2') and ( m['venue']['address_2'].is_a?(String) or m['venue']['address_2'].is_a?(Integer) or m['venue']['address_2'].is_a?(Float) ) and /^.{1,150}$/.match(m['venue']['address_2'].to_s)
-          address = address + ' ' + m['venue']['address_2'].to_s
-        end
-        if m['venue'].has_key?('state') and ( m['venue']['state'].is_a?(String) or m['venue']['state'].is_a?(Integer) or m['venue']['state'].is_a?(Float) ) and /^.{1,150}$/.match(m['venue']['state'].to_s)
-          city = city + ', ' + m['venue']['state'].to_s
-        end
-        # Populate meetups array
-        meetups.push({'date' => date, 'title' => title, 'venue' => venue, 'address' => address, 'city' => city, 'country' => country, 'link' => link, 'geoloc' => geoloc})
-      end
-      return meetups
-    end
 
     def conferences
       conferences = []
@@ -120,21 +43,19 @@ module Jekyll
     def generate(site)
       # Set site.meetups and site.conferences global variables for liquid/jekyll
       class << site
-        attr_accessor :meetups, :conferences
+        attr_accessor :conferences
         alias event_site_payload site_payload
         def site_payload
           h = event_site_payload
           payload = h["site"]
-          payload["meetups"] = self.meetups
           payload["conferences"] = self.conferences
           h["site"] = payload
           h
         end
       end
 
-      # Set site.conferences and site.meetups arrays
+      # Set site.conferences array
       site.conferences = {}
-      site.meetups = {}
 
       #Do nothing if plugin is disabled
       if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('events').nil?
@@ -169,28 +90,6 @@ module Jekyll
       else
         File.open(conferences_cache,'r') do |file|
           site.conferences = Marshal.load(file)
-        end
-      end
-
-      # Populate site.meetups with data from Meetup.com.  Store data in
-      # the cache and only re-retrieve the data if 86,400 seconds (24
-      # hours) passes from the retrieval date or if the cache file is
-      # deleted.
-      meetups_cache = '_cache/meetups.marshall'
-      if File.exists?(meetups_cache)
-        meetups_cache_age = (Time.now - File.stat(meetups_cache).mtime).to_i
-      else
-        meetups_cache_age = Time.now.to_i
-      end
-
-      if meetups_cache_age > 86400
-        site.meetups = meetups()
-        File.open(meetups_cache,'w') do |file|
-          Marshal.dump(site.meetups, file)
-        end
-      else
-        File.open(meetups_cache,'r') do |file|
-          site.meetups = Marshal.load(file)
         end
       end
 

--- a/_templates/events.html
+++ b/_templates/events.html
@@ -6,7 +6,6 @@ layout: base
 id: events
 ---
 {% assign date_sorted_conferences = site.conferences | sort: 'date' %}
-{% assign date_sorted_meetups = site.meetups | sort: 'date' %}
 <!-- Note: this file is built non-deterministically -->
 <link rel="alternate" type="application/rss+xml" href="/en/rss/events.rss" title="Bitcoin conferences and events">
 <h1>{% translate pagetitle %}<a type="application/rss+xml" href="/en/rss/events.rss"><img src="/img/icons/icon_rss.svg" alt="rss" class="rssicon"></a></h1>
@@ -21,10 +20,6 @@ id: events
 <div id="eventdata" class="eventdata">
 
 {% for p in date_sorted_conferences %}{% if p.geoloc %}
-<div data-lat="{{ p.geoloc.lat }}" data-lon="{{ p.geoloc.lon }}"><b><a href="{{ p.link | htmlescape }}">{{ p.title | htmlescape }}</a></b><br>{{ p.date }}<br>{{ p.venue | htmlescape }}<br>{{ p.address | htmlescape }}<br>{{ p.city | htmlescape }}, {{ p.country | htmlescape }}</div>
-{% endif %}{% endfor %}
-
-{% for p in date_sorted_meetups %}{% if p.geoloc %}
 <div data-lat="{{ p.geoloc.lat }}" data-lon="{{ p.geoloc.lon }}"><b><a href="{{ p.link | htmlescape }}">{{ p.title | htmlescape }}</a></b><br>{{ p.date }}<br>{{ p.venue | htmlescape }}<br>{{ p.address | htmlescape }}<br>{{ p.city | htmlescape }}, {{ p.country | htmlescape }}</div>
 {% endif %}{% endfor %}
 

--- a/docs/adding-events-release-notes-and-alerts.md
+++ b/docs/adding-events-release-notes-and-alerts.md
@@ -2,9 +2,7 @@
 
 ### Events
 
-If you're not comfortable with GitHub pull requests, please submit an
-event using the button near the bottom of the [Events
-page](https://bitcoin.org/en/events).
+If you're not comfortable with GitHub pull requests, please open a [new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?title=New%20event&body=%20%20%20%20-%20date%3A%20YYYY-MM-DD%0A%20%20%20%20%20%20title%3A%20%22%22%0A%20%20%20%20%20%20venue%3A%20%22%22%0A%20%20%20%20%20%20address%3A%20%22%22%0A%20%20%20%20%20%20city%3A%20%22%22%0A%20%20%20%20%20%20country%3A%20%22%22%0A%20%20%20%20%20%20link%3A%20%22%22).
 
 To create an event pull request, place the event in `_events.yml` and adhere to
 this format:
@@ -18,11 +16,6 @@ this format:
   country: "United States"
   link: "http://texasbitcoinconference.com/"
 ```
-
-Events that have a [Meetup.com](http://www.meetup.com/) page with a
-publicly-viewable address and "Bitcoin" in the event title should
-already be displayed on the [events page](https://bitcoin.org/en/events).
-(Please open a [new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?title=New%20event&body=%20%20%20%20-%20date%3A%20YYYY-MM-DD%0A%20%20%20%20%20%20title%3A%20%22%22%0A%20%20%20%20%20%20venue%3A%20%22%22%0A%20%20%20%20%20%20address%3A%20%22%22%0A%20%20%20%20%20%20city%3A%20%22%22%0A%20%20%20%20%20%20country%3A%20%22%22%0A%20%20%20%20%20%20link%3A%20%22%22) if a Bitcoin meetup event isn't displayed.)
 
 ### Release Notes
 

--- a/docs/setting-up-your-environment.md
+++ b/docs/setting-up-your-environment.md
@@ -152,7 +152,7 @@ Plugins include:
 | alerts       | 5       | --             | Network alert pages
 | autocrossref | 90      | --             | Developer documentation
 | contributors | 5       | GitHub.com     | Contributor listings
-| events       | 5       | Meetup.com; Google Maps | Events page
+| events       | 5       | Google Maps    | Events page
 | glossary     | 30      | --             | Developer glossary
 | redirects    | 20      | --             | Redirects from old URLs
 | releases     | 10      | --             | Bitcoin Core release notes; Download


### PR DESCRIPTION
Closes #1617 

In testing, the only rendered HTML changes to the site were three fewer lines of whitespace per rendered translation of the Events page.

I also checked the Events RSS feed and it appeared that we never included any Meetups information in it, so no changes were required there.