### PR TITLE
Fixed "buy bitcoin" title

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -136,7 +136,7 @@ en:
     translated_by: "translated by"
     submit_new_translation: 'Do you want to translate the paper into your language? Visit the <a href="https://github.com/saivann/bitcoinwhitepaper">Bitcoin Paper repository</a> for instructions and <a href="https://github.com/saivann/bitcoinwhitepaper/issues/new">open an issue</a> if you have any questions.'
   buy:
-    title: "Buy"
+    title: "Buy - Bitcoin"
     pagetitle: "How to buy Bitcoin"
     summary: "There are several ways you can buy Bitcoin."
     bitcoin-exchange: "Use a Bitcoin Exchange"


### PR DESCRIPTION
Could also be changed to "How to buy Bitcoin". "Buy - Bitcoin" just follows the structure of all other pages.