### PR TITLE
Corrected a following to subsequent

### DIFF
--- a/_data/devdocs/en/guides/block_chain.md
+++ b/_data/devdocs/en/guides/block_chain.md
@@ -90,7 +90,7 @@ to work harder than honest peers who only want to add new blocks to the
 block chain.
 
 Chaining blocks together makes it impossible to modify transactions included
-in any block without modifying all previous blocks. As a
+in any block without modifying all subsequent blocks. As a
 result, the cost to modify a particular block increases with every new block
 added to the block chain, magnifying the effect of the proof of work.
 


### PR DESCRIPTION
Changing a transaction has no impact on previous blocks, it only impacts the block on which the transaction occurs and the subsequent/following blocks.