### PR TITLE
Buy: add back link to LocalBitcoins in P2P Directory section

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -150,7 +150,7 @@ en:
     bitcoin-exchange: "Use a Bitcoin Exchange"
     bitcoin-exchange-text: "Our <a href=\"/en/exchanges\">Bitcoin Exchange</a> page, lists many different businesses that can help you buy Bitcoin using your bank account."
     p2p-bitcoins: "Browse a P2P Directory"
-    p2p-bitcoins-text: "Using a peer-to-peer directory lets you search and browse through various sellers of Bitcoin in your area. Sellers have reviews and feedback scores to help you choose."
+    p2p-bitcoins-text: "Using a peer-to-peer directory like <a href=\"https://localbitcoins.com/\">Local Bitcoins</a> or <a href=\"https://paxful.com/\">Paxful</a> lets you search and browse through various sellers of Bitcoin in your area. Sellers have reviews and feedback scores to help you choose."
     bitcoin-atm: "Use a Bitcoin ATM"
     bitcoin-atm-text: "Bitcoin ATMs work like a regular ATM, except they allow you to deposit and withdrawal money so that you can buy and sell Bitcoin. <a href=\"https://coinatmradar.com/\">Coin ATM Radar</a> has an interactive map to help you find the closest Bitcoin ATM near you."
   community:


### PR DESCRIPTION
In e7b9238d4d207a3f9d9eeb0793c9f9e6bb9b2ed5, the following text was removed:

```diff
-    local-bitcoins: "Discover people selling Bitcoin in your community"
-    local-bitcoins-text: "<a href=\"https://localbitcoins.com/\">Local Bitcoins</a> lets you search and browse through various sellers of Bitcoin in your area. Sellers have reviews and feedback scores to help you choose."
```

In response to feedback, the following text was added back in 77999a48247592deae8753df090d26a83fe53f7c,

```diff
+    p2p-bitcoins: "Browse a P2P Directory"
+    p2p-bitcoins-text: "Using a peer-to-peer directory lets you search and browse through various sellers of Bitcoin in your area. Sellers have reviews and feedback scores to help you choose."
```

When this was changed in PR #2485, I didn't notice that the text was rewritten to remove the link to LocalBitcoins.com, a competitor with Paxful.  I think targeted removal of links to a sponsor's competitor adds credence to the concerns about loss of neutrality given on #2485.  Rather than argue about it, I propose this PR that makes the (I think) reasonable compromise of adding back the link to LocalBitcoins along with a link to Paxful as two leading examples of a "P2P directory".