### PR TITLE
about-us: Change alias to real name

### DIFF
--- a/_templates/about-us.html
+++ b/_templates/about-us.html
@@ -75,7 +75,7 @@ id: about-us
       <br>
       <span>Danish</span>
     </p>
-    <p class="contributor">Pavel Nedved
+    <p class="contributor">Pavle Djordjevic
       <br>
       <span>Serbian</span>
     </p>


### PR DESCRIPTION
This updates Pavle Djordjevic's position as the Serbian translation coordinator to use his real name instead of his alias ([as discussed](https://github.com/bitcoin-dot-org/bitcoin.org/pull/2596#issuecomment-414570070) in #2596).

This will be merged once tests pass.