### PR TITLE
Add description to releases rss feed

### DIFF
--- a/en/rss/releases.rss
+++ b/en/rss/releases.rss
@@ -27,6 +27,9 @@ lang: en
             <pubDate>{{ site.time | date: "%a, %d %b %Y" }} 00:00:00 GMT</pubDate>
             {% warn "This release doesn't have optional_date set" %}
           {% endif %}
+          {% if p.excerpt %}
+            <description><![CDATA[{{ p.excerpt }}]]></description>
+          {% endif %}
         </item>
 	{% endfor %}
 </channel>


### PR DESCRIPTION
This change adds `description` content to releases rss feed.

Closes #1163

If this is accepted, please pay the bounty to 1BzwBwPfrm2fQRaTzuNSCTWeXnF3jmcL7G