### PR TITLE
 buy: Non-renewal of Paxful Sponsorship

### DIFF
--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -7,7 +7,6 @@
     <div class="btn-container">
       <a class="btn btn-bright btn-home" href="/{{ page.lang }}/{% translate getting-started url %}">{% translate getstarted layout %}</a>
       <a class="btn btn-light btn-home" href="/{{ page.lang }}/{% translate choose-your-wallet url %}">{% translate choosebut getting-started %}</a>
-      <a class="btn btn-light btn-home" href="/{{ page.lang }}/{% translate buy url %}" data-proofer-ignore>{% translate title buy %}</a>
     </div>
 
     <div class="mainvideo">

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -929,7 +929,7 @@ h1 span.fa, h2 span.fa, h3 span.fa, h4 span.fa, h5 span.fa, h6 span.fa {
     border-radius:1px;
 }
 .btn-home {
-    width: 270px;
+    width: 325px;
     height: 55px;
 }
 .btn:not(:first-child) {

--- a/_templates/buy.html
+++ b/_templates/buy.html
@@ -17,22 +17,6 @@ id: buy
 </div>
 
 <div class="container">
-  <div class="two-column-layout">
-    <div class="row two-column-row">
-      <div>
-        <a href="https://www.paxful.com/&#63;utm&#95;source&#61;bitcoinorg&amp;utm&#95;medium&#61;referral&amp;utm&#95;campaign&#61;bitcoinorg&amp;utm&#95;term&#61;buy&#95;bitcoin&amp;utm&#95;content&#61;bannerclick" rel="nofollow"><img class="column-img" src="/img/buy/paxful.png?{{site.time | date: '%s'}}" alt="Buy Bitcoin with Paxful"></a>
-      </div>
-      <div class="column-text">
-        <p>{% translate paxful %}</p>
-        <div>
-          <p>
-            <a class="btn btn-bright btn-buy" href="https://www.paxful.com/&#63;utm&#95;source&#61;bitcoinorg&amp;utm&#95;medium&#61;referral&amp;utm&#95;campaign&#61;bitcoinorg&amp;utm&#95;term&#61;buy&#95;bitcoin&amp;utm&#95;content&#61;linkclick" rel="nofollow">{% translate button %}</a>
-          </p>
-          <p class="paxful-sponsor">{% translate sponsor %}</p>
-        </div>
-      </div>
-  </div>
-  <div class="buy-discover"><h2>{% translate discover %}</h2></div>
   <div class="row card-row">
     <div class="card buy-card">
       <img src="/img/icons/ico_exchange.svg?{{site.time | date: '%s'}}" alt="Bank icon">

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -144,10 +144,6 @@ en:
     title: "Buy Bitcoin"
     pagetitle: "How to buy bitcoin"
     summary: "There are several ways you can buy bitcoin."
-    paxful: 'With more than 300 ways to buy and sell bitcoin, Paxful, a leading peer-to-peer (P2P) exchange and <a href="/en/posts/new-supporting-sponsorship-from-paxful">Bitcoin.org sponsor</a>, offers a convenient bitcoin marketplace.'
-    button: "Buy Bitcoin with Paxful"
-    sponsor: "Sponsored Content"
-    discover: "Discover more ways to buy bitcoin:"
     bitcoin-exchange: "Use a Bitcoin Exchange"
     bitcoin-exchange-text: "Our <a href=\"/en/exchanges\">Bitcoin Exchange</a> page, lists many different businesses that can help you buy bitcoin using your bank account."
     p2p-bitcoins: "Browse a P2P Directory"


### PR DESCRIPTION
The Paxful sponsorship ends on October 11th. There are currently no plans or discussions to renew it, so this PR is scheduled to be merged on that date.

We were hoping there might be an opportunity to have more of a long-term relationship with them, however, at present, we feel it may not be in the best interest of trying to represent differing perspectives if we renew the sponsorship. That said, we hope there will be more opportunities for sponsorships on the site in the future. Bitcoin.org is one of the only leading/most-visited websites in the space that isn't directly or indirectly fueled by companies seeking to unilaterally press their own for-profit initiatives. 

We thank Paxful for their support.