### PR TITLE
v0.15.0: Fix incorrect reference to date

### DIFF
--- a/_releases/v0.15.0.md
+++ b/_releases/v0.15.0.md
@@ -9,7 +9,7 @@ required_version: 0.15.0
 ## Required title.
 title: Bitcoin Core version 0.15.0 released
 ## Optional release date.  May be filled in hours/days after a release
-optional_date: 2017-10-14
+optional_date: 2017-09-14
 ## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
 ## and View Details, or install the transmission-cli Debian/Ubuntu package
 ## and run: transmission-show -m <torrent file>


### PR DESCRIPTION
This fixes a small issue in the release notes where today's date is
accidentally referenced as October 14th, 2017.

This will be merged once tests pass.