### PR TITLE
IRC/Slack update

### DIFF
--- a/_templates/development.html
+++ b/_templates/development.html
@@ -76,6 +76,7 @@ improvement in mind?  Here are a few ideas:
 
   <ul>
     <li>{% translate ircjoin %}</li>
+    <li>{% translate slack %}</li>
     <li>{% translate stackexchange %}</li>
     <li>{% translate bitcointalkdev %}</li>
   </ul>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -308,7 +308,7 @@ en:
     disclosuretxt: "If you find a vulnerability related to Bitcoin, non-critical vulnerabilities can be emailed in English to any of the core developers or sent to the private bitcoin-security mailing list listed above. An example of a non-critical vulnerability would be an expensive-to-carry-out denial of service attack. Critical vulnerabilities that are too sensitive for unencrypted email should be sent to one or more of the core developers, encrypted with their PGP key(s)."
     involve: "Get involved"
     involvetxt1: "Bitcoin is free software and any developer can contribute to the project. Everything you need is in the <a href=\"https://github.com/bitcoin/bitcoin\">GitHub repository</a>. Please make sure to read and follow the development process described in the README, as well as to provide good quality code and respect all guidelines."
-    involvetxt2: "Development discussion takes place on GitHub and the <a href=\"https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev\">bitcoin-dev</a> mailing list. Less formal development discussion happens on irc.freenode.net #bitcoin-dev (<a href=\"#\" onclick=\"freenodeShow(event);\">web interface</a>, <a href=\"http://bitcoinstats.com\">logs</a>)."
+    involvetxt2: "Development discussion takes place on GitHub and the <a href=\"https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev\">bitcoin-dev</a> mailing list. Less formal development discussion happens on irc.freenode.net #bitcoin-core-dev (<a href=\"https://webchat.freenode.net/?channels=bitcoin-core-dev\">web interface</a>, <a href=\"http://bitcoinstats.com/irc/bitcoin-core-dev/logs\">logs</a>)."
     more: "More free software projects"
     morewant: "Want to contribute to a different project?"
     morechoose: "You can choose a project to contribute to by answering a few <a href=\"http://whatcanidoforbitcoin.xyz/\">questions about your skills</a>."
@@ -317,7 +317,8 @@ en:
     contributorsorder: "(Ordered by number of commits)"
     devcommunities: "Developer communities"
     devcommunitiesintro: "The following chatrooms and websites host discussions about Bitcoin development.  Please be sure to read their rules of conduct before posting."
-    ircjoin: "<a href=\"https://webchat.freenode.net/?channels=bitcoin-dev\">IRC Channel #bitcoin-dev</a> on freenode."
+    ircjoin: "<a href=\"https://webchat.freenode.net/?channels=bitcoin-core-dev\">IRC Channel #bitcoin-core-dev</a> on freenode."
+    slack: "<a href=\"https://slack.bitcoincore.org/\">Bitcoin Core Slack Channel</a>"
     stackexchange: "<a href=\"https://bitcoin.stackexchange.com/\">Bitcoin StackExchange</a>"
     bitcointalkdev: "<a href=\"https://bitcointalk.org/index.php?board=6.0\">BitcoinTalk Development &amp; Technical Discussion Forum</a>"
   download:


### PR DESCRIPTION
- Adds Bitcoin Core Slack channel to dev communities
- Removes the freenode webchat iframe (doesn't work for me (Firefox, Chrome))
- Replaces #bitcoin-dev with bitcoin-core-dev. We link to the Core project on Github, so we should link to the specific core channel. The channel is also a lot more active and doesn't require a freenode account. I am okay with listing both, if anyone wants to keep the old one.

