### PR TITLE
Fix typo in full-node.md

### DIFF
--- a/en/full-node.md
+++ b/en/full-node.md
@@ -1476,7 +1476,7 @@ also disables the RPC `importwallet`. Two RPCs that are available and
 potentially helpful, however, are `importprunedfunds` and `removeprunedfunds`.
 
 To enable block pruning set `prune=N` on the command line or in `bitcoin.conf`,
-where `N` is the number of MiB to allot for raw block and undo data.
+where `N` is the number of MiB to allow for raw block and undo data.
 
 A value of `0` disables pruning. The minimal value above `0` is `550`. Your
 wallet is as secure with high values as it is with low ones. Higher values


### PR DESCRIPTION
`allot` to `allow`