### PR TITLE
Added glossary term token

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1357,6 +1357,12 @@ source_file = .tx/translations/glossary/en/testnet.yaml
 source_lang = en
 type = GITHUBMARKDOWN
 
+[bitcoinorg.glossary-token]
+file_filter = .tx/translations/glossary/<lang>/token.yaml
+source_file = .tx/translations/glossary/en/token.yaml
+source_lang = en
+type = GITHUBMARKDOWN
+
 [bitcoinorg.glossary-transaction-fee]
 file_filter = .tx/translations/glossary/<lang>/transaction-fee.yaml
 source_file = .tx/translations/glossary/en/transaction-fee.yaml

--- a/_data/glossary/en/token.yaml
+++ b/_data/glossary/en/token.yaml
@@ -1,0 +1,28 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+required:
+                                           #-------------40 characters-------------#
+    title_max_40_characters_no_formatting: Token
+
+    summary_max_255_characters_no_formatting: >
+        Tokens operate on top of a blockchain that facilitates
+        the creation of decentralized applications, while
+        coins are currencies with their own separate block
+        chains.
+
+    synonyms_shown_in_glossary_capitalize_first_letter:
+        - Token
+
+optional:
+    synonyms_and_pluralizations_not_shown_in_glossary:
+        - tokens
+        - assets
+
+    not_to_be_confused_with_capitalize_first_letter:
+
+    links_html_or_markdown_style_capitalize_first_letter:
+        - "[Token](https://en.bitcoinwiki.org/wiki/Token) --- Bitcoin wiki"
+       
+---


### PR DESCRIPTION
Added glossary term token as requested in issue #2001 (New glossary term suggestion: token)
I have rephrased the definition picked by @Richouser, so it begins with token explanation and further explains difference from coin.

Token glossary term looks like in the attachment
![token_glossary_term](https://user-images.githubusercontent.com/34668068/34655194-1608c240-f406-11e7-8cec-57b51dc3a402.PNG)


Bounty / donation address:
BTC: 1DGX4Zu83i3zL3zCNRaiat6tbtPMgEyhNE
