### PR TITLE
Fix incorrect `GetTxOut` description

### DIFF
--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/gettxout.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/gettxout.md
@@ -7,7 +7,7 @@ http://opensource.org/licenses/MIT.
 ##### GetTxOut
 {% include helpers/subhead-links.md %}
 
-{% assign summary_getTxOut="returns details about a transaction output.  Only unspent transaction outputs (UTXOs) are guaranteed to be available." %}
+{% assign summary_getTxOut="returns details about an unspent transaction output (UTXO)." %}
 
 {% autocrossref %}
 
@@ -50,7 +50,7 @@ The `gettxout` RPC {{summary_getTxOut}}
 - n: "`result`"
   t: "object/null"
   p: "Required<br>(exactly 1)"
-  d: "Information about the output.  If output wasn't found or if an error occurred, this will be JSON `null`"
+  d: "Information about the output.  If output wasn't found, if it was spent or if an error occurred, this will be JSON `null`"
 
 - n: "→<br>`bestblock`"
   t: "string (hex)"


### PR DESCRIPTION
See details: https://bitcoin.stackexchange.com/questions/48504/how-to-check-if-an-output-has-been-spent/48505?noredirect=1#comment70553_48505
>  It gives information about unspent outputs, and won't return anything for spent outputs.