### PR TITLE
Add P2P section on Exchanges page

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -2521,6 +2521,10 @@ br.big {
     background: url(../img/flags/africa.svg?1528322191) center no-repeat;
     background-size: contain;
 }
+.exchanges-p2p-title::before {
+    background: url(../img/flags/ALL.svg?1528322191) center no-repeat;
+    background-size: contain;
+}
 .expanded .exchanges-content-row {
     display: -webkit-box;
     display: -ms-flexbox;

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -427,6 +427,19 @@ id: exchanges
   </div>
 </div>
 
+<div class="toccontent-block boxexpand expanded">
+  <h2 class="exchanges-tab-title exchanges-p2p-title" id="p2p">Peer-to-Peer (P2P)</h2>
+  <p>
+    <a class="marketplace-link" href="https://bisq.network/">Bisq</a>
+    <br>
+    <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
+    <br>
+    <a class="marketplace-link" href="https://localbitcoins.com/">Local Bitcoins</a>
+    <br>
+    <a class="marketplace-link" href="https://paxful.com/">Paxful</a>
+    <br>
+  </p>
+</div>
 
 <p class="introlink exchanges-introlink exchanges-buy-link">Visit
   <a href="https://www.buybitcoinworldwide.com/">Buy Bitcoin Worldwide</a> for user reviews on some of the above exchanges.

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -12,17 +12,23 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 class="exchanges-tab-title exchanges-international-title" id="international">International</h2>
   <p>
-    <a class="marketplace-link" href="https://bisq.network/">Bisq</a>
-    <br>
     <a class="marketplace-link" href="https://www.bitstamp.net/">Bitstamp</a>
     <br>
     <a class="marketplace-link" href="https://bitwage.com/">Bitwage</a>
     <br>
     <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
     <br>
-    <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
-    <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>
+    <br>
+  </p>
+</div>
+
+<div class="toccontent-block boxexpand expanded">
+  <h2 class="exchanges-tab-title exchanges-p2p-title" id="p2p">Peer-to-Peer (P2P)</h2>
+  <p>
+    <a class="marketplace-link" href="https://bisq.network/">Bisq</a>
+    <br>
+    <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
     <br>
     <a class="marketplace-link" href="https://localbitcoins.com/">Local Bitcoins</a>
     <br>
@@ -30,6 +36,7 @@ id: exchanges
     <br>
   </p>
 </div>
+
 <div class="toccontent-block boxexpand expanded exchanges-europe">
   <h2 class="exchanges-tab-title exchanges-europe-title" id="europe">Europe</h2>
   <div class="exchanges-content-row">
@@ -425,20 +432,6 @@ id: exchanges
       </div>
     </div>
   </div>
-</div>
-
-<div class="toccontent-block boxexpand expanded">
-  <h2 class="exchanges-tab-title exchanges-p2p-title" id="p2p">Peer-to-Peer (P2P)</h2>
-  <p>
-    <a class="marketplace-link" href="https://bisq.network/">Bisq</a>
-    <br>
-    <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
-    <br>
-    <a class="marketplace-link" href="https://localbitcoins.com/">Local Bitcoins</a>
-    <br>
-    <a class="marketplace-link" href="https://paxful.com/">Paxful</a>
-    <br>
-  </p>
 </div>
 
 <p class="introlink exchanges-introlink exchanges-buy-link">Visit

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -141,18 +141,18 @@ en:
     submit_new_translation: 'Do you want to translate the paper into your language? Visit the <a href="https://github.com/wbnns/bitcoinwhitepaper">Bitcoin whitepaper repository on GitHub</a> for instructions and <a href="https://github.com/wbnns/bitcoinwhitepaper/issues/new">open an issue</a> if you have any questions.'
   buy:
     title: "Buy Bitcoin"
-    pagetitle: "How to buy Bitcoin"
-    summary: "There are several ways you can buy Bitcoin."
+    pagetitle: "How to buy bitcoin"
+    summary: "There are several ways you can buy bitcoin."
     paxful: 'With more than 300 ways to buy and sell bitcoin, Paxful, a leading peer-to-peer (P2P) exchange and <a href="/en/posts/new-supporting-sponsorship-from-paxful">Bitcoin.org sponsor</a>, offers a convenient bitcoin marketplace.'
     button: "Buy Bitcoin with Paxful"
     sponsor: "Sponsored Content"
-    discover: "Discover more ways to buy Bitcoin:"
+    discover: "Discover more ways to buy bitcoin:"
     bitcoin-exchange: "Use a Bitcoin Exchange"
-    bitcoin-exchange-text: "Our <a href=\"/en/exchanges\">Bitcoin Exchange</a> page, lists many different businesses that can help you buy Bitcoin using your bank account."
+    bitcoin-exchange-text: "Our <a href=\"/en/exchanges\">Bitcoin Exchange</a> page, lists many different businesses that can help you buy bitcoin using your bank account."
     p2p-bitcoins: "Browse a P2P Directory"
     p2p-bitcoins-text: "Using an exchange based off of a <a href=\"/en/exchanges#p2p\">peer-to-peer directory</a> lets you search and browse through various sellers of bitcoin. Sellers have reviews and feedback scores to help you choose."
     bitcoin-atm: "Use a Bitcoin ATM"
-    bitcoin-atm-text: "Bitcoin ATMs work like a regular ATM, except they allow you to deposit and withdrawal money so that you can buy and sell Bitcoin. <a href=\"https://coinatmradar.com/\">Coin ATM Radar</a> has an interactive map to help you find the closest Bitcoin ATM near you."
+    bitcoin-atm-text: "Bitcoin ATMs work like a regular ATM, except they allow you to deposit and withdrawal money so that you can buy and sell bitcoin. <a href=\"https://coinatmradar.com/\">Coin ATM Radar</a> has an interactive map to help you find the closest bitcoin ATM near you."
   community:
     title: "Community - Bitcoin"
     pagetitle: "Bitcoin Communities"

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -150,7 +150,7 @@ en:
     bitcoin-exchange: "Use a Bitcoin Exchange"
     bitcoin-exchange-text: "Our <a href=\"/en/exchanges\">Bitcoin Exchange</a> page, lists many different businesses that can help you buy Bitcoin using your bank account."
     p2p-bitcoins: "Browse a P2P Directory"
-    p2p-bitcoins-text: "Using a peer-to-peer directory lets you search and browse through various sellers of Bitcoin in your area. Sellers have reviews and feedback scores to help you choose."
+    p2p-bitcoins-text: "Using an exchange based off of a <a href=\"/en/exchanges#p2p\">peer-to-peer directory</a> lets you search and browse through various sellers of bitcoin. Sellers have reviews and feedback scores to help you choose."
     bitcoin-atm: "Use a Bitcoin ATM"
     bitcoin-atm-text: "Bitcoin ATMs work like a regular ATM, except they allow you to deposit and withdrawal money so that you can buy and sell Bitcoin. <a href=\"https://coinatmradar.com/\">Coin ATM Radar</a> has an interactive map to help you find the closest Bitcoin ATM near you."
   community:


### PR DESCRIPTION
This adds a new P2P category on the exchanges page, to help highlight and support exchanges that are based on P2P exchange:

![image](https://user-images.githubusercontent.com/1130872/42676189-66cb64ec-8634-11e8-83f0-1a5b0c2b07d4.png)

The P2P directory card on the buy bitcoin page will also be linking to this.

This is scheduled to be merged on Monday, July 16th.