### PR TITLE
community: Remove Colombian Nonprofit

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -163,13 +163,6 @@ id: community
           </div>
         </div>
         <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/CO.svg?{{site.time | date: '%s'}}" alt="Colombian Flag">
-          <div>
-            <h3 class="organization-country" id="colombia">Colombia</h3>
-            <a class="organization-link" href="http://www.bitcoincolombia.org/">Fundación Bitcoin Colombia</a>
-          </div>
-        </div>
-        <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/DK.svg?{{site.time | date: '%s'}}" alt="Danish flag">
           <div>
             <h3 class="organization-country" id="denmark">Denmark</h3>


### PR DESCRIPTION
This removes a dead link pointing to "Fundacion Bitcoin Colombia" on the
Community page and will be merged once tests pass. The referenced domain
(bitcoincolombia.org) only shows a default cPanel configuration page,
now.

Cc: @santy2001