### PR TITLE
Show donation modal in download page

### DIFF
--- a/_includes/layout/base/html-head.html
+++ b/_includes/layout/base/html-head.html
@@ -15,7 +15,7 @@ http://opensource.org/licenses/MIT.
 {% if page.lang == 'ar' or page.lang == 'fa' %}<link rel="stylesheet" href="/css/rtl.css?{{site.time | date: '%s'}}">{% endif %}
 {% if page.lang == 'bg' or page.lang == 'el' or page.lang == 'ko' or page.lang == 'hi' or page.lang == 'pl' or page.lang == 'sl' or page.lang == 'ro' or page.lang == 'ru' or page.lang == 'tr' or page.lang == 'uk' or page.lang == 'zh_CN' or page.lang == 'zh_TW' %}<link rel="stylesheet" href="/css/sans.css?{{site.time | date: '%s'}}">{% endif %}
 <script type="text/javascript" src="/js/base.js?{{site.time | date: '%s'}}"></script>
-{% if page.id != 'download' %}<script type="text/javascript" src="/js/main.js?{{site.time | date: '%s'}}"></script>{% endif %}
+<script type="text/javascript" src="/js/main.js?{{site.time | date: '%s'}}"></script>
 <script src="/js/jquery/jquery-1.11.2.min.js"></script>
 <script src="/js/jquery/jquery-ui.min.js"></script>
 <script src="/js/jquery/jquery.qrcode.min.js"></script>


### PR DESCRIPTION
This imports main.js into the download page so we can call the function to show the donation modal, which currently isn't displaying.

I screwed up in https://github.com/bitcoin-dot-org/bitcoin.org/pull/2626 a bit, but this fixes that. Suggest to merge as soon as tests pass. 