### PR TITLE
Alerts: add warning for potential 2017-08-01 BIP148 split

### DIFF
--- a/_alerts/2017-07-12-disruptive-forks.md
+++ b/_alerts/2017-07-12-disruptive-forks.md
@@ -5,17 +5,20 @@
 title: "Potential disruptive chain forks"
 shorturl: "disruptive-forks"
 active: true
-banner: "Warning: Bitcoin may be unsafe to use on August 1st (click here for details)"
+banner: "Warning: Bitcoin may be unsafe to use starting July 31st (click here for details)"
 
 ## 7/12 to 7/28: "warning" (orange); 7/29 until resolution: "alert" (red)
 bannerclass: "warning"
 ---
-*Last updated: 2017-07-12 12:00 UTC.  This page will be updated when new
-information becomes available.  See the [list of updates][].*
+{% assign start='<span class="date">2017/08/01 00:00 UTC</span>' %}
 
-On 1 August 2017, Bitcoin confirmation scores may become unreliable for
+*Last updated: <span class="date">2017/07/12 12:00 UTC</span>.  This
+page will be updated when new information becomes available.  See the
+[list of updates][].*
+
+At {{start}}, Bitcoin confirmation scores may become unreliable for
 an unknown length of time.  This means that any bitcoins you receive
-after August 1st may disappear from your wallet at a later time or be a
+after that time may later disappear from your wallet or be a
 type of bitcoin that other people will not accept as payment.
 
 Once the situation is resolved, confirmation scores will either
@@ -25,7 +28,7 @@ return to using Bitcoin normally; in the later case, you will need to
 take extra steps in order to begin safely receiving bitcoins again.
 
 This post currently describes what actions you can take to prepare for
-this situation.  Subsequent to August 1st, we will update this post as
+this situation.  Subsequent to {{start}}, we will update this post as
 best we can with relevant information, but you are also advised to
 monitor other Bitcoin [news sites][] and [community resources][] for
 updates and to cross-check all information, as someone may attempt to
@@ -35,15 +38,15 @@ Remember that you alone are responsible for the safety of your bitcoins,
 and that if you lose control of them for any reason, there is nothing
 the operators or contributors to this website can do to help you.
 
-## Before August 1st
+## Preparation
 
 1. If you accept bitcoins as payments, we recommend that you stop
-accepting Bitcoin payments at least 12 hours before 00:00 UTC on August
-1st (24 to 48 hours may be safer).  This will give time for all pending
-payments to confirm on the Bitcoin block chain before the event.
+accepting Bitcoin payments at least 12 hours before {{start}}, although
+24 to 48 hours earlier may be safer.  This will give time for all
+pending payments to confirm on the Bitcoin block chain before the event.
 
 1. If you send bitcoins as payments, note that many services may stop
-accepting bitcoins at 00:00 UTC on August 1st or earlier.
+accepting bitcoins at {{start}} or earlier.
 
 1. Be wary of storing your bitcoins on an exchange or other third-party
 wallet.  If they accept transactions during the event, they could lose
@@ -51,9 +54,9 @@ money and will likely spread those loses across all their users.  If
 there end up being two or more competing versions of Bitcoin, then they
 may refuse to give you your bitcoins on versions they don't like.
 
-## On August 1st
+## During the event
 
-1. Do not trust any payments you receive after August 1st until the situation
+1. Do not trust any payments you receive after {{start}} until the situation
 is resolved.  No matter how many confirmations the new payment says it
 has, it can disappear from your wallet at any point up until the
 situation is resolved.
@@ -66,7 +69,7 @@ recovery if you attempt this.
 by "splitting" your coins.  Some of these offers may be scams, and
 software claiming to split your coins can also steal them.
 
-## After August 1st
+## After the event
 
 No information available yet.  Please wait for multiple trustworthy
 sources to state that the event is resolved before returning to normal
@@ -78,9 +81,24 @@ A [full history][] of this document is available.  The following points
 summarize major changes, with the most recent changes being listed
 first.
 
-- 2017-07-12 12:00 UTC: initial version.
+- <span class="date">2017/07/12 12:00 UTC</span>: initial version.
 
 [full history]: https://github.com/bitcoin-dot-org/bitcoin.org/commits/master/_alerts/2017-07-12-disruptive-forks.md
 [list of updates]: #document-history
 [news sites]: /en/resources#news
 [community resources]: /en/community
+
+<script src="/js/jquery/jquery-1.11.2.min.js"></script>
+<script>
+// Localize dates
+$(".date").each(function() {
+  // Try to parse the string as a date
+  epoch = Date.parse($(this).text());
+  // Only convert the string to localtime if it's a number
+  if (isNaN(epoch) == false) {
+    var utcdate=new Date(epoch);
+    var localedate = utcdate.toString();
+    $(this).text(localedate);
+  }
+});
+</script>

--- a/_alerts/2017-07-12-disruptive-forks.md
+++ b/_alerts/2017-07-12-disruptive-forks.md
@@ -48,11 +48,12 @@ pending payments to confirm on the Bitcoin block chain before the event.
 1. If you send bitcoins as payments, note that many services may stop
 accepting bitcoins at {{start}} or earlier.
 
-1. Be wary of storing your bitcoins on an exchange or other third-party
-wallet.  If they accept transactions during the event, they could lose
-money and will likely spread those loses across all their users.  If
-there end up being two or more competing versions of Bitcoin, then they
-may refuse to give you your bitcoins on versions they don't like.
+1. Be wary of storing your bitcoins on an exchange or any service that
+doesn't allow you to make a local backup copy of your private keys.  If
+they accept transactions during the event, they could lose money and
+will likely spread those loses across all their users.  If there end up
+being two or more competing versions of Bitcoin, then they may refuse to
+give you your bitcoins on versions they don't like.
 
 ## During the event
 

--- a/_alerts/2017-07-12-disruptive-forks.md
+++ b/_alerts/2017-07-12-disruptive-forks.md
@@ -1,0 +1,86 @@
+---
+## This file is licensed under the MIT License (MIT) available on
+## http://opensource.org/licenses/MIT.
+
+title: "Potential disruptive chain forks"
+shorturl: "disruptive-forks"
+active: true
+banner: "Warning: Bitcoin may be unsafe to use on August 1st (click here for details)"
+
+## 7/12 to 7/28: "warning" (orange); 7/29 until resolution: "alert" (red)
+bannerclass: "warning"
+---
+*Last updated: 2017-07-12 12:00 UTC.  This page will be updated when new
+information becomes available.  See the [list of updates][].*
+
+On 1 August 2017, Bitcoin confirmation scores may become unreliable for
+an unknown length of time.  This means that any bitcoins you receive
+after August 1st may disappear from your wallet at a later time or be a
+type of bitcoin that other people will not accept as payment.
+
+Once the situation is resolved, confirmation scores will either
+automatically return to their normal reliability or there will be two
+(or more) competing versions of Bitcoin.  In the former case, you may
+return to using Bitcoin normally; in the later case, you will need to
+take extra steps in order to begin safely receiving bitcoins again.
+
+This post currently describes what actions you can take to prepare for
+this situation.  Subsequent to August 1st, we will update this post as
+best we can with relevant information, but you are also advised to
+monitor other Bitcoin [news sites][] and [community resources][] for
+updates and to cross-check all information, as someone may attempt to
+spread false news in order to exploit the situation.
+
+Remember that you alone are responsible for the safety of your bitcoins,
+and that if you lose control of them for any reason, there is nothing
+the operators or contributors to this website can do to help you.
+
+## Before August 1st
+
+1. If you accept bitcoins as payments, we recommend that you stop
+accepting Bitcoin payments at least 12 hours before 00:00 UTC on August
+1st (24 to 48 hours may be safer).  This will give time for all pending
+payments to confirm on the Bitcoin block chain before the event.
+
+1. If you send bitcoins as payments, note that many services may stop
+accepting bitcoins at 00:00 UTC on August 1st or earlier.
+
+1. Be wary of storing your bitcoins on an exchange or other third-party
+wallet.  If they accept transactions during the event, they could lose
+money and will likely spread those loses across all their users.  If
+there end up being two or more competing versions of Bitcoin, then they
+may refuse to give you your bitcoins on versions they don't like.
+
+## On August 1st
+
+1. Do not trust any payments you receive after August 1st until the situation
+is resolved.  No matter how many confirmations the new payment says it
+has, it can disappear from your wallet at any point up until the
+situation is resolved.
+
+1. Try not to send any payments.  Although you should not technically be
+able to lose money this way, wallets may become confused and require
+recovery if you attempt this.
+
+1. Be wary of offers to allow you to invest in the outcome of the event
+by "splitting" your coins.  Some of these offers may be scams, and
+software claiming to split your coins can also steal them.
+
+## After August 1st
+
+No information available yet.  Please wait for multiple trustworthy
+sources to state that the event is resolved before returning to normal
+Bitcoin use.
+
+## Document history
+
+A [full history][] of this document is available.  The following points
+summarize major changes, with the most recent changes being listed
+first.
+
+- 2017-07-12 12:00 UTC: initial version.
+
+[full history]: https://github.com/bitcoin-dot-org/bitcoin.org/commits/master/_alerts/2017-07-12-disruptive-forks.md
+[list of updates]: #document-history
+[news sites]: /en/resources#news
+[community resources]: /en/community

--- a/_alerts/2017-07-12-potential-split.md
+++ b/_alerts/2017-07-12-potential-split.md
@@ -2,8 +2,8 @@
 ## This file is licensed under the MIT License (MIT) available on
 ## http://opensource.org/licenses/MIT.
 
-title: "Potential disruptive chain forks"
-shorturl: "disruptive-forks"
+title: "Potential disruptive chain split"
+shorturl: "potential-split"
 active: true
 banner: "Warning: Bitcoin may be unsafe to use starting July 31st (click here for details)"
 
@@ -84,7 +84,7 @@ first.
 
 - <span class="date">2017/07/12 12:00 UTC</span>: initial version.
 
-[full history]: https://github.com/bitcoin-dot-org/bitcoin.org/commits/master/_alerts/2017-07-12-disruptive-forks.md
+[full history]: https://github.com/bitcoin-dot-org/bitcoin.org/commits/master/_alerts/2017-07-12-potential-split.md
 [list of updates]: #document-history
 [news sites]: /en/resources#news
 [community resources]: /en/community

--- a/_alerts/2017-07-12-potential-split.md
+++ b/_alerts/2017-07-12-potential-split.md
@@ -72,9 +72,9 @@ software claiming to split your coins can also steal them.
 
 ## After the event
 
-No information available yet.  Please wait for multiple trustworthy
-sources to state that the event is resolved before returning to normal
-Bitcoin use.
+We will update this section with more information after {{start}}.
+Please wait until multiple news sources that you trust have stated that
+the event is resolved before returning to normal Bitcoin use.
 
 ## Document history
 

--- a/_alerts/2017-07-12-potential-split.md
+++ b/_alerts/2017-07-12-potential-split.md
@@ -59,6 +59,10 @@ will likely spread those loses across all their users.  If there end up
 being two or more competing versions of Bitcoin, then they may refuse to
 give you your bitcoins on versions they don't like.
 
+1. Bitcoin may experience significant price fluctuations in relation to
+other currencies.  Learn more about [price volatility][] and ensure you
+aren't holding more bitcoin than you can afford to lose.
+
 ## During the event
 
 1. Do not trust any payments you receive after {{start}} until the situation
@@ -93,6 +97,7 @@ first.
 [news sites]: /en/resources#news
 [community resources]: /en/community
 [confirmation scores]: /en/you-need-to-know#instant
+[price volatility]: /en/you-need-to-know#volatile
 
 <script src="/js/jquery/jquery-1.11.2.min.js"></script>
 <script>

--- a/_alerts/2017-07-12-potential-split.md
+++ b/_alerts/2017-07-12-potential-split.md
@@ -38,6 +38,10 @@ Remember that you alone are responsible for the safety of your bitcoins,
 and that if you lose control of them for any reason, there is nothing
 the operators or contributors to this website can do to help you.
 
+*Note:* there is a chance a milder level of disruption could start
+between now and {{start}}. If that is the case, this post will be
+updated with details.
+
 ## Preparation
 
 1. If you accept bitcoins as payments, we recommend that you stop

--- a/_alerts/2017-07-12-potential-split.md
+++ b/_alerts/2017-07-12-potential-split.md
@@ -5,7 +5,7 @@
 title: "Potential network disruption"
 shorturl: "potential-split"
 active: true
-banner: "Warning: Bitcoin may be unsafe to use starting July 31st (click here for details)"
+banner: "Warning: potential network disruption starting July 31st"
 
 ## 7/12 to 7/28: "warning" (orange); 7/29 until resolution: "alert" (red)
 bannerclass: "warning"

--- a/_alerts/2017-07-12-potential-split.md
+++ b/_alerts/2017-07-12-potential-split.md
@@ -70,9 +70,10 @@ is resolved.  No matter how many confirmations the new payment says it
 has, it can disappear from your wallet at any point up until the
 situation is resolved.
 
-1. Try not to send any payments.  Although you should not technically be
-able to lose money this way, wallets may become confused and require
-recovery if you attempt this.
+1. Try not to send any payments.  During the event there may be two or
+more different types of bitcoin and you may send all of the different
+types to a recipient who only expects one type.  This would benefit the
+recipient at your expense.
 
 1. Be wary of offers to allow you to invest in the outcome of the event
 by "splitting" your coins.  Some of these offers may be scams, and

--- a/_alerts/2017-07-12-potential-split.md
+++ b/_alerts/2017-07-12-potential-split.md
@@ -2,7 +2,7 @@
 ## This file is licensed under the MIT License (MIT) available on
 ## http://opensource.org/licenses/MIT.
 
-title: "Potential disruptive chain split"
+title: "Potential network disruption"
 shorturl: "potential-split"
 active: true
 banner: "Warning: Bitcoin may be unsafe to use starting July 31st (click here for details)"
@@ -16,7 +16,7 @@ bannerclass: "warning"
 page will be updated when new information becomes available.  See the
 [list of updates][].*
 
-At {{start}}, Bitcoin confirmation scores may become unreliable for
+At {{start}}, Bitcoin [confirmation scores][] may become unreliable for
 an unknown length of time.  This means that any bitcoins you receive
 after that time may later disappear from your wallet or be a
 type of bitcoin that other people will not accept as payment.
@@ -88,6 +88,7 @@ first.
 [list of updates]: #document-history
 [news sites]: /en/resources#news
 [community resources]: /en/community
+[confirmation scores]: /en/you-need-to-know#instant
 
 <script src="/js/jquery/jquery-1.11.2.min.js"></script>
 <script>


### PR DESCRIPTION
This PR adds a warning for the chainsplit that may occur on 1 August 2017.  It's focused on describing to non-expert users what they should do to secure their funds and does not advocate any particular position on the fork or attempt to describe the background of the situation.

The warning is displayed in orange above every regular page on Bitcoin.org; a comment in the file suggests changing the warning to red 72 hours before the beginning of the potential chain split.  I will submit a PR for that on the 28th.

I will do my best to submit PRs with changes to the page on and after August 1st, although of course anyone else can submit a PR to Bitcoin.org too.

Preview:

![2017-07-12-08_44_59_634405919](https://user-images.githubusercontent.com/61096/28118484-2dc3b7fa-66df-11e7-9a33-9850f2f098f5.png)
