### PR TITLE
Alerts: Bitcoin Network Alert Retirement: Fix broken table

### DIFF
--- a/_alerts/2016-11-01-alert-retirement.md
+++ b/_alerts/2016-11-01-alert-retirement.md
@@ -66,6 +66,7 @@ receive the final alert.
 |Pre-final Alert|The alert itself warning that the Alert system will be retired|2016-11-02|
 |Final Alert|Max sequence Alert to disable the Alert system|2017-01-19|
 |Alert key release|The Alert key will be made publicly available|Postponed until further notice.|
+
 </div>
 
 <div class="toccontent-block boxexpand expanded" markdown="1">


### PR DESCRIPTION
On https://bitcoin.org/en/alert/2016-11-01-alert-retirement#the-retirement-plan , the markdown-table is broken by the div added to the end of it:

![2018-06-22-10_59_03_738588958](https://user-images.githubusercontent.com/61096/41783628-5462a6aa-760b-11e8-9879-d30ac53123ec.png)

This should fix it.  Note, I only tested with a quick preview not a full site build.

This is related to the links being added in https://github.com/bitcoin-core/bitcoincore.org/pull/567