### PR TITLE
Update resources.html

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -40,6 +40,7 @@ id: resources
     {% if page.lang == 'fr' %}
     <p><a href="https://le-coin-coin.fr">Le Coin Coin</a></p>
     <p><a href="https://bitcoin.fr">Bitcoin.fr</a></p>
+    <p><a href="https://achat-bitcoin.fr/">Achat-bitcoin.fr</a></p>
     {% endif %}
     {% if page.lang == 'pl' %}<p><a href="https://satoshi.pl/">Satoshi.pl</a></p>{% endif %}
     {% if page.lang == 'ru' %}


### PR DESCRIPTION
The website achat-bitcoin.fr provides news and guides about Bitcoin since 2013, french section needs more diversity for news and guides websites.