### PR TITLE
Add Bitcoin Embassy Tel Aviv to non-profit organizations

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -134,6 +134,7 @@ id: community
     <h3 id="israel"><img src="/img/flags/IL.png" alt="Israeli flag">Israel</h3>
     <p>
       <a href="http://www.bitcoin.org.il/">איגוד הביטקוין הישראלי</a>
+      <a href="http://bitembassy.org/">Bitcoin Embassy Tel Aviv</a>
     </p>
   </div>
   <div>


### PR DESCRIPTION
Add the Bitcoin Embassy Tel Aviv to the non-profit organizations list.