### PR TITLE
about-sidebar: Fix typo, 'begining'

### DIFF
--- a/_layouts/about-sidebar.html
+++ b/_layouts/about-sidebar.html
@@ -27,7 +27,7 @@ end_of_page: |
     <div class="own">
       <div class="own-block">
         <div class="own-timeline">
-          <p class="own-timeline-text">Begining</p>
+          <p class="own-timeline-text">Beginning</p>
           <div class="own-timeline-number">
             <img src="../img/getting-started/number-1.svg?{{site.time | date: '%s'}}" alt="1" class="own-timeline-number-img">
           </div>


### PR DESCRIPTION
This fixes a typo ('begining') and will be merged once tests passed.