### PR TITLE
Add 10 Year Anniversary of Bitcoin.org Blog Post

### DIFF
--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -13,6 +13,9 @@
     <div class="mainvideo">
       <button class="mainvideo-btn-open" onclick="loadYoutubeVideo(event);" ontouchstart="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/{% if page.lang == 'ro' %}JPNwbWu0tMQ{% else %}Gc2en3nHxA4{% endif %}?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">What is Bitcoin?</button>
     </div>
+    <div class="mainannouncement">
+      <p>Special announcement - <a href="/en/posts/ten-year-anniversary">Bitcoin.org is ten years old!</a></p>
+    </div>
     {% include helpers/hero-social.html %}
   </div>
 </div>

--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -13,9 +13,11 @@
     <div class="mainvideo">
       <button class="mainvideo-btn-open" onclick="loadYoutubeVideo(event);" ontouchstart="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/{% if page.lang == 'ro' %}JPNwbWu0tMQ{% else %}Gc2en3nHxA4{% endif %}?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">What is Bitcoin?</button>
     </div>
+    {% if page.lang == 'en' %}
     <div class="mainannouncement">
       <p>Special announcement - <a href="/en/posts/ten-year-anniversary">Bitcoin.org is ten years old!</a></p>
     </div>
+    {% endif %}
     {% include helpers/hero-social.html %}
   </div>
 </div>

--- a/_posts/2018-08-16-ten-year-anniversary.md
+++ b/_posts/2018-08-16-ten-year-anniversary.md
@@ -47,7 +47,7 @@ Here are a few mentions and links to bitcoin.org from over the years:
 
 Today, bitcoin.org is one of the most visited Bitcoin websites and receives
 millions of visitors. Many thanks to all of the
-[contributors](/en/about-us#github) who have spent time their improving the
+[contributors](/en/about-us#github) who have spent their time improving the
 site!
 
 ## Interested in getting involved?

--- a/_posts/2018-08-16-ten-year-anniversary.md
+++ b/_posts/2018-08-16-ten-year-anniversary.md
@@ -1,0 +1,37 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+type: posts
+layout: post
+category: blog
+
+title: "Bitcoin.org is 10 Years Old!"
+permalink: /en/posts/new-supporting-sponsorship-from-paxful.html
+date: 2018-08-16
+author: |
+  <a href="https://github.com/wbnns">Will Binns</a>
+---
+
+{:.center}
+![Bitcoin.org is 10 Years Old](/img/blog/free/bitcoin-dot-org-10-years.gif?{{site.time | date: '%s'}})
+
+This month (August 18th, 2018 to be exact), will mark 10 years from the day bitcoin.org was registered. Bitcoin.org was originally registered and owned by Bitcoin's first two developers, Satoshi Nakamoto and Martti Malmi. When Nakamoto left the project, he gave ownership of the domain to additional people, separate from the Bitcoin developers, to spread responsibility and prevent any one person or group from easily gaining control over the Bitcoin project.
+
+Bitcoin.org's code is open source. Final publication authority is held by the co-owners, but all regular activity is organized through the public pull request process and managed by the site maintainer. To date on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), there have been over 4,400 commits from 245 contributors from all over the world. In addition to this, over [1000 translators](https://www.transifex.com/bitcoinorg/bitcoinorg/) have helped to make the site display natively to visitors by default in their own languages — now 27 different languages and growing.
+
+Here are a few mentions and links to bitcoin.org from over the years:
++ 2009 - [Bitcoin open source implementation of P2P currency](http://p2pfoundation.ning.com/forum/topics/bitcoin-open-source)
++ 2010 - [Bitcoin Releases Version 0.3](https://news.slashdot.org/story/10/07/11/1747245/bitcoin-releases-version-03)
++ 2011 - [Bitcoin - A Step Toward Censorship-Resistant Digital Currency](https://www.eff.org/deeplinks/2011/01/bitcoin-step-toward-censorship-resistant)
++ 2012 - [Bitcoin - The Libertarian Introduction](http://moneyandstate.com/bitcoin-libertarian-introduction-used-care/)
++ 2013 - [The Economics of Bitcoin](https://www.econlib.org/library/Columns/y2013/Murphybitcoin.html)
++ 2014 - [The Best Places on the Internet to Learn About Bitcoin](https://medium.com/zapchain-magazine/the-best-places-on-the-internet-to-learn-about-bitcoin-a4733f9f3ac7)
++ 2015 - [Russia blocks bitcoin websites over "shadow economy" fears](https://gigaom.com/2015/01/13/russia-blocks-bitcoin-websites-as-potential-ban-looms/)
++ 2016 - [What Is Gitian Building? How Bitcoin's Security Processes Became a Model for the Open Source Community](https://bitcoinmagazine.com/articles/what-is-gitian-building-how-bitcoin-s-security-processes-became-a-model-for-the-open-source-community-1461862937/)
++ 2017 - [Bitcoin: What's in the whitepaper?](https://www.linkedin.com/pulse/bitcoin-whats-whitepaper-benjamin-hendricks)
+
+Today, bitcoin.org is one of the most visited Bitcoin websites and receives millions of visitors a year. Many thanks to all contributors who are spending time improving the site!
+
+## Interested in getting involved?
+You can report any problem or help to improve bitcoin.org on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org#how-to-participate) by opening an issue or a pull request. When submitting a pull request, please take required time to discuss your changes and adapt your work. You can also help with translations by joining a team on [Transifex](https://github.com/bitcoin-dot-org/bitcoin.org#translation). 

--- a/_posts/2018-08-16-ten-year-anniversary.md
+++ b/_posts/2018-08-16-ten-year-anniversary.md
@@ -7,31 +7,53 @@ layout: post
 category: blog
 
 title: "Bitcoin.org is 10 Years Old!"
-permalink: /en/posts/new-supporting-sponsorship-from-paxful.html
+permalink: /en/posts/ten-year-anniversary.html
 date: 2018-08-16
 author: |
   <a href="https://github.com/wbnns">Will Binns</a>
 ---
+## Bitcoin.org, registered August 18, 2008
 
 {:.center}
 ![Bitcoin.org is 10 Years Old](/img/blog/free/bitcoin-dot-org-10-years.gif?{{site.time | date: '%s'}})
 
-This month (August 18th, 2018 to be exact), will mark 10 years from the day bitcoin.org was registered. Bitcoin.org was originally registered and owned by Bitcoin's first two developers, Satoshi Nakamoto and Martti Malmi. When Nakamoto left the project, he gave ownership of the domain to additional people, separate from the Bitcoin developers, to spread responsibility and prevent any one person or group from easily gaining control over the Bitcoin project.
+This month marks 10 years since the bitcoin.org domain was registered.
+Bitcoin.org was originally registered and owned by Bitcoin's first two
+developers, Satoshi Nakamoto and Martti Malmi. When Satoshi left the project,
+he gave ownership of the domain to additional people, separate from the Bitcoin
+developers, to spread responsibility and prevent any one person or group from
+easily gaining control over the Bitcoin project.
 
-Bitcoin.org's code is open source. Final publication authority is held by the co-owners, but all regular activity is organized through the public pull request process and managed by the site maintainer. To date on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), there have been over 4,400 commits from 245 contributors from all over the world. In addition to this, over [1000 translators](https://www.transifex.com/bitcoinorg/bitcoinorg/) have helped to make the site display natively to visitors by default in their own languages — now 27 different languages and growing.
+Bitcoin.org's code is open source. Final publication authority is held by the
+co-owners, but all regular activity is organized through the public pull request
+process and managed by the site maintainer. To date on
+[GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), there have been over
+4,400 commits from 245 contributors from all over the world. In addition to
+this, over [1000 translators](https://www.transifex.com/bitcoinorg/bitcoinorg/)
+have helped to make the site display natively to visitors by default in their
+own languages — now 27 different languages and growing.
 
 Here are a few mentions and links to bitcoin.org from over the years:
-+ 2009 - [Bitcoin open source implementation of P2P currency](http://p2pfoundation.ning.com/forum/topics/bitcoin-open-source)
-+ 2010 - [Bitcoin Releases Version 0.3](https://news.slashdot.org/story/10/07/11/1747245/bitcoin-releases-version-03)
-+ 2011 - [Bitcoin - A Step Toward Censorship-Resistant Digital Currency](https://www.eff.org/deeplinks/2011/01/bitcoin-step-toward-censorship-resistant)
-+ 2012 - [Bitcoin - The Libertarian Introduction](http://moneyandstate.com/bitcoin-libertarian-introduction-used-care/)
-+ 2013 - [The Economics of Bitcoin](https://www.econlib.org/library/Columns/y2013/Murphybitcoin.html)
-+ 2014 - [The Best Places on the Internet to Learn About Bitcoin](https://medium.com/zapchain-magazine/the-best-places-on-the-internet-to-learn-about-bitcoin-a4733f9f3ac7)
-+ 2015 - [Russia blocks bitcoin websites over "shadow economy" fears](https://gigaom.com/2015/01/13/russia-blocks-bitcoin-websites-as-potential-ban-looms/)
-+ 2016 - [What Is Gitian Building? How Bitcoin's Security Processes Became a Model for the Open Source Community](https://bitcoinmagazine.com/articles/what-is-gitian-building-how-bitcoin-s-security-processes-became-a-model-for-the-open-source-community-1461862937/)
-+ 2017 - [Bitcoin: What's in the whitepaper?](https://www.linkedin.com/pulse/bitcoin-whats-whitepaper-benjamin-hendricks)
 
-Today, bitcoin.org is one of the most visited Bitcoin websites and receives millions of visitors a year. Many thanks to all contributors who are spending time improving the site!
+* 2009 - [Bitcoin open source implementation of P2P currency](http://p2pfoundation.ning.com/forum/topics/bitcoin-open-source)
+* 2010 - [Bitcoin Releases Version 0.3](https://news.slashdot.org/story/10/07/11/1747245/bitcoin-releases-version-03)
+* 2011 - [Bitcoin - A Step Toward Censorship-Resistant Digital Currency](https://www.eff.org/deeplinks/2011/01/bitcoin-step-toward-censorship-resistant)
+* 2012 - [Bitcoin - The Libertarian Introduction](http://moneyandstate.com/bitcoin-libertarian-introduction-used-care/)
+* 2013 - [The Economics of Bitcoin](https://www.econlib.org/library/Columns/y2013/Murphybitcoin.html)
+* 2014 - [The Best Places on the Internet to Learn About Bitcoin](https://medium.com/zapchain-magazine/the-best-places-on-the-internet-to-learn-about-bitcoin-a4733f9f3ac7)
+* 2015 - [Russia blocks bitcoin websites over "shadow economy" fears](https://gigaom.com/2015/01/13/russia-blocks-bitcoin-websites-as-potential-ban-looms/)
+* 2016 - [What Is Gitian Building? How Bitcoin's Security Processes Became a Model for the Open Source Community](https://bitcoinmagazine.com/articles/what-is-gitian-building-how-bitcoin-s-security-processes-became-a-model-for-the-open-source-community-1461862937/)
+* 2017 - [Bitcoin: What's in the whitepaper?](https://www.linkedin.com/pulse/bitcoin-whats-whitepaper-benjamin-hendricks)
+
+Today, bitcoin.org is one of the most visited Bitcoin websites and receives
+millions of visitors. Many thanks to all of the
+[contributors](/en/about-us#github) who have spent time their improving the
+site!
 
 ## Interested in getting involved?
-You can report any problem or help to improve bitcoin.org on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org#how-to-participate) by opening an issue or a pull request. When submitting a pull request, please take required time to discuss your changes and adapt your work. You can also help with translations by joining a team on [Transifex](https://github.com/bitcoin-dot-org/bitcoin.org#translation). 
+You can report any problem or help to improve bitcoin.org on
+[GitHub](https://github.com/bitcoin-dot-org/bitcoin.org#how-to-participate) by
+opening an issue or a pull request. When submitting a pull request, please take
+required time to discuss your changes and adapt your work. You can also help
+with translations by joining a team on
+[Transifex](https://github.com/bitcoin-dot-org/bitcoin.org#translation).

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -778,6 +778,14 @@ h1 span.fa, h2 span.fa, h3 span.fa, h4 span.fa, h5 span.fa, h6 span.fa {
     background-size: contain;
     border: none;
 }
+.mainannouncement {
+  margin: 18px auto 0;
+  text-align: center;
+}
+.mainannouncement a {
+  color: #FF7E00;
+  text-decoration: underline;
+}
 .closed {
     display: none;
 }


### PR DESCRIPTION
Tomorrow, August 18, 2018 will be ten years since the bitcoin.org domain was registered. This PR adds  a blog post commemorating the milestone and thanks the contributors who have helped develop the site over the years:

![image](https://user-images.githubusercontent.com/1130872/44283633-437f4b80-a21c-11e8-9109-40a748718f1d.png)

I added a small link on the homepage (that only appears to English readers), linking to the blog post and was thinking we could leave it up for the next week or so (if people think it's a good idea):

![image](https://user-images.githubusercontent.com/1130872/44283733-8b05d780-a21c-11e8-8dd5-07178cb10009.png)

Feedback welcome.

Cc: @Cobra-Bitcoin

Closes #2294