### PR TITLE
Hide currently selected wallet

### DIFF
--- a/_includes/layout/base/wallets-filter.html
+++ b/_includes/layout/base/wallets-filter.html
@@ -60,6 +60,9 @@ http://opensource.org/licenses/MIT.
 <div class="wallet-list wallet-filter-list">
     <!-- All wallets -->
     {% for wallet in site.wallets %}
+	{% if page.id contains wallet.id %}
+		{% continue %}
+	{% endif %}
     {% assign platformList = "" %}
     {% for platform in wallet.platform %}
      {% capture platformList %}{{platformList}}{{platform.name}} {% endcapture %}
@@ -95,6 +98,9 @@ http://opensource.org/licenses/MIT.
 
     <!-- Particular wallets-->
     {% for wallet in site.wallets %}
+		{% if page.id contains wallet.id %}
+			{% continue %}
+		{% endif %}
         {% for platform in wallet.platform %}
           {% for os in platform.os%}
           <div class="wallet-list-item" data-category="{{os.name}}" data-walletlevel="{{ wallet.level }}">

--- a/_includes/layout/base/wallets-filter.html
+++ b/_includes/layout/base/wallets-filter.html
@@ -60,9 +60,9 @@ http://opensource.org/licenses/MIT.
 <div class="wallet-list wallet-filter-list">
     <!-- All wallets -->
     {% for wallet in site.wallets %}
-	{% if page.id contains wallet.id %}
-		{% continue %}
-	{% endif %}
+    {% if page.id contains wallet.id %}
+     {% continue %}
+    {% endif %}
     {% assign platformList = "" %}
     {% for platform in wallet.platform %}
      {% capture platformList %}{{platformList}}{{platform.name}} {% endcapture %}
@@ -98,9 +98,9 @@ http://opensource.org/licenses/MIT.
 
     <!-- Particular wallets-->
     {% for wallet in site.wallets %}
-		{% if page.id contains wallet.id %}
-			{% continue %}
-		{% endif %}
+    {% if page.id contains wallet.id %}
+      {% continue %}
+    {% endif %}
         {% for platform in wallet.platform %}
           {% for os in platform.os%}
           <div class="wallet-list-item" data-category="{{os.name}}" data-walletlevel="{{ wallet.level }}">

--- a/_includes/layout/base/wallets-list.html
+++ b/_includes/layout/base/wallets-list.html
@@ -63,6 +63,9 @@ http://opensource.org/licenses/MIT.
 
         <!-- All wallets -->
         {% for wallet in site.wallets %} 
+		{% if page.id contains wallet.id %}
+			{% continue %}
+		{% endif %}
         {% assign platformList = "" %} 
         {% for platform in wallet.platform %} 
         {% capture platformList %}{{platformList}}{{platform.name}} {% endcapture %} 
@@ -94,6 +97,9 @@ http://opensource.org/licenses/MIT.
         
         <!-- Particular Wallets -->
         {% for wallet in site.wallets %} 
+		{% if page.id contains wallet.id %}
+			{% continue %}
+		{% endif %}
         {% assign platform = page.platform['name'] %} 
         {% assign os = page.os['name'] %} 
         {% if wallet.compat contains platform and wallet.compat contains os %}

--- a/_includes/layout/base/wallets-list.html
+++ b/_includes/layout/base/wallets-list.html
@@ -63,9 +63,9 @@ http://opensource.org/licenses/MIT.
 
         <!-- All wallets -->
         {% for wallet in site.wallets %} 
-		{% if page.id contains wallet.id %}
-			{% continue %}
-		{% endif %}
+	{% if page.id contains wallet.id %}
+	  {% continue %}
+        {% endif %}
         {% assign platformList = "" %} 
         {% for platform in wallet.platform %} 
         {% capture platformList %}{{platformList}}{{platform.name}} {% endcapture %} 
@@ -97,9 +97,9 @@ http://opensource.org/licenses/MIT.
         
         <!-- Particular Wallets -->
         {% for wallet in site.wallets %} 
-		{% if page.id contains wallet.id %}
-			{% continue %}
-		{% endif %}
+	{% if page.id contains wallet.id %}
+	  {% continue %}
+	{% endif %}
         {% assign platform = page.platform['name'] %} 
         {% assign os = page.os['name'] %} 
         {% if wallet.compat contains platform and wallet.compat contains os %}


### PR DESCRIPTION
This fixes https://github.com/bitcoin-dot-org/bitcoin.org/issues/2585 and hides the currently selected wallet because it's redundant to display it.