### PR TITLE
Remove Bitcoin Wallet for BlackBerry OS from wallets page.

### DIFF
--- a/_templates/development.html
+++ b/_templates/development.html
@@ -108,7 +108,7 @@ Want to contribute to a different project?
 <ul class="devprojectlist">
   <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A wallet with enhanced security features, written in C++.</li>
   <li><a href="https://github.com/luke-jr/bfgminer">BFGMiner</a> - A modular miner, written in C.</li>
-  <li><a href="https://github.com/bitcoin-wallet/bitcoin-wallet">Bitcoin Wallet</a> - A SPV wallet for Android and Blackberry, written in Java.</li>
+  <li><a href="https://github.com/bitcoin-wallet/bitcoin-wallet">Bitcoin Wallet</a> - A SPV wallet for Android, written in Java.</li>
   <li><a href="https://github.com/bitcoinj/bitcoinj">bitcoinj</a> - A library for SPV wallets, written in Java.</li>
   <li><a href="https://github.com/btcsuite/btcd">btcd</a> - A full node, written in Go.</li>
   <li><a href="https://github.com/btcsuite/btcwallet">btcwallet</a> - A hierarchical deterministic wallet daemon, written in Go.</li>

--- a/_wallets/bitcoinwallet.md
+++ b/_wallets/bitcoinwallet.md
@@ -5,7 +5,7 @@
 id: bitcoinwallet
 title: "Bitcoin Wallet"
 titleshort: "Bitcoin<br>Wallet"
-compat: "mobile android blackberry"
+compat: "mobile android"
 level: 2
 platform:
   - mobile:
@@ -14,22 +14,6 @@ platform:
       - name: android
         text: "walletbitcoinwallet"
         link: "https://play.google.com/store/apps/details?id=de.schildbach.wallet"
-        source: "https://github.com/bitcoin-wallet/bitcoin-wallet"
-        screenshot: "bitcoinwalletandroid.png"
-        check:
-          control: "checkgoodcontrolfull"
-          validation: "checkpassvalidationspvp2p"
-          transparency: "checkpasstransparencyopensource"
-          environment: "checkpassenvironmentmobile"
-          privacy: "checkpassprivacybasic"
-          fees: "checkgoodfeecontrolfull"
-        privacycheck:
-          privacyaddressreuse: "checkpassprivacyaddressrotation"
-          privacydisclosure: "checkfailprivacydisclosurespv"
-          privacynetwork: "checkfailprivacynetworknosupporttor"
-      - name: blackberry
-        text: "walletbitcoinwallet"
-        link: "https://appworld.blackberry.com/webstore/content/23952882/"
         source: "https://github.com/bitcoin-wallet/bitcoin-wallet"
         screenshot: "bitcoinwalletandroid.png"
         check:


### PR DESCRIPTION
It's unpublished and not supported any more.

Side notes:

I haven't really tested this change as I haven't got the site generation infrastructure set up at the moment.

This change will likely leave the BlackBerry category empty; removal of that category is left to a separate PR (and decision process).