### PR TITLE
exchanges: Remove BTCXIndia

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -114,7 +114,6 @@ id: exchanges
     <div>
       <h3 id="india"><img src="/img/flags/IN.png" alt="Indian flag">India</h3>
       <p>
-        <a href="https://btcxindia.com">BTCXIndia</a><br>
         <a href="https://coinsecure.in/">Coinsecure</a><br>
         <a href="https://www.unocoin.com/">Unocoin</a><br>
         <a href="https://www.zebpay.com">Zebpay</a>


### PR DESCRIPTION
This removes BTCXIndia from the exchanges page. It appears they have
shifted away from BTC and are focusing solely on Ripple-related exchange
pairings, now.

This will be merged once tests pass.