### PR TITLE
_alerts: Drop 2X alert from tops of pages

### DIFF
--- a/_alerts/2017-10-09-segwit2x-safety.md
+++ b/_alerts/2017-10-09-segwit2x-safety.md
@@ -1,9 +1,9 @@
 ---
 title: "Beware of Bitcoin's possible incompatibility with some major services"
 shorturl: "segwit2x-safety"
-active: true
-banner: "Beware of Bitcoin's possible incompatibility with some major services"
-bannerclass: "alert"
+active: false
+## banner: "Beware of Bitcoin's possible incompatibility with some major services"
+## bannerclass: "alert"
 date: 2017-10-11
 ---
 


### PR DESCRIPTION
This drops the 2X alert that's currently displaying across the
tops of all pages on the website, [since there will no longer be a
2X-related fork](https://lists.linuxfoundation.org/pipermail/bitcoin-segwit2x/2017-November/000685.html).

Unless others object, this will be merged on Sunday, November 12th.