### PR TITLE
blog: Add 'Test New Bitcoin.org Design' post

### DIFF
--- a/_posts/2018-05-01-test-the-new-site-design.md
+++ b/_posts/2018-05-01-test-the-new-site-design.md
@@ -1,0 +1,78 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+type: posts
+layout: post
+category: blog
+
+title: "Help Test Bitcoin.org's New Design Before Launch"
+permalink: /en/posts/test-the-new-site-design.html
+date: 2018-05-01
+author: |
+  <a href="https://github.com/wbnns">Will Binns</a>
+---
+
+## A Redesigned Bitcoin.org
+
+One of our goals in 2018 has been to modernize the look and feel of
+Bitcoin.org. Each day, tens of thousands of new users come to Bitcoin.org to
+learn how to get started using the currency and technology. The site has grown
+exponentially in popularity as Bitcoin adoption has increased. Last year alone,
+there were over 30 million visitors to Bitcoin.org. These visitors viewed the
+site's pages over 200 million times. Many of these pages are often the first
+results on search engines for bitcoin-related phrases and terms.
+
+As traffic and engagement has increased, however, the design has become very
+dated. In fact, the current look and feel of the site has pretty much remained
+the same for ~5 years, going all the way back to 2013. As a result, a large
+amount of effort and attention has gone into a recent redesign project, that's
+getting closer to complete. After holding a [community vote](https://bitcoin.org/en/posts/vote-on-the-new-site-design)
+on various design options, the community selection has been extended into all of
+the different subpages.
+
+We've reached one of the most critical phases of the project, now, which is
+getting feedback and lots of help testing from a bunch of different people,
+before it goes live.
+
+**[Help test the new design.](https://staging.bitcoin.org/)**
+
+If you visited the link above and experienced any issues or have feedback, please
+[send us an email](mailto:will@bitcoin.org?subject=Redesign%20Feedback") or
+[open an issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?title=Redesign%20Feedback)
+on Bitcoin.org's GitHub repository. Please also make sure to note your device,
+operating system and browser version(s), when applicable, to give us additional
+context and clarity - it is super-helpful.
+
+Even the most minor bits of feedback, nits or issues are welcome. The community
+we are all part of is very diverse, and we want to strive to make Bitcoin.org
+the best site it can be for as many people as possible.
+
+## Acknowledgments
+
+Bitcoin.org is funded exclusively by donations from the community, and a huge
+debt of gratitude is owed. Without community donations, the current redesign
+work would not have been possible. More enhancements and special projects are
+on the horizon, so stay tuned. The support from donations that allow
+Bitcoin.org to compete with sites that aren't community supported, are greatly
+appreciated.
+
+A big thanks is also due specifically to Natalia, Marek and Oleksandr at
+[ETHworks](https://ethworks.io) who have spear-headed the redesign efforts,
+worked tirelessly, and have delivered great results from the very beginning,
+every step of the way. They are amazingly talented people in the cryptocurrency
+space.
+
+## About Bitcoin.org
+
+Bitcoin.org was originally registered and owned by Satoshi Nakamoto and Martti
+Malmi. When Satoshi left the project, he gave ownership of the domain to
+additional people, separate from the Bitcoin developers, to spread
+responsibility and prevent any one person or group from easily gaining control
+over the Bitcoin project. Since then, the site has been developed and
+maintained by different members of the Bitcoin community.
+
+There have been over 3,200 commits from 180 contributors from all over the
+world. In addition to this, over 950 translators have helped to make the site
+display natively to visitors by default in their own languages —now 25
+different languages and growing.

--- a/_posts/2018-05-01-test-the-new-site-design.md
+++ b/_posts/2018-05-01-test-the-new-site-design.md
@@ -35,7 +35,7 @@ We've reached one of the most critical phases of the project, now, which is
 getting feedback and lots of help testing from a bunch of different people,
 before it goes live.
 
-**[Help test the new design.](https://staging.bitcoin.org/)**
+**[Help test the new design.](https://bitcoin.cryptopelago.com/)**
 
 If you visited the link above and experienced any issues or have feedback, please
 [send us an email](mailto:will@bitcoin.org?subject=Redesign%20Feedback") or


### PR DESCRIPTION
This adds a new blog post, soliciting testers from the community to help review the new Bitcoin.org design in preparation for launch.

Screenshot of post:

![image](https://user-images.githubusercontent.com/1130872/39505950-f51ca556-4d92-11e8-8acd-dce38da65750.png)

Cc: @Cobra-Bitcoin 