### PR TITLE
Update IRC channel: #bitcoin-dev → #bitcoin-core-dev

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -96,7 +96,7 @@ id: community
         <p>#bitcoin
           <small>{% translate chanbitcoin %}</small>
         </p>
-        <p>#bitcoin-dev
+        <p>#bitcoin-core-dev
           <small>{% translate chandev %}</small>
         </p>
         <p>#bitcoin-otc


### PR DESCRIPTION
The #bitcoin-dev IRC channel has been dead for more than two years now, so this updates the text to point to the active #bitcoin-core-dev channel.