### PR TITLE
index: Drop Bitcoin.org Anniversary Note

### DIFF
--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -13,11 +13,6 @@
     <div class="mainvideo">
       <button class="mainvideo-btn-open" onclick="loadYoutubeVideo(event);" ontouchstart="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/{% if page.lang == 'ro' %}JPNwbWu0tMQ{% else %}Gc2en3nHxA4{% endif %}?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">What is Bitcoin?</button>
     </div>
-    {% if page.lang == 'en' %}
-    <div class="mainannouncement">
-      <p>New Blog Post: <a href="/en/posts/ten-year-anniversary">Bitcoin.org is ten years old!</a></p>
-    </div>
-    {% endif %}
     {% include helpers/hero-social.html %}
   </div>
 </div>


### PR DESCRIPTION
This drops the blog post link on the homepage that Bitcoin.org is 10 years old, which has been up for the past week, and will be merged once tests pass.

Related: #2597 