### PR TITLE
bither: Remove Bither for iOS

### DIFF
--- a/_wallets/bither.md
+++ b/_wallets/bither.md
@@ -5,28 +5,12 @@
 id: bither
 title: "Bither"
 titleshort: "Bither"
-compat: "mobile ios android desktop windows mac linux"
+compat: "mobile android desktop windows mac linux"
 level: 2
 platform:
   - mobile:
     name: mobile
     os:
-      - name: ios
-        text: "walletbither"
-        link: "https://itunes.apple.com/us/app/bither/id899478936"
-        source: "https://github.com/bither/bither-ios"
-        screenshot: "bithermobile.png?1528322191"
-        check:
-          control: "checkgoodcontrolfull"
-          validation: "checkpassvalidationspvp2p"
-          transparency: "checkpasstransparencyopensource"
-          environment: "checkpassenvironmentmobile"
-          privacy: "checkfailprivacyweak"
-          fees: "checkfailfeecontrolstatic"
-        privacycheck:
-          privacyaddressreuse: "checkfailprivacyaddressrotation"
-          privacydisclosure: "checkfailprivacydisclosurespv"
-          privacynetwork: "checkfailprivacynetworknosupporttor"
       - name: android
         text: "walletbither"
         link: "https://play.google.com/store/apps/details?id=net.bither"


### PR DESCRIPTION
It seems that Bither for iOS [may no longer be available](https://itunes.apple.com/us/app/bither/id899478936) in the App Store. This drops the iOS option so users don't get misdirected to it.

Reached out to Bither Support to confirm (or perhaps others are able to load the page and it is some sort of localized or regional problem with the App Store). Will wait before merging just in case.