### PR TITLE
docs: Add note mentioning Hendrawan and background exp. for handling translations

### DIFF
--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -7,11 +7,13 @@ This document provides information regarding translations for bitcoin.org.
 * [Getting Started with the Translation Team](#getting-started-with-the-translation-team)
 * [Responsibilities and Tasks for each User Role](#responsibilities-and-tasks-for-each-user-role)
 
-___
+---
 
 ## Handling Translations on GitHub
 
-This section outlines how to handle translations on GitHub. If you only want to help by translating content, scroll down to the section [Getting Started with the Translation Team](#getting-started-with-the-translation-team).
+This section outlines how to handle translations on GitHub. In order to handle translations on GitHub, it's important that you have a fundamental understanding of [Ruby](https://ruby.github.io/TryRuby/), [HTML](https://www.w3schools.com/html/default.asp)/[CSS](https://www.w3schools.com/css/default.asp), [JavaScript](https://www.javascript.com/try), [Jekyll](https://jekyllrb.com/), [Git](https://guides.github.com/) and [Travis CI](https://travis-ci.org/bitcoin-dot-org/bitcoin.org). You should also be able to [set up your environment](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/setting-up-your-environment.md).
+
+**If you only want to help by translating content, simply navigate to [Getting Started with the Translation Team](#getting-started-with-the-translation-team).**
 
 ### Import Translations
 

--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -126,7 +126,7 @@ ___
 This section shall outline the responsibilities and tasks for each user role.
 
 ### 1. Team Leaders
-Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: “Komodorpudel”) and Apple AKA “ajsolbrilla”.
+Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: “Komodorpudel”) and Hendrawan AKA “khendraw”.
 
 * Oversight on the complete translation efforts on Transifex.
 * Keeping track on everything.


### PR DESCRIPTION
This adds a small note regarding background experience that would be helpful in order to update translation files on Bitcoin.org. There was some confusion in not realizing one needed to know a bit about how the stack operates as a prerequisite. This also adds Hendrawan, a Team Leader on Transifex, as a person who can be contacted for translation-specific questions (in addition to Simon).

This will be merged once tests pass.