### PR TITLE
Fix bugs in devsearch

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -1035,7 +1035,7 @@ h1 span.fa, h2 span.fa, h3 span.fa, h4 span.fa, h5 span.fa, h6 span.fa {
     margin: 0;
     font-size: 137.5%;
     line-height: 1.9;
-    color: #FFFFFF; 
+    color: #FFFFFF;
 }
 .maincard-link {
     font-size: 100%;
@@ -1624,7 +1624,6 @@ h1 span.fa, h2 span.fa, h3 span.fa, h4 span.fa, h5 span.fa, h6 span.fa {
     padding: 17px 17px 17px 72px;
     font-size: 112.5%;
     line-height: 21px;
-    color: #bcb7b8;
     border: 1px solid #DADADA;
     -webkit-box-sizing: border-box;
             box-sizing: border-box;
@@ -1777,8 +1776,8 @@ table.privacy-comparison td:nth-child(1n+2) {
     width: 120px;
 }
 
-table.validation { 
-    width: 100%; 
+table.validation {
+    width: 100%;
     margin-bottom: 30px;
 }
 
@@ -2346,8 +2345,8 @@ br.big {
 .boxexpand.expanded>h3:first-child {
     padding: 40px 35px 15px 30px;
 }
-.boxexpand>h1:first-child::after, 
-.boxexpand>h2:first-child::after, 
+.boxexpand>h1:first-child::after,
+.boxexpand>h2:first-child::after,
 .boxexpand>h3:first-child::after {
     content: '';
     position: absolute;
@@ -2834,7 +2833,7 @@ br.big {
 }
 /* Events END */
 
-/* About us page START*/ 
+/* About us page START*/
 .about {
     padding: 70px 0;
 }
@@ -2977,7 +2976,7 @@ br.big {
     font-size: 18px;
     color: #9496A0;
 }
-/* About us page END*/ 
+/* About us page END*/
 
 /* Timeline layout START */
 .post-list {
@@ -3238,7 +3237,7 @@ br.big {
     display: block;
 }
 .vocabulary-list {
-    
+
 }
 .bitcore-content .callout{
     margin: 0 auto 90px;
@@ -3255,7 +3254,7 @@ br.big {
     max-width: 100%;
     margin: 0 auto 20px;
 }
-.bitcore-content ol, 
+.bitcore-content ol,
 .bitcore-content ul{
     font-size: 125%;
 }
@@ -3293,11 +3292,11 @@ br.big {
     color: #ff7e00;
 }
 .ui-state-default .ui-icon {
-    background: url(../img/icons/ico_angle_grey.svg?1528322191) center no-repeat;   
+    background: url(../img/icons/ico_angle_grey.svg?1528322191) center no-repeat;
     background-size: contain;
 }
 .ui-icon-closethick {
-    background: url(../img/icons/close-btn.svg?1528322191) center no-repeat !important;   
+    background: url(../img/icons/close-btn.svg?1528322191) center no-repeat !important;
     background-size: contain;
 }
 .ui-accordion .ui-accordion-header .ui-accordion-header-icon {
@@ -3307,7 +3306,7 @@ br.big {
 }
 .ui-accordion .ui-state-active .ui-accordion-header-icon{
     width: 17px;
-    background: url(../img/icons/ico_angle_orange.svg?1528322191) center no-repeat;   
+    background: url(../img/icons/ico_angle_orange.svg?1528322191) center no-repeat;
     background-size: contain;
 }
 .ui-accordion .ui-accordion-content {
@@ -3395,9 +3394,9 @@ br.big {
     .develdocdisclaimer div {
         padding: 0 60px 0 90px;
     }
-    .develdocdisclaimerclose, 
-    .develdocdisclaimerclose:visited, 
-    .develdocdisclaimerclose:link, 
+    .develdocdisclaimerclose,
+    .develdocdisclaimerclose:visited,
+    .develdocdisclaimerclose:link,
     .develdocdisclaimerclose:active {
         right: 30px;
     }
@@ -3450,7 +3449,7 @@ br.big {
     blockquote {
         margin: 0 0 80px;
         padding: 16px 50px 45px;
-    } 
+    }
     .section-title {
         margin: 0 0 40px;
     }
@@ -3567,13 +3566,13 @@ br.big {
         min-width: auto;
         width: 245px;
     }
-    .boxexpand>h1:first-child, 
-    .boxexpand>h2:first-child, 
+    .boxexpand>h1:first-child,
+    .boxexpand>h2:first-child,
     .boxexpand>h3:first-child {
         padding: 30px 35px 30px 30px;
     }
-    .boxexpand.expanded>h1:first-child, 
-    .boxexpand.expanded>h2:first-child, 
+    .boxexpand.expanded>h1:first-child,
+    .boxexpand.expanded>h2:first-child,
     .boxexpand.expanded>h3:first-child {
         padding: 30px 35px 20px 30px;
     }
@@ -3581,8 +3580,8 @@ br.big {
     .boxexpand>h2 {
         font-size: 150%;
     }
-    .boxexpand>h1:first-child::after, 
-    .boxexpand>h2:first-child::after, 
+    .boxexpand>h1:first-child::after,
+    .boxexpand>h2:first-child::after,
     .boxexpand>h3:first-child::after {
         right: 15px;
     }
@@ -3655,7 +3654,7 @@ br.big {
     .left-column div {
         bottom: -87px;
     }
-    .start-content div div a, 
+    .start-content div div a,
     .start-content div div a:link {
         padding: 15px 20px;
     }
@@ -3824,7 +3823,7 @@ br.big {
         border: none;
         width: auto;
     }
-    .glossary-subpage-search .glossary_term {    
+    .glossary-subpage-search .glossary_term {
         max-width: 710px;
         margin: 0 auto 50px;
     }
@@ -3902,10 +3901,10 @@ br.big {
     }
     .container {
         padding: 0 15px;
-    } 
+    }
     .hero-container {
         padding: 0 40px;
-    } 
+    }
     .footer-bottom-row {
         flex-direction: column;
     }
@@ -4006,11 +4005,11 @@ br.big {
         -webkit-transform: translate(-50%, -4px);
                 transform: translate(-50%, -4px);
     }
-    .left-column, 
+    .left-column,
     .right-column {
         max-width: 100%;
     }
-    .left-column div, 
+    .left-column div,
     .right-column div {
         position: static;
     }
@@ -4204,7 +4203,7 @@ br.big {
     .post:nth-child(2) {
         margin-top: 0;
     }
-    .post:nth-child(even)::after, 
+    .post:nth-child(even)::after,
     .post:nth-child(odd)::after {
         right: auto;
         left: -10px;
@@ -4212,7 +4211,7 @@ br.big {
         height: 20px;
         background: url(../img/icons/timeline-point-right-mob.svg?1528322191) center no-repeat;
     }
-    .post:nth-child(odd) .post-inner, 
+    .post:nth-child(odd) .post-inner,
     .post:nth-child(even) .post-inner {
         padding: 35px 15px 35px 15px;
     }
@@ -4255,13 +4254,13 @@ br.big {
         margin-left: 15px;
         margin-right: 15px;
     }
-    .boxexpand>h1:first-child, 
-    .boxexpand>h2:first-child, 
+    .boxexpand>h1:first-child,
+    .boxexpand>h2:first-child,
     .boxexpand>h3:first-child {
         padding: 30px 30px 30px 15px;
     }
-    .boxexpand.expanded>h1:first-child, 
-    .boxexpand.expanded>h2:first-child, 
+    .boxexpand.expanded>h1:first-child,
+    .boxexpand.expanded>h2:first-child,
     .boxexpand.expanded>h3:first-child {
         padding: 30px 30px 15px 15px;
     }
@@ -4377,7 +4376,7 @@ br.big {
         -moz-appearance: none;
         cursor: pointer;
     }
-     
+
     .footer-langselect {
         display: block;
     }
@@ -4405,7 +4404,7 @@ br.big {
         pointer-events: none;
         text-align: center;
     }
-    .langselect select:hover + .center-select__text, 
+    .langselect select:hover + .center-select__text,
     .langselect select:active + .center-select__text {
         color: #F7931A;
     }
@@ -4452,7 +4451,7 @@ br.big {
         background-color: #090c14;
         border: none;
     }
-    .menusimple.menutap li.hover>ul a, 
+    .menusimple.menutap li.hover>ul a,
     .menusimple.menutap li.active>ul a {
         color: #9d9d9d;
         background: #090c14;
@@ -4473,11 +4472,11 @@ br.big {
     }
     .is-expand:hover::after {
         -webkit-transform: translateY(-50%);
-                transform: translateY(-50%); 
+                transform: translateY(-50%);
     }
     .hover .is-expand:hover::after {
         -webkit-transform: translateY(-50%) rotate(180deg);
-                transform: translateY(-50%) rotate(180deg); 
+                transform: translateY(-50%) rotate(180deg);
     }
     .summarytxt {
         font-size: 112.5%;
@@ -4729,14 +4728,14 @@ br.big {
     .boxexpand>h2 {
         font-size: 137.5%;
     }
-    .boxexpand>h1:first-child, 
-    .boxexpand>h2:first-child, 
+    .boxexpand>h1:first-child,
+    .boxexpand>h2:first-child,
     .boxexpand>h3:first-child {
         padding: 15px 35px 15px 15px;
         background: #f8f8f8
     }
-    .boxexpand.expanded>h1:first-child, 
-    .boxexpand.expanded>h2:first-child, 
+    .boxexpand.expanded>h1:first-child,
+    .boxexpand.expanded>h2:first-child,
     .boxexpand.expanded>h3:first-child {
         padding: 15px 35px 15px 15px;
         background: #fff;
@@ -5021,16 +5020,16 @@ br.big {
     .own-text p {
         font-size: 16px;
     }
-    .glossary_term.help-search::-webkit-input-placeholder { 
+    .glossary_term.help-search::-webkit-input-placeholder {
         font-size: 16px
     }
-    .glossary_term.help-search::-moz-placeholder { 
+    .glossary_term.help-search::-moz-placeholder {
         font-size: 16px
     }
-    .glossary_term.help-search:-ms-input-placeholder { 
+    .glossary_term.help-search:-ms-input-placeholder {
         font-size: 16px
     }
-    .glossary_term.help-search:-moz-placeholder { 
+    .glossary_term.help-search:-moz-placeholder {
         font-size: 16px
     }
     .recommendation-card {

--- a/js/devsearch.js
+++ b/js/devsearch.js
@@ -33,24 +33,15 @@ $.widget("custom.catcomplete", $.ui.autocomplete, {
 });
 $(function() {
   $("#glossary_term").catcomplete({
-    source: function(request, respond) {
-        var lang = $('html').attr('lang');
-        var term = request.term;
-
-        var results = search_data.filter(function(data) {
-            return (
-                (data.label.indexOf(term) !== -1 && data.lang === lang) || data.category !== "Glossary"
-            );
-        });
-
-        respond(results);
-    },
+    source: search_data,
     delay: 0,
     minLength: 2,
     autoFocus: true,
     select: function(event, ui) {
       location.href = ui.item.uri;
     }
-  });
+  }).bind('focus', function(){ $(this).catcomplete("search"); if (this.setSelectionRange) { var len = $(this).val().length * 2; var input = this; window.setTimeout(function() { input.setSelectionRange(len, len); }, 0); } else { $(this).val($(this).val());}});
+
+
 });
 {% endraw %}


### PR DESCRIPTION
Fixes a bug in the search widget that is messing up the suggestions, bug is described below:

- Go to a page with the search widget visible (https://bitcoin.org/en/developer-documentation)
- Type "bump" into the box
- **Expected behavior**: "BumpFee" is the only thing present in the suggestions
- **Actual behavior**: _Everything_ in the glossary is being returned in the suggestions

This pull request fixes that bug by making sure the right results are returned, additionally the UX/UI of the widget is improved with the following additions in look and behavior:

- The color of the text in the input field is changed to be darker, since the current color is too faint and not ideal
- When the user clicks back into the box, the suggestions are displayed again, as is the behavior on search engines like Google/Bing
- When the user clicks back into the box, the cursor is automatically placed at the end, so the user can easily backspace their search and make a new one