### PR TITLE
Fix for overflow-x scrolling on mobile phones

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -4739,6 +4739,7 @@ br.big {
         background: #fff;
     }
     .toc+.toccontent {
+	padding: 0;    
         border: none;
     }
     .toccontent .toccontent-block {

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -4739,7 +4739,7 @@ br.big {
         background: #fff;
     }
     .toc+.toccontent {
-	padding: 0;    
+	padding: 0;
         border: none;
     }
     .toccontent .toccontent-block {

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -4739,7 +4739,7 @@ br.big {
         background: #fff;
     }
     .toc+.toccontent {
-	padding: 0;
+        padding: 0;
         border: none;
     }
     .toccontent .toccontent-block {


### PR DESCRIPTION
Scroll bar would show after the table of contents snapped to bottom, namely on phones in portrait mode. The extra padding seemed to be causing this. That padding is not longer needed once the TOC is at the bottom.

![responsive-container-x-scroll](https://user-images.githubusercontent.com/6774432/45163416-65864100-b1be-11e8-80fb-d37bdcb6bf8c.png)