### PR TITLE
Add .mailmap with entries for top committers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+David A. Harding <dave@dtrt.org>
+Saivann <saivann@gmail.com>
+Will Binns <will@trek.io>
+Will Binns <will@trek.io> <gwb3@trek.io>
+Will Binns <will@trek.io> <wbnns@users.noreply.github.com>
+Will Binns <will@trek.io> <binns@21.co>


### PR DESCRIPTION
This commit adds a .mailmap file as described in the `git shortlog`
manpage, normalizing names and email addresses for several top
committers.

For context, see the conversation between @cbeams and @harding at
https://twitter.com/cbeams/status/967491714335297536. Entries in a
.mailmap like those found in this commit eliminate the need to manually
"combine multiple entries" for authors like @wbinns who have had commits
with varying author metadata over time.

Ultimately, the purpose is to make the output of `git shortlog` as
concise and accurate as possible. Compare the results of `git shortlog
-nse` before and after this commit to see the difference it makes.