### PR TITLE
[Resources] Add more recent Bitcoin Documentary links

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -154,6 +154,15 @@ id: resources
         <p>
           <a href="https://www.youtube.com/watch?v=6pWblf8COH4">The Bitcoin Phenomenon</a>
         </p>
+        <p>
+          <a href="https://www.youtube.com/watch?v=LszOt51OjXU">Bitcoin: Beyond The Bubble</a>
+        </p>
+        <p>
+          <a href="https://www.youtube.com/watch?v=PVo5wCSnmSs">Magic Money: The Bitcoin Revolution</a>
+        </p>
+        <p>
+          <a href="https://www.youtube.com/watch?v=HUpGHOLkoXs">Evolution of Bitcoin</a>
+        </p>
       </div>
 
       <div class="card resources-card">


### PR DESCRIPTION
The documentary links currently available in the site are dated back 2014-2015. This PR updates three more recent (2017) documentary links.