### PR TITLE
alerts: Discontinue network disruption alert

### DIFF
--- a/_alerts/2017-07-12-potential-split.md
+++ b/_alerts/2017-07-12-potential-split.md
@@ -4,10 +4,9 @@
 
 title: "Potential network disruption"
 shorturl: "potential-split"
-active: true
-banner: "Warning: wait for extra confirmations starting July 22nd"
-
-bannerclass: "warning"
+active: false
+## banner: "Warning: wait for extra confirmations starting July 22nd"
+## bannerclass: "warning"
 ---
 {% assign start='<span class="date">2017/08/01 00:00 UTC</span>' %}
 


### PR DESCRIPTION
This removes the current alert as discussed in #1726 and will be merged once tests pass.

Closes #1726