### PR TITLE
exchanges: Add back NYA agreement companies

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -68,6 +68,8 @@ id: exchanges
       <div>
         <h3 id="japan" class="no_toc">Japan</h3>
         <p>
+          <a class="marketplace-link" href="https://bitflyer.jp/">bitFlyer</a>
+          <br>
           <a class="marketplace-link" href="https://www.btcbox.co.jp/">BtcBox</a>
         </p>
       </div>
@@ -270,6 +272,8 @@ id: exchanges
       <div>
         <h3 id="united-states" class="no_toc">United States</h3>
         <p>
+          <a class="marketplace-link" href="https://bitflyer.com/">bitFlyer</a>
+          <br>
           <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
           <br>
           <a class="marketplace-link" href="https://www.itbit.com/">itBit</a>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -295,6 +295,8 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.buenbit.com/">Buenbit</a>
           <br>
+          <a class="marketplace-link" href="https://www.ripio.com/">Ripio</a>
+          <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>
         </p>
       </div>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -15,6 +15,8 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://bitwage.com/">Bitwage</a>
     <br>
+    <a class="marketplace-link" href="https://www.coinbase.com/">Coinbase</a>
+    <br>
     <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
     <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -274,6 +274,8 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitflyer.com/">bitFlyer</a>
           <br>
+          <a class="marketplace-link" href="https://bittrex.com/">Bittrex</a>
+          <br>
           <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
           <br>
           <a class="marketplace-link" href="https://www.itbit.com/">itBit</a>


### PR DESCRIPTION
This closes #2577 as part of the discussion that was had regarding reconsideration of the site ban on NYA companies. I did not add Xapo back to the Exchanges page because I've seen a number of people mentioning issues with their KYC/AML process (e.g. long delays, no response to questions) and/or lack of responses from their support team. I also logged into a web wallet to ask their support team if it's possible to buy/sell bitcoin with them to confirm and never received a reply.