### PR TITLE
Add BIP70 deprecation warnings

### DIFF
--- a/_data/devdocs/en/examples/payment_processing.md
+++ b/_data/devdocs/en/examples/payment_processing.md
@@ -3,6 +3,7 @@ This file is licensed under the MIT License (MIT) available on
 http://opensource.org/licenses/MIT.
 {% endcomment %}
 {% assign filename="_data/devdocs/en/examples/payment_processing.md" %}
+{% assign DEPRECATED='Deprecated' %}
 
 
 ## Payment Processing
@@ -15,6 +16,13 @@ http://opensource.org/licenses/MIT.
 
 To request payment using the payment protocol, you use an extended (but
 backwards-compatible) `bitcoin:` URI.  For example:
+
+![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+ **Warning:** The payment protocol is considered to be deprecated and will be removed in a later version of Bitcoin Core. 
+The protocol has multiple security design flaws and implementation flaws in some wallets.
+Users will begin receiving deprecation warnings in Bitcoin Core version 0.18 when using BIP70 URI's.
+Merchants should transition away from BIP70 to more secure options such as BIP21.
+Merchants should never require BIP70 payments and should provide BIP21 fallbacks.
 
 {% endautocrossref %}
 

--- a/_data/devdocs/en/guides/payment_processing.md
+++ b/_data/devdocs/en/guides/payment_processing.md
@@ -256,6 +256,13 @@ displayed on high-resolution screens.
 
 {% autocrossref %}
 
+![Warning icon](/img/icons/icon_warning.svg?{{site.time | date: '%s'}})
+ **Warning:** The payment protocol is considered to be deprecated and will be removed in a later version of Bitcoin Core. 
+The protocol has multiple security design flaws and implementation flaws in some wallets.
+Users will begin receiving deprecation warnings in Bitcoin Core version 0.18 when using BIP70 URI's.
+Merchants should transition away from BIP70 to more secure options such as BIP21.
+Merchants should never require BIP70 payments and should provide BIP21 fallbacks.
+
 Bitcoin Core 0.9 supports the new [payment protocol][/en/glossary/payment-protocol]{:#term-payment-protocol}{:.term}. The payment protocol
 adds many important features to payment requests:
 

--- a/_data/devdocs/en/guides/transactions.md
+++ b/_data/devdocs/en/guides/transactions.md
@@ -259,7 +259,7 @@ that script does. Receivers do care about the script conditions and, if
 they want, they can ask spenders to use a particular pubkey script.
 Unfortunately, custom pubkey scripts are less convenient than short
 Bitcoin addresses and there was no standard way to communicate them
-between programs prior to widespread implementation of the BIP70 Payment
+between programs prior to widespread implementation of the now deprecated BIP70 Payment
 Protocol discussed later.
 
 To solve these problems, pay-to-script-hash

--- a/_data/devdocs/en/references/p2p_networking.md
+++ b/_data/devdocs/en/references/p2p_networking.md
@@ -12,7 +12,7 @@ http://opensource.org/licenses/MIT.
 
 This section describes the Bitcoin P2P network protocol (but it is [not a
 specification][]). It does not describe the discontinued direct [IP-to-IP
-payment protocol][], the [BIP70 payment protocol][/en/glossary/payment-protocol], the
+payment protocol][], the [deprecated BIP70 payment protocol][/en/glossary/payment-protocol], the
 [GetBlockTemplate mining protocol][section getblocktemplate], or any
 network protocol never implemented in an official version of Bitcoin Core.
 

--- a/_data/glossary/en/payment-protocol.yaml
+++ b/_data/glossary/en/payment-protocol.yaml
@@ -7,7 +7,7 @@ required:
     title_max_40_characters_no_formatting: Payment Protocol, Payment Request, BIP70
 
     summary_max_255_characters_no_formatting: >
-        The protocol defined in BIP70 (and other BIPs) which lets
+        The deprecated protocol defined in BIP70 (and other BIPs) which lets
         spenders get signed payment details from receivers.
 
     synonyms_shown_in_glossary_capitalize_first_letter:


### PR DESCRIPTION
BIP70 has been [deprecated](https://github.com/bitcoin/bitcoin/pull/14451) in Bitcoin Core and its use should be strongly discouraged due to design and implementation flaws that have an impact on security.