### PR TITLE
index: Shorten text to remove wrap

### DIFF
--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -15,7 +15,7 @@
     </div>
     {% if page.lang == 'en' %}
     <div class="mainannouncement">
-      <p>Special announcement - <a href="/en/posts/ten-year-anniversary">Bitcoin.org is ten years old!</a></p>
+      <p>New Blog Post: <a href="/en/posts/ten-year-anniversary">Bitcoin.org is ten years old!</a></p>
     </div>
     {% endif %}
     {% include helpers/hero-social.html %}


### PR DESCRIPTION
This shortens the announcement text in #2597 so that it won't wrap on smaller mobile / handheld devices, and will be merged once tests pass.