### PR TITLE
Change Coinomi wallet link to solve issue #1622

### DIFF
--- a/_templates/choose-your-wallet.html
+++ b/_templates/choose-your-wallet.html
@@ -740,7 +740,7 @@ wallets:
     platform:
       mobile:
         text: "walletcoinomi"
-        link: "https://play.google.com/store/apps/details?id=com.coinomi.wallet"
+        link: "https://github.com/Coinomi/coinomi-android/releases"
         source: "https://github.com/Coinomi"
         screenshot: "coinomiwalletandroid.png"
         os:
@@ -748,7 +748,7 @@ wallets:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
-          transparency: "checkfailtransparencyclosedsource"
+          transparency: "checkpasstransparencyopensource"
           environment: "checkpassenvironmentmobile"
           privacy: "checkpassprivacybasic"
           fees: "checkpassfeecontroldynamic"
@@ -758,7 +758,7 @@ wallets:
           privacynetwork: "checkfailprivacynetworknosupporttor"
       android:
         text: "walletcoinomi"
-        link: "https://play.google.com/store/apps/details?id=com.coinomi.wallet"
+        link: "https://github.com/Coinomi/coinomi-android/releases"
         source: "https://github.com/Coinomi/coinomi-android"
         screenshot: "coinomiwalletandroid.png"
         os:
@@ -766,7 +766,7 @@ wallets:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
-          transparency: "checkfailtransparencyclosedsource"
+          transparency: "checkpasstransparencyopensource"
           environment: "checkpassenvironmentmobile"
           privacy: "checkpassprivacybasic"
           fees: "checkpassfeecontroldynamic"


### PR DESCRIPTION
As the policy of Bitcoin.org does not allow closed source
wallets that allow user private key access, we are changing
the link for the Coinomi Android wallet to point to the
Github release page, that contains the latest open source
version along with the necessary source code.

Additionally we revert the transparency to "checkpasstransparencyopensource"
as the source code is available from the same site.