### PR TITLE
community: Remove Bitcoin Organization of the Philippines

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -187,13 +187,6 @@ id: community
           </div>
         </div>
         <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/PH.svg?{{site.time | date: '%s'}}" alt="Philippine flag">
-          <div>
-            <h3 class="organization-country" id="philippines">Philippines</h3>
-            <a class="organization-link" href="https://bitcoin.org.ph/">Bitcoin Organization of the Philippines</a>
-          </div>
-        </div>
-        <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="Polish flag">
           <div>
             <h3 class="organization-country" id="poland">Poland</h3>


### PR DESCRIPTION
This removes the [Bitcoin Organization of the Philippines](https://bitcoin.org.ph/) from the
Community page and will be merged once tests pass. Their site has been
going up and down over the past month, and has now been down for seven
days straight, it seems.

This is to protect our [page rank](https://en.wikipedia.org/wiki/PageRank) from being harmed by linking to web
pages (like this one) that 404 and/or domains that do not respond. When
a page on the site does this, search engines can in turn give our
corresponding linking page a lower search engine ranking, because they
will deem that the page has less relevancy for the search phrase, since it
links to content that doesn't exist (compared to other web pages on
other web sites that could be competing in the search results against
us, that do not).