### PR TITLE
Adding cryptex24.com link

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -18,6 +18,8 @@ id: exchanges
     <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
     <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>
+    <br>
+    <a class="marketplace-link" href="https://www.cryptex24.com/">Cryptex24</a>
   </p>
 </div>
 


### PR DESCRIPTION
Kindly add Cryptex24.com to the exchanges list. The service is based in Russia, but operates worldwide since 2014.