### PR TITLE
Add subtractfeeamount parameter

### DIFF
--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/fundrawtransaction.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/fundrawtransaction.md
@@ -70,6 +70,14 @@ All existing inputs must have their previous output transaction be in the wallet
   p: "Optional<br>(0 or 1)"
   d: "A json array of integers. The fee will be equally deducted from the amount of each specified output. The outputs are specified by their zero-based index, before any change output is added."
 
+- n: "→ →<br>Output index"
+  t: numeric (int)
+  p: Optional<br>(0 or more)
+  d: "A output index number (vout) from which the fee should be subtracted.
+  If multiple vouts are provided, the total fee will be divided by the
+  numer of vouts listed and each vout will have that amount subtracted
+  from it"
+
 {% enditemplate %}
 
 *Result---information about the created transaction*

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendmany.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendmany.md
@@ -61,8 +61,12 @@ The `sendmany` RPC {{summary_sendMany}}
 - n: "Subtract Fee From Amount"
   t: "array"
   p: "Optional<br>(0 or 1)"
-  d: "The fee will be equally deducted from the amount of each selected address. Those recipients will receive less bitcoins than you enter in their corresponding amount field. If no addresses are specified here, the sender pays the fee."
+  d: "An array of addresses.  The fee will be equally divided by as many addresses as are entries in this array and subtracted from each address.  If this array is empty or not provided, the fee will be paid by the sender"
   
+- n: "→<br>Address"
+  t: "string (base58)"
+  p: "Optional (0 or more)"
+  d: "An address previously listed as one of the recipients."
 {% enditemplate %}
 
 *Result---a TXID of the sent transaction*

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendmany.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendmany.md
@@ -55,6 +55,16 @@ The `sendmany` RPC {{summary_sendMany}}
 
 {% enditemplate %}
 
+*Parameter #5---automatic fee subtraction
+
+{% itemplate ntpd1 %}
+- n: "Subtract Fee From Amount"
+  t: "boolean"
+  p: "Optional<br>(0 or 1)"
+  d: "The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. Default is false"
+  
+{% enditemplate %}
+
 *Result---a TXID of the sent transaction*
 
 {% itemplate ntpd1 %}

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendmany.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendmany.md
@@ -55,7 +55,7 @@ The `sendmany` RPC {{summary_sendMany}}
 
 {% enditemplate %}
 
-*Parameter #5---automatic fee subtraction
+*Parameter #5---automatic fee subtraction*
 
 {% itemplate ntpd1 %}
 - n: "Subtract Fee From Amount"

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendmany.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendmany.md
@@ -59,9 +59,9 @@ The `sendmany` RPC {{summary_sendMany}}
 
 {% itemplate ntpd1 %}
 - n: "Subtract Fee From Amount"
-  t: "boolean"
+  t: "array"
   p: "Optional<br>(0 or 1)"
-  d: "The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. Default is false"
+  d: "The fee will be equally deducted from the amount of each selected address. Those recipients will receive less bitcoins than you enter in their corresponding amount field. If no addresses are specified here, the sender pays the fee."
   
 {% enditemplate %}
 

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendtoaddress.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendtoaddress.md
@@ -56,7 +56,7 @@ The `sendtoaddress` RPC {{summary_sendToAddress}}
 
 {% enditemplate %}
 
-*Parameter #5---automatic fee subtraction
+*Parameter #5---automatic fee subtraction*
 
 {% itemplate ntpd1 %}
 - n: "Subtract Fee From Amount"

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendtoaddress.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendtoaddress.md
@@ -62,7 +62,7 @@ The `sendtoaddress` RPC {{summary_sendToAddress}}
 - n: "Subtract Fee From Amount"
   t: "boolean"
   p: "Optional<br>(0 or 1)"
-  d: "The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. Default is false"
+  d: "The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. Default is `false`"
   
 {% enditemplate %}
 

--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendtoaddress.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/sendtoaddress.md
@@ -56,6 +56,16 @@ The `sendtoaddress` RPC {{summary_sendToAddress}}
 
 {% enditemplate %}
 
+*Parameter #5---automatic fee subtraction
+
+{% itemplate ntpd1 %}
+- n: "Subtract Fee From Amount"
+  t: "boolean"
+  p: "Optional<br>(0 or 1)"
+  d: "The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. Default is false"
+  
+{% enditemplate %}
+
 *Result---a TXID of the sent transaction*
 
 {% itemplate ntpd1 %}
@@ -63,7 +73,7 @@ The `sendtoaddress` RPC {{summary_sendToAddress}}
   t: "string"
   p: "Required<br>(exactly 1)"
   d: "The TXID of the sent transaction, encoded as hex in RPC byte order"
-
+  
 {% enditemplate %}
 
 *Example from Bitcoin Core 0.10.0*


### PR DESCRIPTION
Functionality was merged into Bitcoin Core in March '15 which I think is Bitcoin Core 0.10.1?

Here it is in the latest version: https://github.com/bitcoin/bitcoin/blob/e4918316d80f0541189c40039095c716a09d636e/src/wallet/rpcwallet.cpp#L403