### PR TITLE
Add Bither for iOS Back

### DIFF
--- a/_wallets/bither.md
+++ b/_wallets/bither.md
@@ -5,12 +5,28 @@
 id: bither
 title: "Bither"
 titleshort: "Bither"
-compat: "mobile android desktop windows mac linux"
+compat: "mobile ios android desktop windows mac linux"
 level: 2
 platform:
   - mobile:
     name: mobile
     os:
+      - name: ios
+        text: "walletbither"
+        link: "https://itunes.apple.com/us/app/bither/id899478936"
+        source: "https://github.com/bither/bither-ios"
+        screenshot: "bithermobile.png?1528322191"
+        check:
+          control: "checkgoodcontrolfull"
+          validation: "checkpassvalidationspvp2p"
+          transparency: "checkpasstransparencyopensource"
+          environment: "checkpassenvironmentmobile"
+          privacy: "checkfailprivacyweak"
+          fees: "checkfailfeecontrolstatic"
+        privacycheck:
+          privacyaddressreuse: "checkfailprivacyaddressrotation"
+          privacydisclosure: "checkfailprivacydisclosurespv"
+          privacynetwork: "checkfailprivacynetworknosupporttor"
       - name: android
         text: "walletbither"
         link: "https://play.google.com/store/apps/details?id=net.bither"


### PR DESCRIPTION
This Pull Request reverses #2530. After the discussion in #2530 with @wbnns , Apple eventually finished their review of Bither app. Bither is now back in App Store. 

[This link](https://itunes.apple.com/us/app/bither/id899478936) can lead you to the App Store download page of Bither when opened on iPhone.

Thank you for your effort @wbnns . Now we can add Bither iOS back.