### PR TITLE
Update Bitsquare exchange branding

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -21,7 +21,7 @@ id: exchanges
     <div>
       <h3 id="international"><img src="/img/flags/ALL.png" alt="Globe">International</h3>
       <p>
-        <a href="https://bitsquare.io/">Bitsquare</a><br>
+        <a href="https://bisq.network/">Bisq</a><br>
         <a href="https://www.bitstamp.net/">Bitstamp</a><br>
         <a href="https://bitwage.com/">Bitwage</a><br>
         <a href="https://www.coinbase.com/">Coinbase</a><br>


### PR DESCRIPTION
Bitsquare recent rebranded to "bisq" and now has a new website. The previous one (https://bitsquare.io) redirects to the new location, but this should not be counted on long term.