### PR TITLE
Improved the P2SH documentation

### DIFF
--- a/_data/devdocs/en/guides/transactions.md
+++ b/_data/devdocs/en/guides/transactions.md
@@ -348,8 +348,16 @@ Signature script: <sig> <pubkey>
 {% autocrossref %}
 
 P2SH is used to send a transaction to a script hash. Each of the standard
-pubkey scripts can be used as a P2SH redeem script, but in practice only the
-multisig pubkey script makes sense until more transaction types are made standard.
+pubkey scripts can be used as a P2SH redeem script, excluding P2SH itself. 
+As of Bitcoin Core 0.9.2, P2SH transactions can contain any valid redeemScript, 
+making the P2SH standard much more flexible and allowing for experimentation with 
+many novel and complex types of transactions. The most common use of P2SH is the standard 
+multisig pubkey script, with the second most common use being the [Open Assets Protocol][open assets protocol].
+
+Another common redeemScript used for P2SH is storing textual data on the blockchain.
+The first bitcoin transaction ever made included text, and P2SH is a convenient method
+of storing text on the blockchain as its possible to store up to 1.5kb of text data. An
+example of storing text on the blockchain using P2SH can be found in this [repository][peter todd p2sh example].
 
 {% endautocrossref %}
 

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -430,7 +430,9 @@ http://opensource.org/licenses/MIT.
 [offline transactions]: http://bitcoin.stackexchange.com/a/34122/21052
 [open a pull request]: https://github.com/bitcoin-dot-org/bitcoin.org#working-with-github
 [open an issue]: https://github.com/bitcoin-dot-org/bitcoin.org/issues/new
+[open assets protocol]: https://github.com/OpenAssets/open-assets-protocol/blob/master/specification.mediawiki
 [Payment Request Generator]: https://github.com/gavinandresen/paymentrequest/blob/master/php/demo_website/createpaymentrequest.php
+[peter todd p2sh example]: https://github.com/petertodd/checklocktimeverify-demos/blob/master/lib/python-bitcoinlib/examples/publish-text.py
 [Piotr Piasecki's testnet faucet]: https://tpfaucet.appspot.com/
 [prime symbol]: https://en.wikipedia.org/wiki/Prime_%28symbol%29
 [protobuf]: https://developers.google.com/protocol-buffers/


### PR DESCRIPTION
Cleared up the confusion stemming from the outdated information in the P2SH documentation as described in #1894 . Since Bitcoin Core 0.9.2 , any valid redeemScript can be used aside from the P2SH pubkey script itself to prevent recursion, greatly extending the possibilities of P2SH. Also added a link to a python example from Peter Todd, a bitcoin core developer, showing how to store some text data on the blockchain using P2SH.

**Bounty / Donation Address**
BTC: `1NooxLZWSw4h7eUhxkEf3PMRxd2WFEqhwp`