### PR TITLE
Fix Wrong Language Name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ langs:
   'id': 'Bahasa Indonesia'
   'it': 'Italiano'
   'ja': '日本語'
-  'ko': '한국의'
+  'ko': '한국어'
   'nl': 'Nederlands'
   'pl': 'Polski'
   'pt_BR': 'Português Brasil'


### PR DESCRIPTION
'한국의' means 'of Korea'.
The correct translate of 'Korean' is '한국어'.