### PR TITLE
Add Quadriga CX canadian bitcoin exchange

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -80,6 +80,7 @@ id: exchanges
       <p>
         <a href="https://bitaccess.co/">Bitaccess</a><br>
         <a href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a><br>
+        <a href="https://www.quadrigacx.com/">Quadriga CX</a><br>
         <a href="https://quickbt.com/">QuickBT</a>
       </p>
     </div>


### PR DESCRIPTION
Quadriga has ~80% market share in Canada, seems a dis-service to newcomers to omit it from the list.