### PR TITLE
Added CoinSpot to Australian Exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -53,10 +53,10 @@ id: exchanges
         <a href="https://bitcoin.com.au/">Bitcoin Australia</a><br>
         <a href="https://www.coinjar.com/">CoinJar</a><br>
         <a href="https://www.coinloft.com.au/">CoinLoft</a><br>
+	<a href="https://www.coinspot.com.au/">CoinSpot</a><br>
         <a href="https://www.cointree.com.au/">CoinTree</a><br>
         <a href="https://www.hardblock.net/">HardBlock</a><br>
-        <a href="https://www.independentreserve.com/">Independent Reserve</a><br>
-	<a href="https://www.coinspot.com.au/">CoinSpot</a>
+        <a href="https://www.independentreserve.com/">Independent Reserve</a>
       </p>
     </div>
     <div>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -55,7 +55,7 @@ id: exchanges
         <a href="https://www.coinloft.com.au/">CoinLoft</a><br>
         <a href="https://www.cointree.com.au/">CoinTree</a><br>
         <a href="https://www.hardblock.net/">HardBlock</a><br>
-        <a href="https://www.independentreserve.com/">Independent Reserve</a>
+        <a href="https://www.independentreserve.com/">Independent Reserve</a><br>
 	<a href="https://www.coinspot.com.au/">CoinSpot</a>
       </p>
     </div>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -56,6 +56,7 @@ id: exchanges
         <a href="https://www.cointree.com.au/">CoinTree</a><br>
         <a href="https://www.hardblock.net/">HardBlock</a><br>
         <a href="https://www.independentreserve.com/">Independent Reserve</a>
+	<a href="https://www.coinspot.com.au/">CoinSpot</a>
       </p>
     </div>
     <div>


### PR DESCRIPTION
https://www.coinspot.com.au/ is a reliable and popular Australian exchange I've used several times to buy Bitcoin and Altcoins. I am not affiliated with them in any way.