### PR TITLE
Community page housekeeping | http -> https

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -138,7 +138,7 @@ id: community
           <img class="organization-img" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag">
           <div>
             <h3 class="organization-country" id="argentina">Argentina</h3>
-            <a class="organization-link" href="http://www.bitcoinargentina.org/">Fundación Bitcoin Argentina</a>
+            <a class="organization-link" href="https://www.bitcoinargentina.org/">Fundación Bitcoin Argentina</a>
           </div>
         </div>
         <div class="row organizations-item">
@@ -152,7 +152,7 @@ id: community
           <img class="organization-img" src="/img/flags/DK.svg?{{site.time | date: '%s'}}" alt="Danish flag">
           <div>
             <h3 class="organization-country" id="denmark">Denmark</h3>
-            <a class="organization-link" href="http://www.danskbitcoinforening.dk/">Dansk Bitcoinforening</a>
+            <a class="organization-link" href="https://www.danskbitcoinforening.dk/">Dansk Bitcoinforening</a>
             <br>
           </div>
         </div>
@@ -168,7 +168,7 @@ id: community
           <img class="organization-img" src="/img/flags/IL.svg?{{site.time | date: '%s'}}" alt="Israeli flag">
           <div>
             <h3 class="organization-country" id="israel">Israel</h3>
-            <a class="organization-link" href="http://www.bitcoin.org.il/">איגוד הביטקוין הישראלי</a>
+            <a class="organization-link" href="https://www.bitcoin.org.il/">איגוד הביטקוין הישראלי</a>
           </div>
         </div>
         <div class="row organizations-item">
@@ -183,22 +183,21 @@ id: community
           <img class="organization-img" src="/img/flags/NL.svg?{{site.time | date: '%s'}}" alt="Dutch flag">
           <div>
             <h3 class="organization-country" id="netherlands">Netherlands</h3>
-            <a class="organization-link" href="http://stichtingbitcoin.nl/">Stichting Bitcoin Nederland</a>
-            <a class="organization-link" href="https://bitcoinembassy.nl/">Bitcoin Embassy Amsterdam</a>
+            <a class="organization-link" href="https://stichtingbitcoin.nl/">Stichting Bitcoin Nederland</a>
           </div>
         </div>
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/PH.svg?{{site.time | date: '%s'}}" alt="Philippine flag">
           <div>
             <h3 class="organization-country" id="philippines">Philippines</h3>
-            <a class="organization-link" href="http://bitcoin.org.ph/">Bitcoin Organization of the Philippines</a>
+            <a class="organization-link" href="https://bitcoin.org.ph/">Bitcoin Organization of the Philippines</a>
           </div>
         </div>
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="Polish flag">
           <div>
             <h3 class="organization-country" id="poland">Poland</h3>
-            <a class="organization-link" href="http://www.bitcoin.org.pl/">Polish Bitcoin Association</a>
+            <a class="organization-link" href="https://www.bitcoin.org.pl/">Polish Bitcoin Association</a>
           </div>
         </div>
     
@@ -234,7 +233,7 @@ id: community
           <img class="organization-img" src="/img/flags/CH.svg?{{site.time | date: '%s'}}" alt="Swiss flag">
           <div>
             <h3 class="organization-country" id="switzerland">Switzerland</h3>
-            <a class="organization-link" href="http://bitcoinassociation.ch/">Bitcoin Association Switzerland</a>
+            <a class="organization-link" href="https://bitcoinassociation.ch/">Bitcoin Association Switzerland</a>
           </div>
         </div>
         <div class="row organizations-item">


### PR DESCRIPTION
Checked all links were still working. Removed one url that now redirects to an ATM manufacturer.
Changed to https:// where possible.