### PR TITLE
Drop Google+ Bitcoin Community from Community Page

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -65,7 +65,6 @@ id: community
         <p>
           <a href="https://vk.com/bitcoin">Страница на ВКонтакте</a>
         </p>{% endif %}
-        <p>{% translate linkgoogle %}</p>
         <p>
           <a href="https://twitter.com/search?q=bitcoin">{% translate linktwitter %}</a>
         </p>

--- a/_translations/ar.yml
+++ b/_translations/ar.yml
@@ -87,7 +87,6 @@ ar:
     chanmarket: "(إقتباسات مباشرة من الأسواق)"
     chanmining: "(المواضيع المتعلقة بالتنقيب عن البت كوين)"
     social: "الشبكات الإجتماعية"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">مجتمع البت كوين على جوجل+</a>"
     linktwitter: "البحث عن البت كوين على تويتر"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">صفحة البت كوين على فيسبوك</a>"
     meetups: "اللقاءات"

--- a/_translations/bg.yml
+++ b/_translations/bg.yml
@@ -87,7 +87,6 @@ bg:
     chanmarket: "(Канал за съобщения за пазарите в реално време)"
     chanmining: "(Канал за Биткойн добив)"
     social: "Социални мрежи"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Биткойн общност в Google+</a>"
     linktwitter: "Търсене в Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook страница</a>"
     meetups: "Срещи"

--- a/_translations/da.yml
+++ b/_translations/da.yml
@@ -87,7 +87,6 @@ da:
     chanmarket: "(markedsnoteringer i realtid)"
     chanmining: "(relateret til Bitcoin-mining)"
     social: "Sociale netværk"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Bitcoin-fællesskab på Google+</a>"
     linktwitter: "Twitter-søgning"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook-side</a>"
     meetups: "Sammenkomster"

--- a/_translations/de.yml
+++ b/_translations/de.yml
@@ -163,7 +163,6 @@ de:
     chanmarket: "(Echtzeit-Kurse verschiedener Börsen, englisch)"
     chanmining: "(Bitcoin-Mining, englisch)"
     social: "Soziale Netzwerke"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitcoin-Community</a>"
     linktwitter: "Twitter-Suche"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook-Seite</a>"
     meetups: "Meetups"

--- a/_translations/el.yml
+++ b/_translations/el.yml
@@ -87,7 +87,6 @@ el:
     chanmarket: "(Ζωντάνες προσφορές από τις αγορές)"
     chanmining: "(σχετικά με την εξόρυξη Bitcoin)"
     social: "Κοινωνικά δίκτυα"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitcoin Κοινότητα</a>"
     linktwitter: "Αναζήτηση στο Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Σελίδα στο Facebook</a>"
     meetups: "Συναντήσεις"

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -166,7 +166,6 @@ en:
     chanmarket: "(Live quotes from markets)"
     chanmining: "(Bitcoin mining related)"
     social: "Social networks"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitcoin Community</a>"
     linktwitter: "Twitter Search"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook Page</a>"
     meetups: "Meetups"

--- a/_translations/es.yml
+++ b/_translations/es.yml
@@ -94,7 +94,6 @@ es:
     chanmarket: "(Cotizaciones de los mercados en tiempo real, en inglés)"
     chanmining: "(Relacionado con la minería Bitcoin, en inglés)"
     social: "Redes sociales"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Comunidad Bitcoin en Google+</a>"
     linktwitter: "Buscar en Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Página de Facebook</a>"
     meetups: "Encuentros"

--- a/_translations/fa.yml
+++ b/_translations/fa.yml
@@ -87,7 +87,6 @@ fa:
     chanmarket: "(مظنه دادن از بازارها بصورت زنده)"
     chanmining: "(در مورد استخراج بیت کوین)"
     social: "شبکه های اجتماعی"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">جامعه بیت‌کوین در گوگل پلاس</a>"
     linktwitter: "جست و جوی  توئیتری"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">صفحه فیس بوک</a>"
     meetups: "نشست ها"

--- a/_translations/fr.yml
+++ b/_translations/fr.yml
@@ -87,7 +87,6 @@ fr:
     chanmarket: "(Cotations en direct, anglais)"
     chanmining: "(Minage de bitcoins, anglais)"
     social: "Réseaux sociaux"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Communauté Bitcoin sur Google+ (anglais)</a>"
     linktwitter: "Recherche Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Page Facebook (anglais)</a>"
     meetups: "Rencontres"

--- a/_translations/hi.yml
+++ b/_translations/hi.yml
@@ -87,7 +87,6 @@ hi:
     chanmarket: "( बाजार से लाइव उद्धरण) "
     chanmining: "( Bitcoin खनन से संबंधित ) "
     social: " सोशल नेटवर्क"
-    linkgoogle: " <a href=\"https://plus.google.com/communities/115591368588047305300\"> Google+ पर Bitcoin समुदाय </ a > "
     linktwitter: "Twitter खोज "
     facebook: "<a href=\"https://www.facebook.com/bitcoins\"> Facebook  पृष्ठ </a>"
     meetups: " मिलाप"

--- a/_translations/hu.yml
+++ b/_translations/hu.yml
@@ -87,7 +87,6 @@ hu:
     chanmarket: "(élő jegyzés a piacokról)"
     chanmining: "(bitcoin-bányászati témák)"
     social: "Közösségi hálózatok"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitcoin-közösség</a>"
     linktwitter: "Keresés a Twitteren"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook oldal</a>"
     meetups: "Meetupok"

--- a/_translations/id.yml
+++ b/_translations/id.yml
@@ -157,7 +157,6 @@ id:
     chanmarket: "(Kutipan langsung dari pasar)"
     chanmining: "(Hal-hal terkait penambangan Bitcoin)"
     social: "Jejaring sosial"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Komunitas Google+ Bitcoin</a>"
     linktwitter: "Pencarian Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Halaman Facebook</a>"
     meetups: "Pertemuan"

--- a/_translations/it.yml
+++ b/_translations/it.yml
@@ -161,7 +161,6 @@ it:
     chanmarket: "(Quotazioni in tempo reale dai mercati)"
     chanmining: "(Discussioni sul mining di Bitcoin)"
     social: "Social network"
-    linkgoogle: "<a href=\"https://plus.google.com/u/0/communities/102618032315872316256\">Comunità Bitcoin su Google+</a>"
     linktwitter: "Ricerca Twitter"
     facebook: "<a href=\"https://www.facebook.com/groups/144961585575245\"> La Pagina Facebook</a>"
     meetups: "Incontri"

--- a/_translations/ja.yml
+++ b/_translations/ja.yml
@@ -131,7 +131,6 @@ ja:
     chanmarket: "(市場からのリアルタイム相場)"
     chanmining: "(ビットコインマイニング関連)"
     social: "ソーシャル・ネットワーク"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ ビットコイン・コミュニティー</a>"
     linktwitter: "Twitterでの検索"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebookページ</a>"
     meetups: "ミートアップ"

--- a/_translations/ko.yml
+++ b/_translations/ko.yml
@@ -87,7 +87,6 @@ ko:
     chanmarket: "(실시간 시장 거래가)"
     chanmining: "(비트코인 채굴 관련)"
     social: "소셜 네트워크"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ 비트코인 커뮤니티</a>"
     linktwitter: "트위터 검색"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">페이스북 페이지</a>"
     meetups: "모임"

--- a/_translations/nl.yml
+++ b/_translations/nl.yml
@@ -159,7 +159,6 @@ nl:
     chanmarket: "(Live quotes van verschillende markten)"
     chanmining: "(Over Bitcoin-mining)"
     social: "Sociale netwerken"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitcoin Community</a>"
     linktwitter: "Zoek op Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook-pagina</a>"
     meetups: "Meetups"

--- a/_translations/pl.yml
+++ b/_translations/pl.yml
@@ -87,7 +87,6 @@ pl:
     chanmarket: "(Cytaty z rynku na żywo)"
     chanmining: "(O wydobywaniu bitcoinów)"
     social: "Sieci społecznościowe"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Społeczność Bitcoin w Google+</a>"
     linktwitter: "Wyszukaj na Twitterze"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Strona na Facebook</a>"
     meetups: "Spotkania"

--- a/_translations/pt_BR.yml
+++ b/_translations/pt_BR.yml
@@ -158,7 +158,6 @@ pt_BR:
     chanmarket: "(Cotações do mercado em tempo real)"
     chanmining: "(Sobre mineração Bitcoin)"
     social: "Redes sociais"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Comunidade Google+ </a>"
     linktwitter: "Buscas Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Página no Facebook</a>"
     meetups: "Encontros"

--- a/_translations/ro.yml
+++ b/_translations/ro.yml
@@ -87,7 +87,6 @@ ro:
     chanmarket: "(Cursuri live ale burselor)"
     chanmining: "(Discuţii despre minerit Bitcoin)"
     social: "Reţele de socializare"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Comunitatea Bitcoin pe Google+</a>"
     linktwitter: "Căutare pe Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Pagina de Facebook</a>"
     meetups: "Întâlniri"

--- a/_translations/ru.yml
+++ b/_translations/ru.yml
@@ -134,7 +134,6 @@ ru:
     chanmarket: "(Онлайн котировки)"
     chanmining: "(Майнинг)"
     social: "Социальные сети"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+  Сообщество Биткойн</a>"
     linktwitter: "Поиск в Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Страница на Facebook</a>"
     meetups: "Встречи"

--- a/_translations/sl.yml
+++ b/_translations/sl.yml
@@ -87,7 +87,6 @@ sl:
     chanmarket: "(Trenutni podatki s trgov)"
     chanmining: "(Povezano z rudarjenjem)"
     social: "Družbena omrežja"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Bitcoin Skupnost na Google+</a>"
     linktwitter: "Twitter Iskalnik"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Stran na Facebooku</a>"
     meetups: "Srečanja"

--- a/_translations/sr.yml
+++ b/_translations/sr.yml
@@ -152,7 +152,6 @@ sr:
     chanmarket: "Uživo cene na tržištu"
     chanmining: "(Vezano za Bitkoin rudarenje)"
     social: "Socijalne mreže"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitkoin Zajednica</a>"
     linktwitter: "Twitter Pretraga"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook Stranica</a>"
     meetups: "Okupljanja"

--- a/_translations/sv.yml
+++ b/_translations/sv.yml
@@ -94,7 +94,6 @@ sv:
     chanmarket: "(Marknadsnoteringar i realtid)"
     chanmining: "(Bitcoin-utvinning relaterat)"
     social: "Sociala nätverk"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitcoin Community</a>"
     linktwitter: "Twitter-sökning"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook Sida</a>"
     meetups: "Meetups"

--- a/_translations/tr.yml
+++ b/_translations/tr.yml
@@ -87,7 +87,6 @@ tr:
     chanmarket: "(Marketlerden canlı alıntı)"
     chanmining: "(Bitcoin madenciliğiyle ilgili)"
     social: "Sosyal ağlar"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitcoin Topluluğu</a>"
     linktwitter: "Twitter Araması"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook Sayfası</a>"
     meetups: "Toplantılar"

--- a/_translations/uk.yml
+++ b/_translations/uk.yml
@@ -135,7 +135,6 @@ uk:
     chanmarket: "(Онлайн котирування)"
     chanmining: "(Видобуток біткоїнів)"
     social: "Соціальні мережі"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Біткойн-спільнота у Google+</a>"
     linktwitter: "Пошук у Твіттері"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Сторінка у Фейсбуці</a>"
     meetups: "Зустрічі"

--- a/_translations/zh_CN.yml
+++ b/_translations/zh_CN.yml
@@ -125,7 +125,6 @@ zh_CN:
     chanmarket: "（交易市场实时报价）"
     chanmining: "（比特币挖矿相关）"
     social: "社交网络"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ 比特币社区</a>"
     linktwitter: "Twitter搜索"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">比特币的Facebook页</a>"
     meetups: "聚会"

--- a/_translations/zh_TW.yml
+++ b/_translations/zh_TW.yml
@@ -87,7 +87,6 @@ zh_TW:
     chanmarket: "(市場即時報價)"
     chanmining: "(Bitcoin 挖礦相關)"
     social: "社交網路"
-    linkgoogle: "<a href=\"https://plus.google.com/communities/115591368588047305300\">Google+ Bitcoin 社群</a>"
     linktwitter: "Twitter 搜尋"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook 頁面</a>"
     meetups: "聚會"


### PR DESCRIPTION
This drops the Google+ Bitcoin Community link from the [Community](https://bitcoin.org/en/community) page and will be merged once tests pass. Google recently officially shutdown Google+ this month. The link on the Community page now leads to a notice regarding the shutdown:

<img width="583" alt="Screen Shot 2019-04-14 at 20 21 24" src="https://user-images.githubusercontent.com/1130872/56103995-30e12180-5f25-11e9-9c19-3e694bc0da06.png">