### PR TITLE
Change Wasabi transparency to checkgoodtransparencydeterministic

### DIFF
--- a/_wallets/wasabi.md
+++ b/_wallets/wasabi.md
@@ -18,7 +18,7 @@ platform:
       check:
         control: "checkgoodcontrolfull"
         validation: "checkfailvalidationcentralized"
-        transparency: "checkpasstransparencyopensource"
+        transparency: "checkgoodtransparencydeterministic"
         environment: "checkfailenvironmentdesktop"
         privacy: "checkgoodprivacyimproved"
         fees: "checkpassfeecontroldynamic"


### PR DESCRIPTION
Wasabi wallet's transparency score was added with `checkpasstransparencyopensource`. This PR updates its to `checkgoodtransparencydeterministic`.

The reason for `checkpasstransparencyopensource` is that I was not familiar with the deterministic builds concept at the time, thus I just opened an issue to research it: https://github.com/zkSNACKs/WalletWasabi/issues/1078 

I've done my investigation now and it turns out, our tooling is creating deterministic builds by default. While I went ahead and verified it, of which the rest of this comment is about, I'd like to note that in the commit https://github.com/zkSNACKs/WalletWasabi/commit/b4c86c83b978ab0a8ea1fbf2354ec41447634d4d I explicitly specified the deterministic compiler flag to make it future proof and to avoid relying on the default behavior.

Roslyn (C# compiler) uses deterministic builds by default: [Why is deterministic builds the new MS norm now?](https://www.reddit.com/r/dotnet/comments/9pje6r/why_is_deterministic_builds_the_new_ms_norm_now/)

There's also a `<Deterministic>True</Deterministic>` compiler option we can add to our .csprojs.  
I went ahead to verify it. I ran the packager 5 times and extracted the Linux tar.gz archive as a folder (extracted because the diff output will look nicer):

1. Explicitly specified deterministic build in the .csproj: `deterministic`
2. Explicitly specified non-deterministic build in the .csproj: `non-deterministic`
3. Explicitly specified deterministic build (again) in the .csproj: `deterministic2`
4. Explicitly specified non-deterministic build (again) in the .csproj: `non-deterministic2`
5. Did not specify explicitly anything: `default`

After that I ran `git diff --no-index folder1 folder2` to spot the difference:

# ✅ default vs deterministic

![image](https://user-images.githubusercontent.com/9156103/52904745-a041da00-3230-11e9-88f2-16119a74119a.png)

# ✅ default vs deterministic2

![image](https://user-images.githubusercontent.com/9156103/52904747-b51e6d80-3230-11e9-82db-8a082b88850c.png)

# ❌ default vs non-deterministic

![image](https://user-images.githubusercontent.com/9156103/52904763-d0897880-3230-11e9-855d-2e3b86a5c5ff.png)

# ❌ non-deterministic vs non-deterministic2

![image](https://user-images.githubusercontent.com/9156103/52904780-f878dc00-3230-11e9-9022-354a523dd5dc.png)

# Reproduce

After [getting Wasabi source code,](https://github.com/zkSNACKs/WalletWasabi#build-from-source-code) one can reproduce our builds with the same flags we are publishing with (instead of running `dotnet run`): `dotnet publish --configuration Release --force --self-contained true --runtime linux-x64 /p:VersionPrefix=1.1.1 --disable-parallel --no-cache`.  

Source: 

https://github.com/zkSNACKs/WalletWasabi/blob/59c2180556eae2176dc43b25c3ba3a56ea69c281/WalletWasabi.Packager/Program.cs#L172

