### PR TITLE
resources: Update TradeBlock link

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -73,7 +73,7 @@ id: resources
           <a href="https://live.blockcypher.com/btc">BlockCypher</a>
         </p>
         <p>
-          <a href="https://tradeblock.com">Trade Block</a>
+          <a href="https://tradeblock.com/bitcoin">TradeBlock</a>
         </p>
         <p>
           <a href="https://bitcoincharts.com/charts/">Bitcoincharts.com</a>


### PR DESCRIPTION
This updates the link to TradeBlock so that it points to the bitcoin
section of their site instead of their homepage. Their homepage loads a
generic page about enterprise tools for blockchain assets.

This will be merged once tests pass.