### PR TITLE
Adding news source in portuguese Brazil.

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -98,7 +98,10 @@ id: resources
         {% endif %} {% if page.lang == 'es' %}
         <p>
           <a href="https://www.criptonoticias.com/">CriptoNoticias</a>
-        </p>{% endif %}
+        </p>{% endif %} {% if page.lang == 'pt_BR' %}
+        <p>
+          <a href="https://livecoins.com.br/">Livecoins</a>
+        </p>{% endif %}        
         <p>{% translate linkcointelegraph %}
           <p>
             <p>


### PR DESCRIPTION
Livecoins is one of the main news, prices, and information on bitcoin, digital
currencies, and the blockchain movement as a whole in Brazil.

Over 300k people visit the site every month, including fintech/bank executives,
technology entrepreneurs and investors, digital currency traders, lawmakers and
regulators from government agencies, and journalists from major technology
publications.
[https://livecoins.com.br/](url)