### PR TITLE
Small exchange page fixes

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -19,7 +19,6 @@ id: exchanges
     <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
     <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>
-    <br>
   </p>
 </div>
 
@@ -33,7 +32,6 @@ id: exchanges
     <a class="marketplace-link" href="https://localbitcoins.com/">Local Bitcoins</a>
     <br>
     <a class="marketplace-link" href="https://paxful.com/">Paxful</a>
-    <br>
   </p>
 </div>
 
@@ -136,7 +134,6 @@ id: exchanges
         <h3 id="indonesia" class="no_toc">Indonesia</h3>
         <p>
           <a class="marketplace-link" href="https://www.bitcoin.co.id/">Bitcoin Indonesia</a>
-          <br>
         </p>
       </div>
     </div>
@@ -291,7 +288,6 @@ id: exchanges
         <h3 id="chile" class="no_toc">Chile</h3>
         <p>
           <a class="marketplace-link" href="https://www.surbtc.com/">SurBTC</a>
-          <br>
         </p>
       </div>
     </div>
@@ -302,7 +298,6 @@ id: exchanges
         <h3 id="colombia" class="no_toc">Colombia</h3>
         <p>
           <a class="marketplace-link" href="https://www.surbtc.com/">SurBTC</a>
-          <br>
         </p>
       </div>
     </div>
@@ -323,7 +318,6 @@ id: exchanges
         <h3 id="peru" class="no_toc">Peru</h3>
         <p>
           <a class="marketplace-link" href="https://www.surbtc.com/">SurBTC</a>
-          <br>
         </p>
       </div>
     </div>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -55,7 +55,7 @@ id: exchanges
     </div>
     <div class="marketplace-row">
       <div class="row marketplace">
-        <img class="marketplace-flag" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukraine flag">
+        <img class="marketplace-flag" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag">
         <div>
           <h3 id="ukraine" class="no_toc">Ukraine</h3>
           <p>
@@ -64,7 +64,7 @@ id: exchanges
         </div>
       </div>
       <div class="row marketplace">
-        <img class="marketplace-flag" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="United Kingdom flag">
+        <img class="marketplace-flag" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="Polish flag">
         <div>
           <h3 id="poland" class="no_toc">Poland</h3>
           <p>
@@ -293,7 +293,7 @@ id: exchanges
     </div>
 
     <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/CO.svg?{{site.time | date: '%s'}}" alt="Colombia flag">
+      <img class="marketplace-flag" src="/img/flags/CO.svg?{{site.time | date: '%s'}}" alt="Colombian flag">
       <div>
         <h3 id="colombia" class="no_toc">Colombia</h3>
         <p>


### PR DESCRIPTION
This PR makes a couple small fixes to the Exchanges page and will be merged once tests pass:
1. Fixed the Polish flag icon which erroneously had an alt tag listing it as the flag for the United Kingdom (when doing this I also checked to make sure the names of the flags were standardized).
2. Removed several unnecessary line breaks.