### PR TITLE
community: Drop 'Dansk Bitcoinforening'

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -149,14 +149,6 @@ id: community
           </div>
         </div>
         <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/DK.svg?{{site.time | date: '%s'}}" alt="Danish flag">
-          <div>
-            <h3 class="organization-country" id="denmark">Denmark</h3>
-            <a class="organization-link" href="https://www.danskbitcoinforening.dk/">Dansk Bitcoinforening</a>
-            <br>
-          </div>
-        </div>
-        <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/DE.svg?{{site.time | date: '%s'}}" alt="German flag">
           <div>
             <h3 class="organization-country" id="germany">Germany</h3>


### PR DESCRIPTION
This drops Dansk Bitcoinforening from the community page and will be
merged once tests pass. The site has been returning a 404 for many days.