### PR TITLE
Add fastx.io to Australian Exchanges list

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -388,6 +388,8 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://digitalsurge.com.au/">Digital Surge</a>
     <br>
+    <a class="marketplace-link" href="https://fastx.io/">FastX</a>
+    <br>
     <a class="marketplace-link" href="https://www.hardblock.net/">HardBlock</a>
     <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>


### PR DESCRIPTION
Hey,

We have fixed the issues we had on the first pull request attempt.
Our pricing model has been updated as well. 

Fiat to crypto conversion rates include 1.75% Braintree cc processing fee.

Please let me know if any issues arise.

Thank you