### PR TITLE
Make preview charset fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ default: clean build
 
 ## `make preview`: start the built-in Jekyll preview
 preview: clean
-	$S bundle exec jekyll serve --incremental
+	$S export LANG=C.UTF-8 ; bundle exec jekyll serve --incremental
 
 ## `make test`: don't build, but do run all tests
 test: pre-build-tests post-build-tests


### PR DESCRIPTION
Since the incremental build (#1643) update "make preview" leads to the following error:
` Conversion error: Jekyll::Converters::Scss encountered an error while converting 'css/main.scss':
                    Invalid US-ASCII character "\xE2" on line 2427
jekyll 3.0.1 | Error:  Invalid US-ASCII character "\xE2" on line 2427
`
I don't know if this is the best solution but it fixes the error.