### PR TITLE
Add CoinMall on 'Spending Bitcoin' page

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -767,7 +767,7 @@ en:
     pagetitle: "Spending Bitcoin"
     summary: "There are thousands of businesses, across the globe, that accept Bitcoin."
     products-online: "Find products for sale online"
-    products-online-text: "One common use for Bitcoin is making purchases online. There are hundreds of online shops and retailers that accept Bitcoin. Using a search engine like <a href=\"https://spendabit.co/\">Spendabit</a> you can search through millions of products, all available for purchase with bitcoins."
+    products-online-text: "One common use for Bitcoin is making purchases online. There are hundreds of online shops and retailers that accept Bitcoin. Using a search engine like <a href=\"https://spendabit.co/\">Spendabit</a> you can search through millions of products, all available for purchase with bitcoins. There is also <a href=\"https://spendabit.co/\">CoinMall</a>, a marketplace on which users are able to buy and sell digital goods for Bitcoin"
     directory: "Navigate a business directory"
     directory-text: "You can also find many businesses listed in <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">online directories</a>."
     business-map: "Find local businesses"

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -767,7 +767,7 @@ en:
     pagetitle: "Spending Bitcoin"
     summary: "There are thousands of businesses, across the globe, that accept Bitcoin."
     products-online: "Find products for sale online"
-    products-online-text: "One common use for Bitcoin is making purchases online. There are hundreds of online shops and retailers that accept Bitcoin. Using a search engine like <a href=\"https://spendabit.co/\">Spendabit</a> you can search through millions of products, all available for purchase with bitcoins. There is also <a href=\"https://spendabit.co/\">CoinMall</a>, a marketplace on which users are able to buy and sell digital goods for Bitcoin"
+    products-online-text: "One common use for Bitcoin is making purchases online. There are hundreds of online shops and retailers that accept Bitcoin. Using a search engine like <a href=\"https://spendabit.co/\">Spendabit</a> you can search through millions of products, all available for purchase with bitcoins. There is also <a href=\"https://www.coinmall.io/\">CoinMall</a>, a marketplace on which users are able to buy and sell digital goods for Bitcoin."
     directory: "Navigate a business directory"
     directory-text: "You can also find many businesses listed in <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">online directories</a>."
     business-map: "Find local businesses"


### PR DESCRIPTION
This Pull Request adds CoinMall to the Spending Bitcoin page found here: https://bitcoin.org/en/spend-bitcoin

CoinMall is a marketplace on which users can buy and sell digital goods for Bitcoin. Our company fundamentals align with those of the rational Bitcoin community. We do not and will not support any coins created from forks such as Bitcoin Cash or Segwit 2X.

Feedback is more than welcome.