### PR TITLE
Resolves IE positioning issue of cookie consent popup.

### DIFF
--- a/js/cookieconsent/light-floating.css
+++ b/js/cookieconsent/light-floating.css
@@ -78,7 +78,7 @@
 
 @media screen and (min-width: 500px){
 	.cc_container{
-		left:initial;
+		left:auto;
 		right:20px;
 		bottom:20px;
 		width:300px;


### PR DESCRIPTION
On IE for desktop resolutions, the cookie consent pop-up is displayed on the left side of the screen with no space to the left:

![ie](https://user-images.githubusercontent.com/45130411/48958828-4f408380-ef6a-11e8-9a83-f3f0f517ff32.png)

as opposed to being displayed on the right side of the screen, like on Chrome, Firefox, Opera:

![chrome](https://user-images.githubusercontent.com/45130411/48958844-62535380-ef6a-11e8-9596-fcf038e7b3a1.png)

By changing the value of the "left" property on that element from "initial" to "auto" it will be displayed correctly.

This is happening because IE does not support the "initial" value:
https://caniuse.com/css-initial-value

Also, "auto" **is** the initial default value for the "left" property.