### PR TITLE
Remove incorrect explanation of `verifymessage`

### DIFF
--- a/_data/devdocs/en/bitcoin-core/rpcs/rpcs/verifymessage.md
+++ b/_data/devdocs/en/bitcoin-core/rpcs/rpcs/verifymessage.md
@@ -19,7 +19,7 @@ The `verifymessage` RPC {{summary_verifyMessage}}
 - n: "Address"
   t: "string (base58)"
   p: "Required<br>(exactly 1)"
-  d: "The P2PKH address corresponding to the private key which made the signature.  A P2PKH address is a hash of the public key corresponding to the private key which made the signature.  When the ECDSA signature is checked, up to four possible ECDSA public keys will be reconstructed from from the signature; each key will be hashed and compared against the P2PKH address provided to see if any of them match.  If there are no matches, signature validation will fail"
+  d: "The P2PKH address corresponding to the private key which made the signature.  A P2PKH address is a hash of the public key corresponding to the private key which made the signature."
 
 {% enditemplate %}
 


### PR DESCRIPTION
It's not true that all four possible public keys (corresponding to recovery
ids) are tried. The recovery id is instead read from the signature, see
https://github.com/bitcoin/bitcoin/blob/78dae8caccd82cfbfd76557f1fb7d7557c7b5edb/src/pubkey.cpp#L189.