### PR TITLE
community: Drop Bitcoin Alliance of Canada

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -156,13 +156,6 @@ id: community
           </div>
         </div>
         <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/CA.svg?{{site.time | date: '%s'}}" alt="Canadian flag">
-          <div>
-            <h3 class="organization-country" id="canada">Canada</h3>
-            <a class="organization-link" href="http://www.bitcoinalliance.ca/">Bitcoin Alliance of Canada</a>
-          </div>
-        </div>
-        <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/DK.svg?{{site.time | date: '%s'}}" alt="Danish flag">
           <div>
             <h3 class="organization-country" id="denmark">Denmark</h3>


### PR DESCRIPTION
This closes #2769 and drops "The Bitcoin Alliance of Canada" from the community page. This will be merged once tests pass. The link that is being removed is redirecting to an alternative blockchain / token-based initiative, with no specific relation to Bitcoin. 