### PR TITLE
update -regtest generate time

### DIFF
--- a/_includes/devdoc/example_testing.md
+++ b/_includes/devdoc/example_testing.md
@@ -74,7 +74,7 @@ bitcoin-cli -regtest generate 101
 {% autocrossref %}
 
 Generate 101 blocks using a special RPC
-which is only available in regtest mode. This takes about 30 seconds on
+which is only available in regtest mode. This takes less than a second on
 a generic PC. Because this is a new block chain using Bitcoin's default
 rules, the first blocks pay a block reward of 50 bitcoins.  Unlike
 mainnet, in regtest mode only the first 150 blocks pay a reward of 50 bitcoins.


### PR DESCRIPTION
When I ran the listed command, it took 100 ms on my laptop:

```
real	0m0.100s
user	0m0.001s
sys	0m0.003s
```

I don't know how my laptop compares to a "generic PC", but I don't think it's 10x faster, much less 300x faster.