### PR TITLE
Add Cryptoradar to Directories

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -56,6 +56,8 @@ id: resources
         <p>
           <a href="https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/">{% translate linkmerchants %}</a> - 99Bitcoins.com</p>
         <p>
+          <a href="https://cryptoradar.co/buy-bitcoin">{% translate linkexchanges %}</a> - cryptoradar.co</p>
+        <p>
           <a href="https://www.buybitcoinworldwide.com/">{% translate linkexchanges %}</a> - buybitcoinworldwide.com</p>
         <p>
           <a href="https://en.bitcoin.it/wiki/Category:Shopping_Cart_Interfaces">{% translate linkmerchantstools %}</a> - en.bitcoin.it</p>


### PR DESCRIPTION
Cryptoradar is a popular tool that lists more than 30 international Bitcoin exchanges and allows users to compare these platforms based on a number of factors such as prices, fees, features and user reviews.