### PR TITLE
exchanges: Change name, Bitcoin Indonesia > Indodax

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -43,7 +43,7 @@ id: exchanges
       <div>
         <h3 id="indonesia" class="no_toc">Indonesia</h3>
         <p>
-          <a class="marketplace-link" href="https://www.bitcoin.co.id/">Bitcoin Indonesia</a>
+          <a class="marketplace-link" href="https://indodax.com/">Indodax</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Bitcoin Indonesia has rebranded and changed their name to Indodax. This
updates the name and will be merged once tests pass.