### PR TITLE
community: Drop 'Belgian Bitcoin Association'

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -149,13 +149,6 @@ id: community
           </div>
         </div>
         <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/BE.svg?{{site.time | date: '%s'}}" alt="Belgian flag">
-          <div>
-            <h3 class="organization-country" id="belgium">Belgium</h3>
-            <a class="organization-link" href="http://www.bitcoinassociation.be/">Belgian Bitcoin Association</a>
-          </div>
-        </div>
-        <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/DK.svg?{{site.time | date: '%s'}}" alt="Danish flag">
           <div>
             <h3 class="organization-country" id="denmark">Denmark</h3>


### PR DESCRIPTION
This drops the Belgian Bitcoin Association from the community page and
will be merged once tests pass. Their domain expired on December 24th
and the website no longer resolves.

Cc: @arnuschky