### PR TITLE
blog: Add post - 'How to Help Translate Bitcoin.org'

### DIFF
--- a/_posts/2018-09-07-thanks-to-recent-translation-volunteers.md
+++ b/_posts/2018-09-07-thanks-to-recent-translation-volunteers.md
@@ -105,7 +105,7 @@ way to help Bitcoin continue to spread.
 
 [__If you want to be like one of the people above and join the effort, learn how to get started.__](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md#getting-started-with-the-translation-team)
 
-_A special thanks also goes to Simon AKA "Komodorpudel" who has spent a lot of
+*A special thanks also goes to Simon AKA "Komodorpudel" who has spent a lot of
 time co-organizing various translation-related efforts. Thank you, Simon. Lastly,
 but not least, to [Transifex](https://transifex.com/), for graciously providing
-enterprise-grade localization services to support Bitcoin.org.
+enterprise-grade localization services to support Bitcoin.org.*

--- a/_posts/2018-09-14-how-to-translate.md
+++ b/_posts/2018-09-14-how-to-translate.md
@@ -78,7 +78,7 @@ when helping translate Bitcoin.org.
 
 ### Team Leaders
 
-Team Leaders are currently Simon AKA “[Komodorpudel](telegram.me/komodorpudel)” and Hendrawan AKA “[khendraw](https://telegram.me/khendraw)”.
+Team Leaders are currently Simon AKA “[Komodorpudel](https://telegram.me/komodorpudel)” and Hendrawan AKA “[khendraw](https://telegram.me/khendraw)”.
 
 #### Responsibilities and Tasks
 

--- a/_posts/2018-09-14-how-to-translate.md
+++ b/_posts/2018-09-14-how-to-translate.md
@@ -18,6 +18,8 @@ blog post will help you learn how to get started translating Bitcoin.org so
 that more people around the world who speak your language can learn about
 Bitcoin.
 
+*Thank you to Simon AKA “Komodorpudel” for preparing content to help organize this post.*
+
 ## Getting Started with the Translation Team
 
 Translations for Bitcoin.org are done on a website called [Transifex](https://www.transifex.com/bitcoinorg/bitcoinorg/). Basic instructions for how Transifex works can be [found here](https://docs.transifex.com/getting-started/translators).
@@ -28,37 +30,37 @@ Translations for Bitcoin.org are done on a website called [Transifex](https://ww
 Creating a Transifex account is free and not much information is needed.
 
 2. [Join the Bitcoin.org translation team](https://www.transifex.com/bitcoinorg/bitcoinorg/)
-and select the language you want to translate into. Your request to join a team
-will be accepted instantly, and you will be a translator for the language you
-selected. If your language is not available yet, close the pop-up, scroll down,
-and click on “Request language” on the right side.
+and select the language you want to translate the site into. Your request to
+join a team will be accepted instantly, and you will be a translator for the
+language you selected. If your language is not available yet, close the pop-up,
+scroll down, and navigate to “Request language”.
 
 3. Play around with the interface. Transifex's interface can be a bit confusing
-and it cannot hurt to take a look around. As Translator, you cannot cause any
+and it cannot hurt to take a look around. As a translator, you cannot cause any
 harm as you can only edit unreviewed strings. A complete history is saved for
 every string, making it impossible to destroy previous work. In the beginning,
 stay away from the Glossary as this can be edited by new translators but no
 history is saved.
 
-4. [Join our Telegram Group](https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg). The
-website maintainer, both Team Leaders for translations, a number of language
-coordinators, and various translators are present in this group. We are happy
-to help in case you need assistance.
+4. [Join the Telegram group for translators](https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg).
+The website maintainer, both team leaders for translations, a number of language
+coordinators, and various translators are present in this group. We are happy to
+help in case you need assistance.
 
-5. Choose what you want to translate. Click on "Dashboard" on the top of the
-page, and once you are on the "Dashboard", click on "Languages" on the left
-side and select your language. You will see a lot of different resources and
-their progress. Each resource consists of a number of strings, with a string
-being for example a paragraph or headline. Each string has three possible
-states: "untranslated", "translated but unreviewed", and "reviewed". Only the
-first state "untranslated" is relevant for new volunteers. However, if you find
-a "translated but unreviewed" string that contains obvious mistakes, you are
-free to correct them. "Reviewed" strings can only be changed or unreviewed by
-reviewers. The first resource "bitcoin.org" contains all strings of the main
-page. Start here. Everything else that follows starts with "devdocs...",
-indicating that these files are part of the developer documentation. It is
-recommended that you only try to translate the developer documentation if you
-are an experienced Bitcoin user and/or developer with a profound understanding.
+5. Choose what you want to translate. Navigate to the "Dashboard" on the top of
+the page, then to "Languages" and select your language. You will see a lot
+of different resources and their progress. Each resource consists of a number of
+strings. A string is a "string" of text on Bitcoin.org. Each string has three
+possible states - "untranslated", "translated but unreviewed", and "reviewed".
+Only the first state "untranslated" is relevant for most translators. However,
+if you find a "translated but unreviewed" string that contains obvious mistakes,
+you are free to correct them. "Reviewed" strings can only be changed or
+unreviewed by reviewers. The first resource "bitcoin.org" contains all strings
+of the main page. Start here. Everything else that follows starts with
+"devdocs...", indicating that these files are part of the developer
+documentation. It is recommended that you only try to translate the developer
+documentation if you are an experienced Bitcoin user and/or developer with a
+profound understanding.
 
 6. Start translating. You must be a native or fluent speaker for the language
 you choose to translate. Please be careful to preserve the original meaning of
@@ -66,17 +68,19 @@ each text. Sentences and popular expressions should sound native in your
 language. Translations need to be reviewed by a reviewer or coordinator before
 publication. Once reviewed, coordinators will notify the Team Leaders that a
 certain translation is ready for publication. If in doubt, please contact the
-coordinator(s) for your language on Transifex. 
+coordinator(s) for your language on Transifex.
 
-7. Please take a look at the Responsibilities and Tasks for different types of
-team members that you'll encounter on Transifex, below.
+7. Please take a look at the Responsibilities and Tasks section below to learn
+more about the different types of users that you'll encounter on Transifex
+when helping translate Bitcoin.org.
 
 ## Responsibilities and Tasks
 
 ### Team Leaders
 
-Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: “Komodorpudel”)
-and Hendrawan AKA “khendraw”.
+Team Leaders are currently Simon AKA “[Komodorpudel](telegram.me/komodorpudel)” and Hendrawan AKA “[khendraw](https://telegram.me/khendraw)”.
+
+#### Responsibilities and Tasks
 
 - Oversight on the complete translation efforts on Transifex.
 - Keeping track on everything.
@@ -90,6 +94,8 @@ Various people across all language teams are coordinators. For a number of
 languages, no active coordinator exists. If there are any questions or you want
 to assist by becoming a coordinator, write one of the Team Leaders.
 
+#### Responsibilities and Tasks
+
 - When additional help is needed: Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 - Oversight on the complete translation efforts for a specific language.
 - Notifying Team Leaders if a resource is ready to be put on the website.
@@ -101,12 +107,16 @@ to assist by becoming a coordinator, write one of the Team Leaders.
 
 ### Reviewers
 
+#### Responsibilities and Tasks
+
 - Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 - Reviewing strings (preferably not your own strings if possible).
 - Checking translations for correctness regarding meaning and spelling.
 - Checking for consistency across translations (e.g. is “transaction malleability” translated consistently across all strings?).
 
 ### Translators
+
+#### Responsibilities and Tasks
 
 - Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 - Extending the glossary with translations for necessary and general terms.

--- a/_posts/2018-09-14-how-to-translate.md
+++ b/_posts/2018-09-14-how-to-translate.md
@@ -66,7 +66,7 @@ profound understanding.
 you choose to translate. Please be careful to preserve the original meaning of
 each text. Sentences and popular expressions should sound native in your
 language. Translations need to be reviewed by a reviewer or coordinator before
-publication. Once reviewed, coordinators will notify the Team Leaders that a
+publication. Once reviewed, coordinators will notify the team leaders that a
 certain translation is ready for publication. If in doubt, please contact the
 coordinator(s) for your language on Transifex.
 
@@ -82,8 +82,8 @@ Team Leaders are currently Simon AKA “[Komodorpudel](https://telegram.me/komod
 
 **Responsibilities and Tasks**
 
-- Oversight on the complete translation efforts on Transifex.
-- Keeping track on everything.
+- Providing oversight on the complete translation efforts on Transifex.
+- Keeping track of everything.
 - Being a contact person for all sorts of questions that cannot be answered by language coordinators.
 - Promoting or demoting users (e.g. promoting a reviewer to coordinator).
 - Managing groups that have no active coordinator.
@@ -92,25 +92,25 @@ Team Leaders are currently Simon AKA “[Komodorpudel](https://telegram.me/komod
 
 Various people across all language teams are coordinators. For a number of
 languages, no active coordinator exists. If there are any questions or you want
-to assist by becoming a coordinator, write one of the Team Leaders.
+to assist by becoming a coordinator, please write one of the team leaders.
 
 **Responsibilities and Tasks**
 
-- When additional help is needed: Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
-- Oversight on the complete translation efforts for a specific language.
-- Notifying Team Leaders if a resource is ready to be put on the website.
-- Being a contact person for the Team Leaders.
+- Translating and striving for consistency across strings.
+- Providing oversight on the complete translation efforts for a specific language.
+- Notifying team leaders if a resource is ready to be put on the website.
+- Being a contact person for the team leaders.
 - Being a contact person for all reviewers and translators within a specific language team.
 - Introducing and helping new volunteers.
 - Promoting or demoting users (e.g. promoting a translator to reviewer).
-- Kicking out users that do not behave (e.g. only use Google Translator) or are completely inactive.
+- Removing user that do not follow instructions (e.g. using Google Translate).
 
 ### Reviewers
 
 **Responsibilities and Tasks**
 
-- Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
-- Reviewing strings (preferably not your own strings if possible).
+- Translating and striving for consistency across strings.
+- Reviewing strings (preferably not their own strings if possible).
 - Checking translations for correctness regarding meaning and spelling.
 - Checking for consistency across translations (e.g. is “transaction malleability” translated consistently across all strings?).
 
@@ -118,7 +118,7 @@ to assist by becoming a coordinator, write one of the Team Leaders.
 
 **Responsibilities and Tasks**
 
-- Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
+- Translating and striving for consistency across strings.
 - Extending the glossary with translations for necessary and general terms.
 
 ## About Bitcoin.org

--- a/_posts/2018-09-14-how-to-translate.md
+++ b/_posts/2018-09-14-how-to-translate.md
@@ -1,0 +1,128 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+type: posts
+layout: post
+category: blog
+
+title: "How to Help Translate Bitcoin.org"
+permalink: /en/posts/help-translate.html
+date: 2018-09-14
+author: |
+  <a href="https://github.com/wbnns">Will Binns</a>
+---
+
+If you're a fluent or native speaker of a language other than English, this
+blog post will help you learn how to get started translating Bitcoin.org so
+that more people around the world who speak your language can learn about
+Bitcoin.
+
+## Getting Started with the Translation Team
+
+Translations for Bitcoin.org are done on a website called [Transifex](https://www.transifex.com/bitcoinorg/bitcoinorg/). Basic instructions for how Transifex works can be [found here](https://docs.transifex.com/getting-started/translators).
+
+**Below is a summary:**
+
+1. [Create a free Transifex account](https://www.transifex.com/signup/).
+Creating a Transifex account is free and not much information is needed.
+
+2. [Join the Bitcoin.org translation team](https://www.transifex.com/bitcoinorg/bitcoinorg/)
+and select the language you want to translate into. Your request to join a team
+will be accepted instantly, and you will be a translator for the language you
+selected. If your language is not available yet, close the pop-up, scroll down,
+and click on “Request language” on the right side.
+
+3. Play around with the interface. Transifex's interface can be a bit confusing
+and it cannot hurt to take a look around. As Translator, you cannot cause any
+harm as you can only edit unreviewed strings. A complete history is saved for
+every string, making it impossible to destroy previous work. In the beginning,
+stay away from the Glossary as this can be edited by new translators but no
+history is saved.
+
+4. [Join our Telegram Group](https://t.me/joinchat/Bgh47RC1BZb2YE6u8iznOg). The
+website maintainer, both Team Leaders for translations, a number of language
+coordinators, and various translators are present in this group. We are happy
+to help in case you need assistance.
+
+5. Choose what you want to translate. Click on "Dashboard" on the top of the
+page, and once you are on the "Dashboard", click on "Languages" on the left
+side and select your language. You will see a lot of different resources and
+their progress. Each resource consists of a number of strings, with a string
+being for example a paragraph or headline. Each string has three possible
+states: "untranslated", "translated but unreviewed", and "reviewed". Only the
+first state "untranslated" is relevant for new volunteers. However, if you find
+a "translated but unreviewed" string that contains obvious mistakes, you are
+free to correct them. "Reviewed" strings can only be changed or unreviewed by
+reviewers. The first resource "bitcoin.org" contains all strings of the main
+page. Start here. Everything else that follows starts with "devdocs...",
+indicating that these files are part of the developer documentation. It is
+recommended that you only try to translate the developer documentation if you
+are an experienced Bitcoin user and/or developer with a profound understanding.
+
+6. Start translating. You must be a native or fluent speaker for the language
+you choose to translate. Please be careful to preserve the original meaning of
+each text. Sentences and popular expressions should sound native in your
+language. Translations need to be reviewed by a reviewer or coordinator before
+publication. Once reviewed, coordinators will notify the Team Leaders that a
+certain translation is ready for publication. If in doubt, please contact the
+coordinator(s) for your language on Transifex. 
+
+7. Please take a look at the Responsibilities and Tasks for different types of
+team members that you'll encounter on Transifex, below.
+
+## Responsibilities and Tasks
+
+### Team Leaders
+
+Team Leaders are currently Simon AKA “Komodorpudel” (Telegram: “Komodorpudel”)
+and Hendrawan AKA “khendraw”.
+
+- Oversight on the complete translation efforts on Transifex.
+- Keeping track on everything.
+- Being a contact person for all sorts of questions that cannot be answered by language coordinators.
+- Promoting or demoting users (e.g. promoting a reviewer to coordinator).
+- Managing groups that have no active coordinator.
+
+### Coordinators
+
+Various people across all language teams are coordinators. For a number of
+languages, no active coordinator exists. If there are any questions or you want
+to assist by becoming a coordinator, write one of the Team Leaders.
+
+- When additional help is needed: Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
+- Oversight on the complete translation efforts for a specific language.
+- Notifying Team Leaders if a resource is ready to be put on the website.
+- Being a contact person for the Team Leaders.
+- Being a contact person for all reviewers and translators within a specific language team.
+- Introducing and helping new volunteers.
+- Promoting or demoting users (e.g. promoting a translator to reviewer).
+- Kicking out users that do not behave (e.g. only use Google Translator) or are completely inactive.
+
+### Reviewers
+
+- Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
+- Reviewing strings (preferably not your own strings if possible).
+- Checking translations for correctness regarding meaning and spelling.
+- Checking for consistency across translations (e.g. is “transaction malleability” translated consistently across all strings?).
+
+### Translators
+
+- Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
+- Extending the glossary with translations for necessary and general terms.
+
+## About Bitcoin.org
+
+Bitcoin.org was originally registered and owned by Satoshi Nakamoto and Martti
+Malmi. When Satoshi left the project, he gave ownership of the domain to
+additional people, separate from the Bitcoin developers, to spread
+responsibility and prevent any one person or group from easily gaining control
+over the Bitcoin project. Since then, the site has been developed and
+maintained by different members of the Bitcoin community.
+
+Despite being a privately owned site, its code is
+[open-source](https://github.com/bitcoin-dot-org/bitcoin.org/) and there have
+been over 3,200 commits from 180 contributors from all over the world. In
+addition to this, over 950 translators have helped to make the site display
+natively to visitors by default in their own languages — now 25 different
+languages and growing.

--- a/_posts/2018-09-14-how-to-translate.md
+++ b/_posts/2018-09-14-how-to-translate.md
@@ -7,7 +7,7 @@ layout: post
 category: blog
 
 title: "How to Help Translate Bitcoin.org"
-permalink: /en/posts/help-translate.html
+permalink: /en/posts/how-to-help-translate.html
 date: 2018-09-14
 author: |
   <a href="https://github.com/wbnns">Will Binns</a>
@@ -80,7 +80,7 @@ when helping translate Bitcoin.org.
 
 Team Leaders are currently Simon AKA “[Komodorpudel](https://telegram.me/komodorpudel)” and Hendrawan AKA “[khendraw](https://telegram.me/khendraw)”.
 
-#### Responsibilities and Tasks
+**Responsibilities and Tasks**
 
 - Oversight on the complete translation efforts on Transifex.
 - Keeping track on everything.
@@ -94,7 +94,7 @@ Various people across all language teams are coordinators. For a number of
 languages, no active coordinator exists. If there are any questions or you want
 to assist by becoming a coordinator, write one of the Team Leaders.
 
-#### Responsibilities and Tasks
+**Responsibilities and Tasks**
 
 - When additional help is needed: Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 - Oversight on the complete translation efforts for a specific language.
@@ -107,7 +107,7 @@ to assist by becoming a coordinator, write one of the Team Leaders.
 
 ### Reviewers
 
-#### Responsibilities and Tasks
+**Responsibilities and Tasks**
 
 - Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 - Reviewing strings (preferably not your own strings if possible).
@@ -116,7 +116,7 @@ to assist by becoming a coordinator, write one of the Team Leaders.
 
 ### Translators
 
-#### Responsibilities and Tasks
+**Responsibilities and Tasks**
 
 - Translating, thereby using translations provided by the glossary if applicable and striving for consistency across strings.
 - Extending the glossary with translations for necessary and general terms.


### PR DESCRIPTION
This adds a blog post to help people get started translating Bitcoin.org. Most translators are not familiar with GitHub - the UI is confusing and very difficult for them to understand making it overwhelming when reading the assisting with translations doc in the repository. This post provides them with easy to understand page that we can share/reference to help them quickly get started.

This is scheduled to be merged on September 19th.

[Link to Preview](https://bitcoin.cryptopelago.com/en/posts/how-to-help-translate).