### PR TITLE
sidebar: Change 'View Topics' to 'View All'

### DIFF
--- a/_layouts/sidebar.html
+++ b/_layouts/sidebar.html
@@ -35,7 +35,7 @@ end_of_page: |
 
     <div id="toc" class="toc">
       <div>
-        <button class="mob-sidebar-open" hidden>ALL TOPICS</button>
+        <button class="mob-sidebar-open" hidden>View All</button>
         <div class="sidebar">
           <div class="sidebar-inner">
             <button class="mob-sidebar-close" hidden></button>


### PR DESCRIPTION
This fixes an issue where-in some pages inherit button text from sidebar.html that does not make sense - like on the exchanges page, for example, where it says 'View Topics'. There are no topics on that page. This is because the table of contents button in the sidebar was erroneously written for the vocabulary page. As implemented, it should have been more generically worded. This updates the text to say 'View All' instead so that it makes sense when displayed on different pages.

This affects mobile / handheld device users and will be merged once tests pass.