### PR TITLE
Update Events Page

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -78,6 +78,14 @@
   country: "Colombia"
   link: "https://www.blocktrainedu.info/"
 
+- date: 2017-11-25
+  title: "Blockchain Summit Kyiv"
+  venue: "Oazis"
+  address: "st. Lypkovskoho, 1A"
+  city: "Kiev"
+  country: "Ukraine"
+  link: "http://blockchainsummit.com.ua"
+
 - date: 2017-11-29
   title: "Blockchain Expo"
   venue: "Santa Clara Convention Center"

--- a/_events.yml
+++ b/_events.yml
@@ -110,6 +110,14 @@
   country: "United States"
   link: "http://blockchainnh.com"
 
+- date: 2017-12-06
+  title: "Blockchain in Africa"
+  venue: "Cyberparc Sidi Abdellah"
+  address: "Rahmania, Sidi Abdellah"
+  city: "Algiers"
+  country: "Algeria"
+  link: "https://www.algeria20.com"
+
 - date: 2017-12-07
   title: "Blockchain and Bitcoin Conference Malta"
   venue: "Intercontinental Malta"

--- a/_events.yml
+++ b/_events.yml
@@ -173,3 +173,11 @@
   city: "Paris"
   country: "France"
   link: "https://achat-bitcoin.fr"
+
+- date: 2018-03-27
+  title: "Blockchain West"
+  venue: "Marine's Memorial Club & Hotel"
+  address: "609 Sutter St."
+  city: "San Francisco"
+  country: "United States"
+  link: "http://blockchainwest.com/san-francisco-2017/"

--- a/_events.yml
+++ b/_events.yml
@@ -70,6 +70,14 @@
   country: "United Arab Emirates"
   link: "http://blockchainconfex.com"
 
+- date: 2017-11-24
+  title: "Blocktrain 1.0"
+  venue: "Centro de Alta Tecnología"
+  address: "Cra. 15 #77-05"
+  city: "Bogota"
+  country: "Colombia"
+  link: "https://www.blocktrainedu.info/"
+
 - date: 2017-11-29
   title: "Blockchain Expo"
   venue: "Santa Clara Convention Center"

--- a/_events.yml
+++ b/_events.yml
@@ -1,19 +1,3 @@
-- date: 2017-11-02
-  title: "Bitcoin Edge Dev++"
-  venue: "Stanford University"
-  address: "326 Galvez Street"
-  city: "Stanford"
-  country: "United States"
-  link: "https://bitcoinedge.org/event/stanford-devplusplus-2017"
-
-- date: 2017-11-04
-  title: "Scaling Bitcoin 2017 - Scaling the Edge"
-  venue: "Stanford University - Frances C. Arrillaga Alumni Center"
-  address: "326 Galvez Street"
-  city: "Palo Alto"
-  country: "United States"
-  link: "https://scalingbitcoin.org/event/stanford2017"
-
 - date: 2017-11-09
   title: "Milwaukee Blockchain Conference"
   venue: "Marquette University"


### PR DESCRIPTION
This removes events that have already passed from the [Events page](https://bitcoin.org/en/events), and also adds some new ones:

- Blockchain in Africa
- Blocktrain 1.0
- Blockchain West
- Blockchain Summit Kyiv

This will be merged once tests pass.