### PR TITLE
WIP: Add Docker Compose for local dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.0.0-onbuild
+
+EXPOSE 4000
+
+ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ default: clean build
 preview: clean
 	$S export LANG=C.UTF-8 ; bundle exec jekyll serve --incremental
 
+## `make preview-docker`: start the built-in Jekyll preview, with proper
+## host setting for running in Docker container
+preview-docker: clean
+	$S export LANG=C.UTF-8 ; bundle exec jekyll serve --incremental --watch -H 0.0.0.0
+
 ## `make test`: don't build, but do run all tests
 test: pre-build-tests post-build-tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3'
+version: "2"
+
 services:
   web:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  web:
+    build: .
+    command: preview-docker
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "4000:4000"

--- a/docs/setting-up-your-environment.md
+++ b/docs/setting-up-your-environment.md
@@ -188,3 +188,23 @@ before building you preview:
 You can also add this line to your `~/.bashrc` file if you frequently
 build site previews so that you don't have to remember to run it for
 each shell.
+
+## Alternative Local Environment Using Docker Compose
+
+Alternatively, you can run a local site using [Docker Compose](https://docs.docker.com/compose/):
+
+1. [Install Docker](https://docs.docker.com/engine/installation/).
+
+1. Ensure you checked out the site repository as described in [Working with GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/working-with-github.md). Then change directory to the top-level of your local repository (replace `bitcoin.org` with the full path to your local repository clone):
+
+   ```bash
+   cd bitcoin.org
+   ```
+
+1. Run the following:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+1. Visit http://localhost:4000/ in your browser to view the site.


### PR DESCRIPTION
This proposed change adds support for running the site locally simply by running `docker-compose up`, eliminating the need to install anything locally (except [Docker](https://www.docker.com/)).

Considering this a "work in progress", as I have only tested on a Mac. It _should_ work everywhere, but I don't want to assume. Any assistance with verifying on Windows/Linux would be much appreciated!

Please let me know if there is interest in this as a feature, and if I can provide more details/context.