### PR TITLE
Extended "Assisting with Translations" document

### DIFF
--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -4,14 +4,14 @@ This document provides information regarding translations for bitcoin.org.
 
 ## Table of Contents
 * [Handling Translations on GitHub](#handling-translations-on-github)
-* [Getting started with the Translation Team](#getting-started-with-the-translation-team)
+* [Getting Started with the Translation Team](#getting-started-with-the-translation-team)
 * [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)
 
 ___
 
 ## Handling Translations on GitHub
 
-This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [Getting started with the Translation Team](#getting-started-with-the-translation-team).
+This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to the section [Getting Started with the Translation Team](#getting-started-with-the-translation-team).
 
 ### Import Translations
 
@@ -68,7 +68,7 @@ translations at once:
     
 ___
 
-## Getting started with the Translation Team
+## Getting Started with the Translation Team
 
 While the website itself is managed on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), the translations are handled through [Transifex](https://www.transifex.com/bitcoinorg/bitcoinorg/).
 This section shall explain the first steps on Transifex for new volunteers who want to help with translating bitcoin.org.
@@ -76,7 +76,7 @@ This section shall explain the first steps on Transifex for new volunteers who w
 General guidelines provided by Transifex itself can be found [here](https://docs.transifex.com/getting-started/translators).
 
 ### 1. Create a Transifex Account
-* Follow this [link](https://www.transifex.com/signup/) and create an account. Not much information is needed.
+* Follow this [link](https://www.transifex.com/signup/) and create an account. Creating a Transifex account is free and not much information is needed.
 
 ### 2. Login and join the Bitcoin.org Translation Team
 
@@ -88,7 +88,7 @@ General guidelines provided by Transifex itself can be found [here](https://docs
 ### 3.	Get to know the Interface
 * Play around with the interface. Transifex's interface can be a bit confusing and it cannot hurt to take a look around.
 * As Translator, you cannot cause any harm as you can only edit unreviewed strings. A complete history is saved for every string, making it impossible to destroy previous work.
-* For the beginning, stay away from the Glossary as this can be edited by new translators but no history is saved.
+* In the beginning, stay away from the Glossary as this can be edited by new translators but no history is saved.
 
 ### 4.	Join our Telegram Group
 * Join our [Telegram Group](https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg).
@@ -134,7 +134,7 @@ Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: “Komodorpud
 
 ### 2.	Coordinators
 Various people across all language teams are coordinators. For a number of languages, no active coordinator exists. If there are any questions or you want to assist by becoming a coordinator, write one of the Team Leaders.
-* If man power is needed: Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
+* When additional help is needed: Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 * Oversight on the complete translation efforts for a specific language.
 * Notifying Team Leaders if a resource is ready to be put on the website.
 * Being a contact person for the Team Leaders.
@@ -147,8 +147,8 @@ Various people across all language teams are coordinators. For a number of langu
 * Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 * Reviewing strings (preferably not your own strings if possible).
 * Checking translations for correctness regarding meaning and spelling.
-* Checking for consistency across translations (e.g. is “transaction malleability” translated consistently across all string?).
+* Checking for consistency across translations (e.g. is “transaction malleability” translated consistently across all strings?).
 
 ### 4. Translators
 * Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
-* Extending the glossary with translations for necessary and general term
+* Extending the glossary with translations for necessary and general terms.

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,4 +1,4 @@
-# Assisting with Translations#
+# Assisting with Translations
 
 This document provides information regarding translations for bitcoin.org.
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,5 +1,6 @@
 
 ___
+___
 
 ## A. Handling Translations on GitHub.md
 
@@ -59,6 +60,7 @@ translations at once:
     tx push -s -t -f --skip --no-interactive
     
 ___
+___
 
 ## B. Getting started with the Bitcoin.org Translation Team
 
@@ -109,6 +111,7 @@ General guidelines provided by Transifex itself can be found [here](https://docs
 ### 7.	Take a look at the Responsibilities and Tasks for each User Role
 * The next document in this folder, "2. responsibilities-and-tasks-for-each-user-role", outlines - as the title says - the responsibilities and tasks for each user role.
 
+___
 ___
 
 ## C. Responsibilities and Tasks for each User Role

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,6 +1,6 @@
 Table of content
 
-[B. Getting started with the Bitcoin.org Translation Team](#b.-getting-started-with-the-bitcoin.org-translation-team)
+[B. Getting started with the Bitcoin.org Translation Team](#B.-Getting-started-with-the-Bitcoin.org-Translation-Team)
 
 
 ___

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -2,11 +2,11 @@ Table of content
 
 [B. Getting started with the Bitcoin.org Translation Team](#B.-Getting-started-with-the-Bitcoin.org-Translation-Team)
 
-[Go to Real Cool Heading section](#real-cool-heading)
+[Go to Real Cool Heading section](#A.-real-cool-heading)
 ___
 ___
 
-# Real Cool Heading
+# A. Real Cool Heading
 
 ## A. Handling Translations on GitHub
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -58,7 +58,7 @@ translations at once:
     # Push changes back to Transifex
     tx push -s -t -f --skip --no-interactive
     
-    ___
+___
 
 ## B. Getting started with the Bitcoin.org Translation Team
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -2,7 +2,7 @@
 
 This document provides information regarding translations for bitcoin.org.
 
-## Table of Content
+## Table of Contents
 * [Handling Translations on GitHub](#handling-translations-on-github)
 * [Getting started with the Translation Team](#getting-started-with-the-translation-team)
 * [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -2,11 +2,11 @@ Table of content
 
 [B. Getting started with the Bitcoin.org Translation Team](#B.-Getting-started-with-the-Bitcoin.org-Translation-Team)
 
-[Go to Real Cool Heading section](#a-real-cool-heading)
+[Go to Real Cool Heading section](#a.-real-cool-heading)
 ___
 ___
 
-# A Real Cool Heading
+# A. Real Cool Heading
 
 ## A. Handling Translations on GitHub
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -2,7 +2,7 @@ Table of content
 
 [B. Getting started with the Bitcoin.org Translation Team](#B.-Getting-started-with-the-Bitcoin.org-Translation-Team)
 
-[Go to Real Cool Heading section](#A-real-cool-heading)
+[Go to Real Cool Heading section](#a-real-cool-heading)
 ___
 ___
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,10 +1,14 @@
+Table of content
+
+[B. Getting started with the Bitcoin.org Translation Team](#b.-getting-started-with-the-bitcoin.org-translation-team)
+
 
 ___
 ___
 
 ## A. Handling Translations on GitHub.md
 
-This document outlines how to handle translations on GitHub. If you only want to help by translating content, take a look at document "1. getting-started.md" in this folder.
+This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [B. Getting started with the Bitcoin.org Translation Team](#b.-getting-started-with-the-bitcoin.org-translation-team)
 
 ### Import Translations
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -71,7 +71,7 @@ ___
 ## Getting started with the Translation Team
 
 While the website itself is managed on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), the translations are handled through [Transifex](https://www.transifex.com/bitcoinorg/bitcoinorg/).
-This document shall explain the first steps on Transifex for new volunteers who want to help with translating bitcoin.org.
+This section shall explain the first steps on Transifex for new volunteers who want to help with translating bitcoin.org.
 
 General guidelines provided by Transifex itself can be found [here](https://docs.transifex.com/getting-started/translators).
 
@@ -121,7 +121,7 @@ ___
 
 ## Responsibilities and Tasks for each User Role
 
-This document shall outline the responsibilities and tasks for each user role.
+This section shall outline the responsibilities and tasks for each user role.
 
 ### 1. Team Leaders
 Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: “Komodorpudel”) and Apple AKA “ajsolbrilla”.

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,18 +1,15 @@
-Table of content
+# Assisting with Translations
 
 * [Handling Translations on GitHub](#handling-translations-on-github)
 * [Getting started with the Bitcoin.org Translation Team](#getting-started-with-the-bitcoin.org-translation-team)
 * [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)
 
-
 ___
 ___
-
-# Real Cool Heading
 
 ## Handling Translations on GitHub
 
-This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [B. Getting started with the Bitcoin.org Translation Team](#b.-getting-started-with-the-bitcoin.org-translation-team)
+This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [Getting started with the Bitcoin.org Translation Team](#getting-started-with-the-bitcoin.org-translation-team)
 
 ### Import Translations
 
@@ -117,7 +114,7 @@ General guidelines provided by Transifex itself can be found [here](https://docs
   appreciated.**
   
 ### 7.	Take a look at the Responsibilities and Tasks for each User Role
-* The next document in this folder, "2. responsibilities-and-tasks-for-each-user-role", outlines - as the title says - the responsibilities and tasks for each user role.
+* The next section [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role) outlines - as the title says - the responsibilities and tasks for each user role.
 
 ___
 ___

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -8,7 +8,7 @@ ___
 
 ## Handling Translations on GitHub
 
-This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [Getting started with the Bitcoin.org Translation Team](#getting-started-with-the-bitcoin.org-translation-team)
+This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [Getting started with the Translation Team](#getting-started-with-the-translation-team)
 
 ### Import Translations
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -5,7 +5,6 @@
 * [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)
 
 ___
-___
 
 ## Handling Translations on GitHub
 
@@ -65,7 +64,6 @@ translations at once:
     tx push -s -t -f --skip --no-interactive
     
 ___
-___
 
 ## Getting started with the Bitcoin.org Translation Team
 
@@ -116,7 +114,6 @@ General guidelines provided by Transifex itself can be found [here](https://docs
 ### 7.	Take a look at the Responsibilities and Tasks for each User Role
 * The next section [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role) outlines - as the title says - the responsibilities and tasks for each user role.
 
-___
 ___
 
 ## Responsibilities and Tasks for each User Role

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,7 +1,7 @@
 # Assisting with Translations
 
 * [Handling Translations on GitHub](#handling-translations-on-github)
-* [Getting started with the Bitcoin.org Translation Team](#getting-started-with-the-bitcoin.org-translation-team)
+* [Getting started with the Translation Team](#getting-started-with-the-translation-team)
 * [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)
 
 ___
@@ -65,7 +65,7 @@ translations at once:
     
 ___
 
-## Getting started with the Bitcoin.org Translation Team
+## Getting started with the Translation Team
 
 While the website itself is managed on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), the translations are handled through [Transifex](https://www.transifex.com/bitcoinorg/bitcoinorg/).
 This document shall explain the first steps on Transifex for new volunteers who want to help with translating bitcoin.org.

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -2,11 +2,11 @@ Table of content
 
 [B. Getting started with the Bitcoin.org Translation Team](#B.-Getting-started-with-the-Bitcoin.org-Translation-Team)
 
-[Go to Real Cool Heading section](#A.-real-cool-heading)
+[Go to Real Cool Heading section](#A-real-cool-heading)
 ___
 ___
 
-# A. Real Cool Heading
+# A Real Cool Heading
 
 ## A. Handling Translations on GitHub
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -85,17 +85,17 @@ General guidelines provided by Transifex itself can be found [here](https://docs
 * Your request to join a team will be accepted instantly, and you will be a translator for the language you selected.
 * If your language is not available yet, close the pop-up, scroll down, and click on “Request language” on the right side. Please consider first if it is necessary that bitcoin.org is available in your language. There is a lot of content to be translated and especially for languages with a low number of native speakers, there won’t be many people available that are willing to assist you.
 
-### 3.	Get to know the Interface
+### 3. Get to know the Interface
 * Play around with the interface. Transifex's interface can be a bit confusing and it cannot hurt to take a look around.
 * As Translator, you cannot cause any harm as you can only edit unreviewed strings. A complete history is saved for every string, making it impossible to destroy previous work.
 * In the beginning, stay away from the Glossary as this can be edited by new translators but no history is saved.
 
-### 4.	Join our Telegram Group
+### 4. Join our Telegram Group
 * Join our [Telegram Group](https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg).
 * The website maintainer, both Team Leaders for translations, a number of language coordinators, and various translators are present in this group.
 * We are happy to help in case you need assistance.
 
-### 5.	Choose what you want to translate
+### 5. Choose what you want to translate
 * Click on "Dashboard" on the top.
 * Once you are on the "Dashboard", click on "Languages" on the left side and select your language.
 * You will see a lot of different resources and their progress.
@@ -104,7 +104,7 @@ General guidelines provided by Transifex itself can be found [here](https://docs
 * **The first resource "bitcoin.org" contains all strings of the main page. If you are no Bitcoin expert, start here.**
 * **Everything else that follows starts with "devdocs...", indicating that these files are part of the developer documentation. It is recommended that you only try to translate the developer documentation if you are an experienced Bitcoin user and/or developer with a profound understanding.**
 
-### 6.	Start translating
+### 6. Start translating
 * You must be a native speaker for the language you choose to translate.
 * Please be careful to preserve the original meaning of each text.
 * Sentences and popular expressions should sound native in your language.
@@ -114,7 +114,7 @@ General guidelines provided by Transifex itself can be found [here](https://docs
 * **In doubt, please contact coordinators on Transifex. That'll be much
   appreciated.**
   
-### 7.	Take a look at the Responsibilities and Tasks for each User Role
+### 7. Take a look at the Responsibilities and Tasks for each User Role
 * The next section [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role) outlines - as the title says - the responsibilities and tasks for each user role.
 
 ___
@@ -132,7 +132,7 @@ Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: “Komodorpud
 * Promoting or demoting users (e.g. promoting a reviewer to coordinator).
 * Managing groups that have no active coordinator.
 
-### 2.	Coordinators
+### 2. Coordinators
 Various people across all language teams are coordinators. For a number of languages, no active coordinator exists. If there are any questions or you want to assist by becoming a coordinator, write one of the Team Leaders.
 * When additional help is needed: Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 * Oversight on the complete translation efforts for a specific language.

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -4,8 +4,11 @@ Table of content
 * [Getting started with the Bitcoin.org Translation Team](#Getting-started-with-the-Bitcoin.org-Translation-Team)
 * [Responsibilities and Tasks for each User Role](#Responsibilities-and-Tasks-for-each-User-Role)
 
+[Go to Real Cool Heading section](#real-cool-heading)
 ___
 ___
+
+#Real Cool Heading
 
 ## Handling Translations on GitHub
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -2,11 +2,11 @@ Table of content
 
 [B. Getting started with the Bitcoin.org Translation Team](#B.-Getting-started-with-the-Bitcoin.org-Translation-Team)
 
-[Go to Real Cool Heading section](#a.-real-cool-heading)
+[Go to Real Cool Heading section](#(a)-real-cool-heading)
 ___
 ___
 
-# A. Real Cool Heading
+# (A) Real Cool Heading
 
 ## A. Handling Translations on GitHub
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,5 +1,8 @@
-# Assisting with Translations
+# Assisting with Translations#
 
+This document provides information regarding translations for bitcoin.org.
+
+## Table of Content
 * [Handling Translations on GitHub](#handling-translations-on-github)
 * [Getting started with the Translation Team](#getting-started-with-the-translation-team)
 * [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,8 +1,8 @@
 Table of content
 
-* [Handling Translations on GitHub](#handling-translations-on-gitHub)
-* [Getting started with the Bitcoin.org Translation Team](#Getting-started-with-the-Bitcoin.org-Translation-Team)
-* [Responsibilities and Tasks for each User Role](#Responsibilities-and-Tasks-for-each-User-Role)
+[Handling Translations on GitHub](#handling-translations-on-github)
+[Getting started with the Bitcoin.org Translation Team](#Getting-started-with-the-Bitcoin.org-Translation-Team)
+[Responsibilities and Tasks for each User Role](#Responsibilities-and-Tasks-for-each-User-Role)
 
 [Go to Real Cool Heading section](#real-cool-heading)
 ___

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -8,7 +8,7 @@ Table of content
 ___
 ___
 
-#Real Cool Heading
+# Real Cool Heading
 
 ## Handling Translations on GitHub
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -2,11 +2,13 @@ Table of content
 
 [B. Getting started with the Bitcoin.org Translation Team](#B.-Getting-started-with-the-Bitcoin.org-Translation-Team)
 
-
+[Go to Real Cool Heading section](#real-cool-heading)
 ___
 ___
 
-## A. Handling Translations on GitHub.md
+# real-cool-heading
+
+## A. Handling Translations on GitHub
 
 This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [B. Getting started with the Bitcoin.org Translation Team](#b.-getting-started-with-the-bitcoin.org-translation-team)
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,14 +1,13 @@
 Table of content
 
-[B. Getting started with the Bitcoin.org Translation Team](#B.-Getting-started-with-the-Bitcoin.org-Translation-Team)
+* [Handling Translations on GitHub](#handling-translations-on-gitHub)
+* [Getting started with the Bitcoin.org Translation Team](#Getting-started-with-the-Bitcoin.org-Translation-Team)
+* [Responsibilities and Tasks for each User Role](#Responsibilities-and-Tasks-for-each-User-Role)
 
-[Go to Real Cool Heading section](#(a)-real-cool-heading)
 ___
 ___
 
-# (A) Real Cool Heading
-
-## A. Handling Translations on GitHub
+## Handling Translations on GitHub
 
 This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [B. Getting started with the Bitcoin.org Translation Team](#b.-getting-started-with-the-bitcoin.org-translation-team)
 
@@ -68,7 +67,7 @@ translations at once:
 ___
 ___
 
-## B. Getting started with the Bitcoin.org Translation Team
+## Getting started with the Bitcoin.org Translation Team
 
 While the website itself is managed on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), the translations are handled through [Transifex](https://www.transifex.com/bitcoinorg/bitcoinorg/).
 This document shall explain the first steps on Transifex for new volunteers who want to help with translating bitcoin.org.
@@ -120,7 +119,7 @@ General guidelines provided by Transifex itself can be found [here](https://docs
 ___
 ___
 
-## C. Responsibilities and Tasks for each User Role
+## Responsibilities and Tasks for each User Role
 
 This document shall outline the responsibilities and tasks for each user role.
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -102,7 +102,7 @@ General guidelines provided by Transifex itself can be found [here](https://docs
 * Each resource consists of a number of strings, with a string being for example a paragraph or headline.
 * Each string has three possible states: "untranslated", "translated but unreviewed", and "reviewed". Only the first state "untranslated" is relevant for new volunteers. However, if you find a "translated but unreviewed" string that contains obvious mistakes, you are free to correct them. "Reviewed" strings can only be changed or unreviewed by reviewers.
 * **The first resource "bitcoin.org" contains all strings of the main page. If you are no Bitcoin expert, start here.**
-* **Everything else that follows starts with "devdocs...", indicating that these files are part of the developer documentation. Is is recommended that you only try to translate the developer documentation if you are an experienced Bitcoin user and/or developer with a profound understanding.**
+* **Everything else that follows starts with "devdocs...", indicating that these files are part of the developer documentation. It is recommended that you only try to translate the developer documentation if you are an experienced Bitcoin user and/or developer with a profound understanding.**
 
 ### 6.	Start translating
 * You must be a native speaker for the language you choose to translate.

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -11,7 +11,7 @@ ___
 
 ## Handling Translations on GitHub
 
-This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [Getting started with the Translation Team](#getting-started-with-the-translation-team)
+This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to section [Getting started with the Translation Team](#getting-started-with-the-translation-team).
 
 ### Import Translations
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,20 +1,9 @@
-## Translations
 
-### How To Translate
+___
 
-You can join a translation team on
-[Transifex](https://www.transifex.com/projects/p/bitcoinorg/) and start
-translating or improving existing translations.
+## A. Handling Translations on GitHub.md
 
-* You must be a native speaker for the language you choose to translate.
-* Please be careful to preserve the original meaning of each text.
-* Sentences and popular expressions should sound native in your language.
-* Translations need to be reviewed by a reviewer or coordinator before
-  publication.
-* Once reviewed, translations can be [submitted](#import-translations) in a pull
-  request on GitHub.
-* **In doubt, please contact coordinators on Transifex. That'll be much
-  appreciated.**
+This document outlines how to handle translations on GitHub. If you only want to help by translating content, take a look at document "1. getting-started.md" in this folder.
 
 ### Import Translations
 
@@ -68,3 +57,90 @@ translations at once:
     
     # Push changes back to Transifex
     tx push -s -t -f --skip --no-interactive
+    
+    ___
+
+## B. Getting started with the Bitcoin.org Translation Team
+
+While the website itself is managed on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), the translations are handled through [Transifex](https://www.transifex.com/bitcoinorg/bitcoinorg/).
+This document shall explain the first steps on Transifex for new volunteers who want to help with translating bitcoin.org.
+
+General guidelines provided by Transifex itself can be found [here](https://docs.transifex.com/getting-started/translators).
+
+### 1. Create a Transifex Account
+* Follow this [link](https://www.transifex.com/signup/) and create an account. Not much information is needed.
+
+### 2. Login and join the Bitcoin.org Translation Team
+
+* Follow this [link](https://www.transifex.com/bitcoinorg/bitcoinorg/) and click on “Join team”.
+* Select the language you want to translate into.
+* Your request to join a team will be accepted instantly, and you will be a translator for the language you selected.
+* If your language is not available yet, close the pop-up, scroll down, and click on “Request language” on the right side. Please consider first if it is necessary that bitcoin.org is available in your language. There is a lot of content to be translated and especially for languages with a low number of native speakers, there won’t be many people available that are willing to assist you.
+
+### 3.	Get to know the Interface
+* Play around with the interface. Transifex's interface can be a bit confusing and it cannot hurt to take a look around.
+* As Translator, you cannot cause any harm as you can only edit unreviewed strings. A complete history is saved for every string, making it impossible to destroy previous work.
+* For the beginning, stay away from the Glossary as this can be edited by new translators but no history is saved.
+
+### 4.	Join our Telegram Group
+* Join our [Telegram Group](https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg).
+* The website maintainer, both Team Leaders for translations, a number of language coordinators, and various translators are present in this group.
+* We are happy to help in case you need assistance.
+
+### 5.	Choose what you want to translate
+* Click on "Dashboard" on the top.
+* Once you are on the "Dashboard", click on "Languages" on the left side and select your language.
+* You will see a lot of different resources and their progress.
+* Each resource consists of a number of strings, with a string being for example a paragraph or headline.
+* Each string has three possible states: "untranslated", "translated but unreviewed", and "reviewed". Only the first state "untranslated" is relevant for new volunteers. However, if you find a "translated but unreviewed" string that contains obvious mistakes, you are free to correct them. "Reviewed" strings can only be changed or unreviewed by reviewers.
+* **The first resource "bitcoin.org" contains all strings of the main page. If you are no Bitcoin expert, start here.**
+* **Everything else that follows starts with "devdocs...", indicating that these files are part of the developer documentation. Is is recommended that you only try to translate the developer documentation if you are an experienced Bitcoin user and/or developer with a profound understanding.**
+
+### 6.	Start translating
+* You must be a native speaker for the language you choose to translate.
+* Please be careful to preserve the original meaning of each text.
+* Sentences and popular expressions should sound native in your language.
+* Translations need to be reviewed by a reviewer or coordinator before
+  publication.
+* Once reviewed, coordinators will notify the Team Leaders that a certain translation is ready for publication.
+* **In doubt, please contact coordinators on Transifex. That'll be much
+  appreciated.**
+  
+### 7.	Take a look at the Responsibilities and Tasks for each User Role
+* The next document in this folder, "2. responsibilities-and-tasks-for-each-user-role", outlines - as the title says - the responsibilities and tasks for each user role.
+
+___
+
+## C. Responsibilities and Tasks for each User Role
+
+This document shall outline the responsibilities and tasks for each user role.
+
+### 1. Team Leaders
+Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: “Komodorpudel”) and Apple AKA “ajsolbrilla”.
+
+* Oversight on the complete translation efforts on Transifex.
+* Keeping track on everything.
+* Being a contact person for all sorts of questions that cannot be answered by language coordinators.
+* Promoting or demoting users (e.g. promoting a reviewer to coordinator).
+* Managing groups that have no active coordinator.
+
+### 2.	Coordinators
+Various people across all language teams are coordinators. For a number of languages, no active coordinator exists. If there are any questions or you want to assist by becoming a coordinator, write one of the Team Leaders.
+* If man power is needed: Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
+* Oversight on the complete translation efforts for a specific language.
+* Notifying Team Leaders if a resource is ready to be put on the website.
+* Being a contact person for the Team Leaders.
+* Being a contact person for all reviewers and translators within a specific language team.
+* Introducing and helping new volunteers.
+* Promoting or demoting users (e.g. promoting a translator to reviewer).
+* Kicking out users that do not behave (e.g. only use Google Translator) or are completely inactive.
+
+### 3. Reviewers
+* Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
+* Reviewing strings (preferably not your own strings if possible).
+* Checking translations for correctness regarding meaning and spelling.
+* Checking for consistency across translations (e.g. is “transaction malleability” translated consistently across all string?).
+
+### 4. Translators
+* Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
+* Extending the glossary with translations for necessary and general term

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -1,10 +1,10 @@
 Table of content
 
-[Handling Translations on GitHub](#handling-translations-on-github)
-[Getting started with the Bitcoin.org Translation Team](#Getting-started-with-the-Bitcoin.org-Translation-Team)
-[Responsibilities and Tasks for each User Role](#Responsibilities-and-Tasks-for-each-User-Role)
+* [Handling Translations on GitHub](#handling-translations-on-github)
+* [Getting started with the Bitcoin.org Translation Team](#getting-started-with-the-bitcoin.org-translation-team)
+* [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)
 
-[Go to Real Cool Heading section](#real-cool-heading)
+
 ___
 ___
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -6,7 +6,7 @@ Table of content
 ___
 ___
 
-# real-cool-heading
+# Real Cool Heading
 
 ## A. Handling Translations on GitHub
 


### PR DESCRIPTION
This PR adds the sections "Getting started with the Translation Team" and "Responsibilities and Tasks for each User Role" to the "Assisting with Translations" document, while the original content of the doc is slightly changed and now serves as section "Handling Translations on GitHub".

@wbnns there you go :)