### PR TITLE
Move Karsha from UAE section to International

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -26,6 +26,7 @@ id: exchanges
         <a href="https://bitwage.com/">Bitwage</a><br>
         <a href="https://www.kraken.com/">Kraken</a><br>
         <a href="https://localbitcoins.com/">Local Bitcoins</a><br>
+        <a href="https://karsha.biz/">Karsha</a>
       </p>
     </div>
     <div>
@@ -227,8 +228,7 @@ id: exchanges
     <div>
       <h3 id="united-arab-emirates"><img src="/img/flags/UAE.png" alt="United Arab Emirates flag">United Arab Emirates</h3>
       <p>
-        <a href="https://bitoasis.net/">BitOasis</a><br>
-        <a href="https://karsha.biz/">Karsha</a>
+        <a href="https://bitoasis.net/">BitOasis</a>
       </p>
     </div>   
     <div>


### PR DESCRIPTION
Doesn't have buy/sell options (e.g. cash and bank transfer) anymore for locals. Only exchange between e-currencies and cryptocurrencies.

Dear @wbnns,
Thank you for adding us to the list two weeks ago. Since then, we got around 50 new visitors per day from Bitcoin.org, but not a single order was registered by them! That's partly because we currently don't have bank transfer option anymore. We currently only exchange between various cryptocurrencies and e-currencies.

We get around 10 new support requests per day from our Bitcoin.org visitors asking "what is Bitcoin?"!

So, I'm kindly asking you to move us to the "International" section of the page please. Please, for God's sake. Just try our website yourself, and if it was up to your own standards, accept this PR.

Please note that we also have a unique automatic exchange Telegram bot (https://t.me/KarshaBizBot). No other exchange has anything even remotely comparable to it. Please try that too and see how fast and easy is to exchange cryptos with it.

Being in the UAE section doesn't have anything good for us. Just extra support requests, and disappointed customers because there is currently no way to buy/sell Bitcoin from/to us using bank transfer, cash, or credit/debit cards.

Thank you so much.

P.S. If needed, I can ask some of our European investors or our Canadian investor to contact you and approve that we are indeed "International".