### PR TITLE
resources: Drop Airbitz as a 'Merchant' link

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -25,7 +25,6 @@ id: resources
     <p><a href="/{{ page.lang }}/{% translate choose-your-wallet url %}">{% translate linkwallets %}</a> - bitcoin.org</p>
     <p><a href="https://coinmap.org/">{% translate linkmerchants %}</a> - coinmap.org</p>
     <p><a href="https://spendabit.co/">{% translate linkmerchants %}</a> - spendabit.co</p>
-    <p><a href="https://airbitz.co/">{% translate linkmerchants %}</a> - airbitz.co</p>
     <p><a href="https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/">{% translate linkmerchants %}</a> - 99Bitcoins.com</p>
     <p><a href="https://www.buybitcoinworldwide.com/">{% translate linkexchanges %}</a> - buybitcoinworldwide.com</p>
     <p><a href="https://en.bitcoin.it/wiki/Category:Shopping_Cart_Interfaces">{% translate linkmerchantstools %}</a> - en.bitcoin.it</p>


### PR DESCRIPTION
This drops Airbitz from the resources page as a place to go to find Merchants. The link was pointing to their homepage which doesn't appear to contain any relevant information.

It was originally added to the page back in 2015 (8308d27c2a32982b67ae7d0db529376b3f26f4c0), so perhaps their homepage has changed quite a bit since then and shifted direction.

Unless others object, this will be merged on Wednesday, May 23rd.