### PR TITLE
Add Reality Keys (Japan) to denunciation list

### DIFF
--- a/_posts/2017-10-05-denounce-segwit2x.md
+++ b/_posts/2017-10-05-denounce-segwit2x.md
@@ -63,6 +63,7 @@ By default, we will be using the following list of companies known to support S2
 + Netki (United States)
 + OB1 (United States)
 + Purse (United States)
++ Reality Keys (Japan)
 + Ripio (Argentina)
 + Safello (Sweden)
 + SFOX (United States)


### PR DESCRIPTION
As one of the various signed data services we offer we provide numbers for propositions like "1 Bitcoin in USD" and "1 Bitcoin to be worth more than $5000 on date x". 

Generally our numbers come from upstream data providers like CoinDesk and Poloniex. However, if someone believes that these data sources are incorrect, we provide an option for them to have us verify the data, in exchange for a fee.

We think it is likely that our upstream data providers will not be in compliance with your stipulation, _"The company will not under any circumstances list “Segwit2x” as “BTC” and/or “Bitcoin”._. 

Additionally, if we were asked to verify data, we would make a judgement based on the available facts and circumstances at the time. For example, without making any assumptions as to the likelihood of this outcome, were B2X to have greater hashpower, higher market price and more general usage than B1X, we think it is likely that it would widely be considered to be "Bitcoin", and we would also describe it this way, and this would be reflected in our data.

We therefore respectfully request inclusion in your denunciation list.