### PR TITLE
Upgrades Ruby version in Gemfile and Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - "2.0.0"
+  - "2.4.1"
 sudo: false
 cache: bundler
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ env:
   global:
     - BITCOINORG_BUILD_TYPE=deployment
 
+before_install: gem install bundler --pre
+
 script: make travis

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 ## version. Then remind one of the site maintainers that they need to
 ## run `rvm install <VERSION>` on the build server(s) before they commit
 ## to master
-ruby '2.0.0'
+ruby '2.4.1'
 
 ## Used on the build server. If you add a package here (like nokogiri)
 ## that has non-Gem dependencies (like zlib), please remind the site
@@ -17,7 +17,7 @@ group :development do
   ## When we upgrade to Jekyll 3.0.0 or higher, remove
   ## _plugin/remove-html-extension.rb
   gem 'jekyll', '~>3.0'
-  gem 'json'
+  gem 'json', '>= 1.9'
   gem 'less', '2.4.0'
   gem 'kramdown'
   gem 'RedCloth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       execjs
       multi_json (>= 1.3)
       rake
-    json (1.8.3)
+    json (2.1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
     kramdown (1.9.0)
@@ -78,9 +78,15 @@ DEPENDENCIES
   html-proofer (= 2.1.0)
   jekyll (~> 3.0)
   jshintrb (~> 0.3.0)
-  json
+  json (>= 1.9)
   json-schema
   kramdown
   less (= 2.4.0)
   safe_yaml
   therubyracer
+
+RUBY VERSION
+   ruby 2.4.1p111
+
+BUNDLED WITH
+   1.15.1


### PR DESCRIPTION
This PR upgrades Ruby version as well as some dependencies (json library) to improve stability and minimize a risk of future upgrades. The library upgrade is necessary due to incompatibility with Ruby version > 2.0.0.

Apart from that I noticed slightly reduced build time using a newer version.

As stated in the instructions I need to notify site maintainers, in this case I assume that's @wbnns, that `rvm install 2.4.1` also must be run on the build server before doing a merge.