### PR TITLE
scams: Add translation string

### DIFF
--- a/_templates/scams.html
+++ b/_templates/scams.html
@@ -43,7 +43,7 @@ voc:
   <div class="row toc-row">
     <div id="toc" class="toc">
       <div>
-        <button class="mob-sidebar-open" hidden>ALL TOPICS</button>
+        <button class="mob-sidebar-open" hidden>{% translate table %}</button>
         <div class="sidebar">
           <div class="sidebar-inner vocabulary-list">
             <button class="mob-sidebar-close" hidden></button>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -816,7 +816,7 @@ en:
     title: "Avoid Scams - Bitcoin"
     pagetitle: "Avoid Scams"
     summary: "Familiarize yourself with some of the most commonly observed bitcoin scams to help protect yourself and your finances."
-    table: "Table of contents"
+    table: "Types of Scams"
     blackmail: "blackmail"
     blackmailtxt: "Be wary of blackmail attempts in which strangers threaten you in exchange for bitcoin as a means of extortion. One common execution of this method is by email, where-in the sender transmits a message claiming that he/she has hacked into your computer and is operating it via remote desktop protocol (RDP). The sender says that a key logger has been installed and that your web cam was used to record you doing something you may not want others to know about. The sender provides two options - send bitcoin to suppress the material, or send nothing and see the content sent to your email contacts and spread across your social networks. Scammers use stolen email lists and other leaked user information to run this scheme across thousands of people en masse."
     fake-exchanges: "fake exchanges"


### PR DESCRIPTION
This page inherited an issue from the glossary page that it was modeled after, where-in a translation string was missing. This fixes the issue and also provides the applicable string for the page.

This will be merged once tests pass.