### PR TITLE
Update Armory link

### DIFF
--- a/_templates/development.html
+++ b/_templates/development.html
@@ -106,7 +106,7 @@ Want to contribute to a different project?
 {% translate morechoose %}</p>
 
 <ul class="devprojectlist">
-  <li><a href="https://github.com/etotheipi/BitcoinArmory">Armory</a> - A wallet with enhanced security features, written in C++.</li>
+  <li><a href="https://github.com/goatpig/BitcoinArmory">Armory</a> - A wallet with enhanced security features, written in C++.</li>
   <li><a href="https://github.com/luke-jr/bfgminer">BFGMiner</a> - A modular miner, written in C.</li>
   <li><a href="https://github.com/bitcoin-wallet/bitcoin-wallet">Bitcoin Wallet</a> - A SPV wallet for Android and Blackberry, written in Java.</li>
   <li><a href="https://github.com/bitcoinj/bitcoinj">bitcoinj</a> - A library for SPV wallets, written in Java.</li>


### PR DESCRIPTION
The original Armory repo (etotheipi) hasn't been maintained for almost two years. Update to link to the current (goatpig) repo.