### PR TITLE
Update to using SVG logo

### DIFF
--- a/_includes/layout/base/head-logo.html
+++ b/_includes/layout/base/head-logo.html
@@ -3,4 +3,4 @@ This file is licensed under the MIT License (MIT) available on
 http://opensource.org/licenses/MIT.
 {% endcomment %}
 
-<a class="logo" href="/{{ page.lang }}/"><img src="/img/icons/logotop.png?{{site.time | date: '%s'}}" alt="Bitcoin"></a>
+<a class="logo" href="/{{ page.lang }}/"><img src="/img/icons/logotop.svg?{{site.time | date: '%s'}}" alt="Bitcoin"></a>

--- a/img/icons/logotop.svg
+++ b/img/icons/logotop.svg
@@ -1,4 +1,4 @@
-<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="190" height="40" version="1.1">
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 190 40" version="1.1">
   <g transform="translate(-289.60744,-341.50536)">
     <g transform="matrix(0.61129216,0,0,0.61129216,170.80346,315.53734)">
       <path d="m258.845 82.989c-4.274 17.143-21.637 27.576-38.782 23.301-17.138-4.274-27.571-21.638-23.295-38.78 4.272-17.145 21.635-27.579 38.775-23.305 17.144 4.274 27.576 21.64 23.302 38.784z" fill="#f7931a"/>


### PR DESCRIPTION
Replaces the logo on the head of the site with SVG version, which sharpens and improves the quality of the logo considerably on higher resolution displays.