### PR TITLE
exchanges: Drop Bitmae

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -246,16 +246,6 @@ id: exchanges
     </div>
 
     <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/CR.png?{{site.time | date: '%s'}}" alt="Costa Rican flag">
-      <div>
-        <h3 id="costa-rica" class="no_toc">Costa Rica</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.bitmae.com/">BitMae</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/MX.svg?{{site.time | date: '%s'}}" alt="Mexican flag">
       <div>
         <h3 id="mexico" class="no_toc">Mexico</h3>


### PR DESCRIPTION
This drops Bitmae from the Exchanges page and will be merged once tests
pass; they are redirecting to Xapo.