### PR TITLE
exchanges: Drop QuickBT

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -238,8 +238,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.quadrigacx.com/">Quadriga CX</a>
           <br>
-          <a class="marketplace-link" href="https://quickbt.com/">QuickBT</a>
-          <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>
         </p>
       </div>


### PR DESCRIPTION
This drops QuickBT from the exchanges page and will be merged once tests
pass. They ceased operations as of this past week.