### PR TITLE
Fixes an issue with URLs like /web/web/

### DIFF
--- a/_includes/layout/base/wallets-list.html
+++ b/_includes/layout/base/wallets-list.html
@@ -9,8 +9,13 @@ http://opensource.org/licenses/MIT.
   {% assign os = page.os['name'] %}
   {% if wallet.compat contains platform and wallet.compat contains os %}
     <div class="wallet-list-item" data-walletlevel="{{ wallet.level }}">
+      {% if platform == os %}
+      <a class="wallet-list-item-link"
+         href="/{{ page.lang}}/wallets/{{ platform }}/{{ wallet.id }}/">
+      {% else %}
       <a class="wallet-list-item-link"
          href="/{{ page.lang}}/wallets/{{ platform }}/{{ os }}/{{ wallet.id }}/">
+      {% endif %}
         <img src="/img/wallet/{{ wallet.id }}.png" alt="{{ wallet.title }}" />
         {{ wallet.titleshort }}
       </a>

--- a/_includes/layout/base/wallets-menu.html
+++ b/_includes/layout/base/wallets-menu.html
@@ -27,7 +27,7 @@ http://opensource.org/licenses/MIT.
     {% endif %}
     <li class="{{ platformClass }}">
       {% if platformName == 'hardware' or platformName == 'web' %}
-      {% assign platformHref = "/" | append: page.lang | append: "/wallets/" | append: platformName | append: "/" | append: platformName | append: "/" %}
+      {% assign platformHref = "/" | append: page.lang | append: "/wallets/" | append: platformName | append: "/" %}
         <a href="{{ platformHref }}">{% translate walletcat{{platformName}} choose-your-wallet %}</a>
       {% else %}
         <a>{% translate walletcat{{platformName}} choose-your-wallet %}</a>

--- a/_layouts/wallet-container.html
+++ b/_layouts/wallet-container.html
@@ -27,8 +27,13 @@ max_wallet_text_length: 418  ## Unicode characters
         {% if page.id contains os.name %}
           {% assign btnClass = btnClass | append: " active" %}
         {% endif %}
+        {% if platform.name == os.name %}
+        <a class="{{ btnClass }}"
+           href="/{{ page.lang }}/wallets/{{platform.name}}/{{page.wallet.id}}/">
+        {% else %}
         <a class="{{ btnClass }}"
            href="/{{ page.lang }}/wallets/{{platform.name}}/{{os.name}}/{{page.wallet.id}}/">
+        {% endif %}
           <img src="/img/os/{{ os.name }}.png"
                alt="{% translate platform{{os.name}} choose-your-wallet %}{% translate walletcat{{os.name}} choose-your-wallet %}"
                title="{% translate platform{{os.name}} choose-your-wallet %}" />

--- a/_plugins/wallets.rb
+++ b/_plugins/wallets.rb
@@ -79,7 +79,11 @@ module Jekyll
           data = YAML.load_file(file)
           platform = data['platform']
           os = data['os']
-          dir = File.join(platform['name'], os['name'])
+          if platform['name'] == os['name']
+            dir = File.join(platform['name'])
+          else
+            dir = File.join(platform['name'], os['name'])
+          end
 
           platformTitle = locs[lang]['choose-your-wallet']['walletcat' + platform['name']]
           osTitle = locs[lang]['choose-your-wallet']['platform' + os['name']]
@@ -103,7 +107,11 @@ module Jekyll
 
               # This allows generation only of valid wallet pages
               if platform['name']
-                dir = File.join(platform['name'], os['name'], wallet['id'])
+                if platform['name'] == os['name']
+                  dir = File.join(platform['name'], wallet['id'])
+                else
+                  dir = File.join(platform['name'], os['name'], wallet['id'])
+                end
 
                 platformTitle = locs[lang]['choose-your-wallet']['walletcat' + platform['name']]
                 osTitle = locs[lang]['choose-your-wallet']['platform' + os['name']]


### PR DESCRIPTION
This PR fixes a problem when platform URLs have duplicated name.

```
https://bitcoin.org/en/wallets/web/web/ -> https://bitcoin.org/en/wallets/web/
https://bitcoin.org/en/wallets/hardware/hardware/ -> https://bitcoin.org/en/wallets/hardware/
```