### PR TITLE
Adds 3xbit to the List of Brazilian Exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -271,6 +271,8 @@ id: exchanges
       <div>
         <h3 id="brazil" class="no_toc">Brazil</h3>
         <p>
+          <a class="marketplace-link" href="https://3xbit.com.br/">3xbit</a>
+          <br>
           <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>
           <br>
           <a class="marketplace-link" href="https://www.mercadobitcoin.com.br/">Mercado Bitcoin</a>
@@ -357,7 +359,7 @@ id: exchanges
         </p>
       </div>
     </div>
-    
+
     <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/US.svg?{{site.time | date: '%s'}}" alt="United States flag">
       <div>


### PR DESCRIPTION
We are a brazilian startup that seeks compliance in crypto currency trades. We can issue invoices to our services to enable the trade of crypto currencies. We also integrate digital bank accounts speeding up operations with FIAT;

__Unfortunately we don't own the *.com* domain.__

#### We have ownership of the following domains:
- 3xbit.com.br
- 3xbit.exchange
- 3xbit.global
- threexbit.com
- threexbit.com.br

#### Crunchbase
- https://www.crunchbase.com/organization/3xbit

#### Startse
- https://startse.com/in/3xbit

#### Brazilian Association of Startups
- https://startupbase.abstartups.com.br/startup/1898

#### Social Networks
- http://facebook.com/3xbit.global
- http://twitter.com/3xbit
- http://linkedin.com/company/3xbit
- http://instagram.com/3xbit.global