### PR TITLE
exchanges: Drop QuadrigaCX

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -238,8 +238,6 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a>
           <br>
-          <a class="marketplace-link" href="https://www.quadrigacx.com/">Quadriga CX</a>
-          <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>
         </p>
       </div>


### PR DESCRIPTION
This removes QuadrigaCX from the Exchanges page in light of [recent controversy](https://www.reddit.com/r/QuadrigaCX/comments/ag1lrx/statement_from_jennifer_robertson_wife_and/) surrounding the platform (i.e. users missing withdrawals, founder death, confusion on who is running the company) and will be merged once tests pass.