### PR TITLE
adding Bitso to bitcoin.org

### DIFF
--- a/_posts/2017-10-05-denounce-segwit2x.md
+++ b/_posts/2017-10-05-denounce-segwit2x.md
@@ -36,7 +36,6 @@ By default, we will be using the following list of companies known to support S2
 + BitPay (United States)
 + BitPesa (Kenya)
 + BitOasis (United Arab Emirates)
-+ Bitso (Mexico)
 + Bixin.com (China)
 + Blockchain (UK)
 + Bloq (United States)

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -154,6 +154,7 @@ id: exchanges
     <div>
       <h3 id="mexico"><img src="/img/flags/MX.png" alt="Mexican flag">Mexico</h3>
       <p>
+        <a href="https://bitso.com/">Bitso</a><br>
         <a href="https://www.volabit.com/">Volabit</a>
       </p>
     </div>


### PR DESCRIPTION
We have not defaulted tickers to Segwit2x. More info in our blog: https://blog.bitso.com/planes-para-el-segwit2x-bitcoin-hard-fork-e347117298e8