### PR TITLE
exchanges: Add Dasset (New Zealand)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -248,6 +248,8 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 id="new-zealand" class="exchanges-tab-title exchanges-newzealand-title">New Zealand</h2>
   <p>
+    <a class="marketplace-link" href="https://www.dasset.co.nz/">Dasset</a>
+    <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
     <br>
     <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a>


### PR DESCRIPTION
Hello,

Please accept the changes made to exchange.html that has included Dasset which is an exchange based in New Zealand that accepts New Zealand Dollars in exchange for BTC amongst other cryptocurrencies.

Best Regards,
Dasset Team