### PR TITLE
exchanges: Remove BTCC

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -93,7 +93,6 @@ id: exchanges
     <div>
       <h3 id="china"><img src="/img/flags/CN.png" alt="Chinese flag">China</h3>
       <p>
-        <a href="https://www.btcchina.com/">BTCC</a><br>
         <a href="https://www.huobi.com/">Huobi</a><br>
         <a href="https://www.okcoin.cn/">OKCoin</a>
       </p>


### PR DESCRIPTION
This removes BTCC from the Exchanges page. They announced that they
will be halting all trading as of September 30, 2017:
https://twitter.com/YourBTCC/status/908285586368167936

This will be merged once tests pass.