### PR TITLE
Request to add SPOT Conference to the list of events

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -190,6 +190,14 @@
   country: "Canada"
   link: "https://blockchainsuperconference.com/"
 
+- date: 2018-07-23
+  title: "SPOT"
+  venue: "Hong Kong Exchange"
+  address: "8 Connaught Pl, Central, Hong Kong"
+  city: "Hong Kong"
+  country: "Hong Kong"
+  link: "https://www.spotconf.com/"
+
 - date: 2018-09-14
   title: "Blockchain & FutureTech Expo"
   venue: "Kay Bailey Hutchison Convention Center"

--- a/_events.yml
+++ b/_events.yml
@@ -193,7 +193,7 @@
 - date: 2018-07-23
   title: "SPOT"
   venue: "Hong Kong Exchange"
-  address: "8 Connaught Pl, Central, Hong Kong"
+  address: "8 Connaught Pl, Central"
   city: "Hong Kong"
   country: "Hong Kong"
   link: "https://www.spotconf.com/"


### PR DESCRIPTION
SPOT is a conference for cryptocurrency exchanges taking place on July 23 in Hong Kong.

- date: 2018-07-23
  title: "SPOT"
  venue: "Hong Kong Exchange"
  address: "8 Connaught Pl, Central"
  city: "Hong Kong"
  country: "Hong Kong"
  link: "https://www.spotconf.com/"