### PR TITLE
_wallets: Update BitGo platform availability

### DIFF
--- a/_wallets/bitgo.md
+++ b/_wallets/bitgo.md
@@ -5,34 +5,9 @@
 id: bitgo
 title: "BitGo"
 titleshort: "BitGo"
-compat: "web desktop windows mac linux"
+compat: "web"
 level: 3
 platform:
-  - desktop:
-    name: desktop
-    default: &DEFAULT
-      text: "walletbitgo"
-      link: "https://chrome.google.com/webstore/detail/bitgo/jlgeogaipkoajobchncghcojanffjfhl"
-      source: "https://github.com/BitGo/bitgo-chrome"
-      screenshot: "bitgo.png"
-      check:
-        control: "checkpasscontrolmulti"
-        validation: "checkfailvalidationcentralized"
-        transparency: "checkfailtransparencyremote"
-        environment: "checkpassenvironmenttwofactor"
-        privacy: "checkpassprivacybasic"
-        fees: "checkpassfeecontroldynamic"
-      privacycheck:
-        privacyaddressreuse: "checkpassprivacyaddressrotation"
-        privacydisclosure: "checkfailprivacydisclosureaccount"
-        privacynetwork: "checkpassprivacynetworksupporttorproxy"
-    os:
-      - name: windows
-        <<: *DEFAULT
-      - name: mac
-        <<: *DEFAULT
-      - name: linux
-        <<: *DEFAULT
   - web:
     name: web
     os:


### PR DESCRIPTION
This fixes an issue with some broken links (#2018) as a result of the
BitGo Chrome App being discontinued, and will be merged once tests pass.

Closes #2018