### PR TITLE
Updated exchanges.html to add Australian and New Zealand exchange

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -54,7 +54,8 @@ id: exchanges
         <a href="https://www.coinjar.com/">CoinJar</a><br>
         <a href="https://www.coinloft.com.au/">CoinLoft</a><br>
         <a href="https://www.cointree.com.au/">CoinTree</a><br>
-        <a href="https://www.hardblock.net/">HardBlock</a>
+        <a href="https://www.hardblock.net/">HardBlock</a><br>
+        <a href="https://www.independentreserve.com/">Independent Reserve</a>
       </p>
     </div>
     <div>
@@ -168,7 +169,8 @@ id: exchanges
     <div>
       <h3 id="new-zealand"><img src="/img/flags/NZ.png" alt="New Zealand Flag">New Zealand</h3>
       <p>
-        <a href="https://kiwi-coin.com/">Kiwi-coin</a>
+        <a href="https://kiwi-coin.com/">Kiwi-coin</a><br>
+        <a href="https://www.independentreserve.com/">Independent Reserve</a>
       </p>
     </div>
     <div>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -169,8 +169,8 @@ id: exchanges
     <div>
       <h3 id="new-zealand"><img src="/img/flags/NZ.png" alt="New Zealand Flag">New Zealand</h3>
       <p>
-        <a href="https://kiwi-coin.com/">Kiwi-coin</a><br>
-        <a href="https://www.independentreserve.com/">Independent Reserve</a>
+        <a href="https://www.independentreserve.com/">Independent Reserve</a><br>
+        <a href="https://kiwi-coin.com/">Kiwi-coin</a>
       </p>
     </div>
     <div>


### PR DESCRIPTION
Independent Reserve has been operating since 2013 and is one of the leading exchanges in Australia and New Zealand