### PR TITLE
Remove Opendime from resources under "Vouchers" category

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -121,9 +121,6 @@ id: resources
         <p>
           <a href="https://gyft.com/bitcoin/">Gyft</a>
         </p>
-        <p>
-          <a href="https://opendime.com/">Opendime</a>
-        </p>
       </div>
 
   </div>


### PR DESCRIPTION
A user in the Bitcoin Core community Slack (shinobimonkey) felt that we were miscategorizing Opendime by listing it as a form of voucher.

This pull request removes Opendime from that page until we find a better way to explain the concept to users.