### PR TITLE
Update transactions.md

### DIFF
--- a/_data/devdocs/en/references/transactions.md
+++ b/_data/devdocs/en/references/transactions.md
@@ -239,7 +239,7 @@ the [CompactSize section][section CompactSize unsigned integer].
 
 {% autocrossref %}
 
-Each non-coinbase input spends an outpoint from a previous transaction.
+Each non-coinbase input spends an output from a previous transaction.
 (Coinbase inputs are described separately after the example section below.)
 
 | Bytes    | Name             | Data Type            | Description


### PR DESCRIPTION
fixed typo. In this context, I would argue one spends an output rather than an outpoint. As per definition an outpoint is the data structure characterizing a specific output. What you are spending is an output, described by an outpoint.