### PR TITLE
Add Transifex config to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ _cache
 
 # To prevent accidental push of translations from
 # Transifex.
-translations/
+.tx/translations/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ vendor
 _cache
 .jekyll-metadata
 .sass-cache/
+
+# To prevent accidental push of translations from
+# Transifex.
+translations/

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[bitcoinorg.bitcoinorg]
+file_filter = translations/bitcoinorg.bitcoinorg/<lang>.yml
+source_lang = en
+type = YML
+

--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [bitcoinorg.bitcoinorg]
-file_filter = translations/bitcoinorg.bitcoinorg/<lang>.yml
+file_filter = .tx/translations/<lang>.yml
 source_lang = en
 type = YML
 


### PR DESCRIPTION
This PR adds Transifex configuration to the project, so when the full project is developed locally, this can be done within a single repository/folder.

Having a configuration in the repository also can simplify the instructions for translators and make it easy to create scripts to automate some translations related tasks, like #1657.