### PR TITLE
Fix typo in translations at ja.yml

### DIFF
--- a/_translations/ja.yml
+++ b/_translations/ja.yml
@@ -124,7 +124,7 @@ ja:
     platformandroid: "Android"
     platformios: "iOS"
     platformblackberry: "BlackBerry"
-    platformwindows: "WIndows"
+    platformwindows: "Windows"
     platformmac: "Mac"
     platformlinux: "Linux"
     checkgoodcontrolfull: "あなたのお金に対するコントロール"


### PR DESCRIPTION
`WIndows` to `Windows`