### PR TITLE
Added news source in Spanish

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -48,6 +48,7 @@ id: resources
     <p><a href="https://bits.media">Bits Media</a></p>
     <p><a href="http://coinspot.ru">CoinSpot</a></p>
     {% endif %}
+    {% if page.lang == 'es' %}<p><a href="https://www.criptonoticias.com/">CriptoNoticias</a></p>{% endif %}
     <p>{% translate linkcointelegraph %}<p>
     <p><a href="http://www.coindesk.com">CoinDesk</a></p>
     <p><a href="https://www.getrevue.co/profile/kyletorpey/">Kyle Torpey's Daily Bitcoin Recap</a></p>


### PR DESCRIPTION
CriptoNoticias is the most read digital newspaper about Bitcoin in Spanish since 2015. We have over 1 million views per month with exclusive news about Latinamerica and Spain and other significant topics related to cryptocurrencies.