### PR TITLE
Revert "update network descriptions to be more accurate"

### DIFF
--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -12,7 +12,7 @@ http://opensource.org/licenses/MIT.
 <div class="mainlist">
   <div><div><img src="/img/icons/main_ico_instant.svg" alt="Icon"><div>{% translate list1 %}</div></div></div>
   <div><div><img src="/img/icons/main_ico_worldwide.svg" alt="Icon"><div>{% translate list2 %}</div></div></div>
-  <div><div><img src="/img/icons/ico_lock.svg" alt="Icon"><div>{% translate list3 %}</div></div></div>
+  <div><div><img src="/img/icons/main_ico_lowfee.svg" alt="Icon"><div>{% translate list3 %}</div></div></div>
 </div>
 <p class="maindesc">{% translate desc %}</p>
 <div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/icons/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -659,9 +659,9 @@ en:
     title: "Bitcoin - Open source P2P money"
     metadescription: "Bitcoin is an innovative payment network and a new kind of money. Find all you need to know and get started with Bitcoin on bitcoin.org."
     listintro: "Bitcoin is an innovative payment network and a new kind of money."
-    list1: "Peer-to-peer<br>transactions"
-    list2: "Borderless<br>payments"
-    list3: "Fraud<br>protection"
+    list1: "Fast peer-to-peer<br>transactions"
+    list2: "Worldwide<br>payments"
+    list3: "Low<br>processing fees"
     desc: "Bitcoin uses peer-to-peer technology to operate with no central authority or banks; managing transactions and the issuing of bitcoins is carried out collectively by the network. <b>Bitcoin is open-source; its design is public, nobody owns or controls Bitcoin and <a href=\"#support-bitcoin#\">everyone can take part</a></b>. Through many of its unique properties, Bitcoin allows exciting uses that could not be covered by any previous payment system."
     overview: "Or get a quick overview for"
   innovation:


### PR DESCRIPTION
Reverts bitcoin-dot-org/bitcoin.org#2010

This reverts the referenced pull request and restores the mention of the "Fast peer-to-peer transactions", "Worldwide payments" and "Low processing fees" features that were previously highlighted in the homepage. At the time the pull request was created, the fees were temporarily high, and there was little adoption of Segwit and batching. Since then, the fees have been low.

There was also not enough thought put into the original pull request, since it's still showing the old labels for languages other than English. I propose we comprehensively change the text across all languages when the fees are very high on a **permanent** basis, which I think is some years off thanks the ecosystem taking better care to optimize usage of the blockchain.