### PR TITLE
Added Bitcoinregulation.world site as a resource

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -42,6 +42,9 @@ id: resources
         <p>
           <a href="http://www.iamsatoshi.com/category/video-archive/">IamSatoshi</a>
         </p>
+        <p>
+          <a href="https://www.bitcoinregulation.world">Global Bitcoin Regulations</a>
+        </p>
       </div>
 
       <div class="card resources-card">


### PR DESCRIPTION
After taking @wbnns feedback into account regarding the way we display information (not using N/A, but providing detail as to why) and adding more countries for areas such as US, South America and Asia, we believe our site is an even more useful resource than it was last time we added to Bitcoin.org and is ready for publication here.