### PR TITLE
Tests: fix wallet schema test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,4 +304,4 @@ check-for-too-many-wallets-on-one-platform:
 
 check-validate-yaml:
 ## Validate YAML files against schemas
-	$S find _wallets -type f -exec bundle exec _contrib/schema-validator.rb quality-assurance/schemas/wallets.yaml {} \;
+	$S ! find _wallets -type f -exec bundle exec _contrib/schema-validator.rb quality-assurance/schemas/wallets.yaml {} \; | grep .


### PR DESCRIPTION
As mentioned by @crwatkins on https://github.com/bitcoin-dot-org/bitcoin.org/pull/2840#issuecomment-460851781 , the schema-validation test failed to catch a problem.  This appears to have been because of how the test was modified to run as a child of the `find` process.  `find` always returns true if it finds files, so its child processes failures wouldn't be propagated back up to the test process.  This fixes the oversight.

I've tested this by reintroducing the exact problem identified by Craig above, running the test, and ensuring that it raised a fault.  Upon removing the bug, the test passes.