### PR TITLE
resources: Drop 'BitcoinFilm.org'

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -90,9 +90,6 @@ id: resources
         <img src="/img/icons/ico_doc.svg?{{site.time | date: '%s'}}" alt="Icon">
         <h2 id="documentaries">{% translate documentaries %}</h2>
         <p>
-          <a href="http://bitcoinfilm.org/">BitcoinFilm.org</a>
-        </p>
-        <p>
           <a href="http://iamsatoshi.com/">Ulterior States</a>
         </p>
         <p>


### PR DESCRIPTION
This drops BitcoinFilm.org from the Resources page and will be merged
once tests pass. Their site has been showing a PHP error and hasn't been
loading properly for a couple of weeks, now:

<img width="661" alt="image" src="https://user-images.githubusercontent.com/1130872/49548368-1928cb00-f8ab-11e8-9f0d-a602b997bede.png">
