### PR TITLE
index: Drop 0.16.3 Upgrade Alert Notice from Homepage

### DIFF
--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -13,9 +13,6 @@
     <div class="mainvideo">
       <button class="mainvideo-btn-open" onclick="loadYoutubeVideo(event);" ontouchstart="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/{% if page.lang == 'ro' %}JPNwbWu0tMQ{% else %}Gc2en3nHxA4{% endif %}?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">What is Bitcoin?</button>
     </div>
-     <div class="mainannouncement">
-       <p><span class="alerttext">Alert:</span> <a href="/en/alert/2018-09-21-required-upgrade">Notice of Required Upgrade to 0.16.3</a></p>
-     </div>
     {% include helpers/hero-social.html %}
   </div>
 </div>


### PR DESCRIPTION
This drops the 0.16.3 upgrade alert notice from the homepage.

It has been up for the last couple of weeks.