### PR TITLE
Update transparency score on mature wallets

### DIFF
--- a/_wallets/coinspace.md
+++ b/_wallets/coinspace.md
@@ -19,7 +19,7 @@ platform:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
-          transparency: "checkfailtransparencynew"
+          transparency: "checkpasstransparencyopensource"
           environment: "checkpassenvironmentmobile"
           privacy: "checkpassprivacybasic"
           fees: "checkpassfeecontroldynamic"
@@ -35,7 +35,7 @@ platform:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
-          transparency: "checkfailtransparencynew"
+          transparency: "checkpasstransparencyopensource"
           environment: "checkpassenvironmentmobile"
           privacy: "checkpassprivacybasic"
           fees: "checkpassfeecontroldynamic"
@@ -51,7 +51,7 @@ platform:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkfailvalidationcentralized"
-          transparency: "checkfailtransparencynew"
+          transparency: "checkpasstransparencyopensource"
           environment: "checkpassenvironmentmobile"
           privacy: "checkpassprivacybasic"
           fees: "checkpassfeecontroldynamic"

--- a/_wallets/digitalbitbox.md
+++ b/_wallets/digitalbitbox.md
@@ -19,7 +19,7 @@ platform:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"
-          transparency: "checkfailtransparencynew"
+          transparency: "checkgoodtransparencydeterministic"
           environment: "checkgoodenvironmenthardware"
           privacy: "checkneutralprivacyvariable"
           fees: "checkneutralfeecontrolvariable"

--- a/_wallets/keepkey.md
+++ b/_wallets/keepkey.md
@@ -19,7 +19,7 @@ platform:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"
-          transparency: "checkfailtransparencynew"
+          transparency: "checkpasstransparencyopensource"
           environment: "checkgoodenvironmenthardware"
           privacy: "checkneutralprivacyvariable"
           fees: "checkneutralfeecontrolvariable"

--- a/_wallets/ledgernanos.md
+++ b/_wallets/ledgernanos.md
@@ -19,7 +19,7 @@ platform:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"
-          transparency: "checkfailtransparencynew"
+          transparency: "checkpasstransparencyopenspechardware"
           environment: "checkgoodenvironmenthardware"
           privacy: "checkneutralprivacyvariable"
           fees: "checkneutralfeecontrolvariable"


### PR DESCRIPTION
This PR is to update the transparency score on coinspace @nikashitsa, digitalbitbox @douglasbakkum, keepkey @dstanchfield, and ledgernanos @EricLarch wallets.  These wallets had previously been listed  as "new" wallets which which earn the "fail" scoring.  These wallets have now all been listed for over six months and deserve better scoring.  Often, we allow developers to propose their scoring, but since these are overdue, I'll propose updated scoring here.