### PR TITLE
GetInfo was removed in 0.16.0

### DIFF
--- a/_data/devdocs/en/bitcoin-core/rpcs/rpcs/getinfo.md
+++ b/_data/devdocs/en/bitcoin-core/rpcs/rpcs/getinfo.md
@@ -13,7 +13,7 @@ http://opensource.org/licenses/MIT.
 
 The `getinfo` RPC {{summary_getInfo}}
 
-{{WARNING}} `getinfo` will be removed in a later version of Bitcoin
+{{WARNING}} `getinfo` was removed in 0.16.0 version of Bitcoin
 Core.  Use the RPCs listed in the See Also subsection below instead.
 
 *Parameters: none*


### PR DESCRIPTION
as from output

```
>bitcoin-cli -datadir=regtest -regtest help getinfo
error code: -32601
error message:
getinfo

This call was removed in version 0.16.0. Use the appropriate fields from:
- getblockchaininfo: blocks, difficulty, chain
- getnetworkinfo: version, protocolversion, timeoffset, connections, proxy, relayfee, warnings
- getwalletinfo: balance, keypoololdest, keypoolsize, paytxfee, unlocked_until, walletversion

bitcoin-cli has the option -getinfo to collect and format these in the old format.
```