### PR TITLE
Fix for #2219: Add deprecated to Estimate Fee in developer reference

### DIFF
--- a/_data/devdocs/en/bitcoin-core/rpcs/quick-reference.md
+++ b/_data/devdocs/en/bitcoin-core/rpcs/quick-reference.md
@@ -160,7 +160,7 @@ Use v0.n.n in abbreviation title to prevent autocrossrefing.
 {% autocrossref %}
 
 * [CreateMultiSig][rpc createmultisig]: {{summary_createMultiSig}}
-* [EstimateFee][rpc estimatefee]: {{summary_estimateFee}} {{UPDATED0_14_0}}
+* [EstimateFee][rpc estimatefee]: {{summary_estimateFee}} {{UPDATED0_14_0}}{{DEPRECATED}}
 * [EstimatePriority][rpc estimatepriority]: {{summary_estimatePriority}} {{DEPRECATED}}
 * [GetMemoryInfo][rpc getmemoryinfo]: {{summary_getMemoryInfo}} {{NEW_14_0}}
 * [ValidateAddress][rpc validateaddress]: {{summary_validateAddress}} {{UPDATED0_13_0}}


### PR DESCRIPTION
PR to add deprecated for 'estimatefee' as requested in #2219