### PR TITLE
Update Tor support for Electrum on Android

### DIFF
--- a/_wallets/electrum.md
+++ b/_wallets/electrum.md
@@ -51,5 +51,5 @@ platform:
         privacycheck:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosureaccount"
-          privacynetwork: "checkfailprivacynetworknosupporttor"
+          privacynetwork: "checkpassprivacynetworksupporttorproxy"
 ---


### PR DESCRIPTION
As suspected in #2837 Electrum on Android seems to support Tor (tested using Orbot).
@ecdsa unless you let us know otherwise, this closes #2837.
Thanks @JeremyRand.