### PR TITLE
community: Add Asociación Bitcoin Chile

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -148,6 +148,13 @@ id: community
           </div>
         </div>
         <div class="row organizations-item">
+          <img class="organization-img" src="/img/flags/CL.svg?{{site.time | date: '%s'}}" alt="Chilean flag">
+          <div>
+            <h3 class="organization-country" id="chile">Chile</h3>
+            <a class="organization-link" href="https://www.asociacionbitcoin.org/">Asociación Bitcoin Chile</a>
+          </div>
+        </div>
+        <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/DE.svg?{{site.time | date: '%s'}}" alt="German flag">
           <div>
             <h3 class="organization-country" id="germany">Germany</h3>

--- a/_templates/community.html
+++ b/_templates/community.html
@@ -133,6 +133,7 @@ id: community
       </h2>
     
       <div class="row organizations-row">
+
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag">
           <div>
@@ -140,6 +141,7 @@ id: community
             <a class="organization-link" href="https://www.bitcoinargentina.org/">Fundación Bitcoin Argentina</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/AT.svg?{{site.time | date: '%s'}}" alt="Austrian flag">
           <div>
@@ -147,6 +149,7 @@ id: community
             <a class="organization-link" href="https://bitcoin-austria.at/">Bitcoin Austria</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/CL.svg?{{site.time | date: '%s'}}" alt="Chilean flag">
           <div>
@@ -154,6 +157,7 @@ id: community
             <a class="organization-link" href="https://www.asociacionbitcoin.org/">Asociación Bitcoin Chile</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/DE.svg?{{site.time | date: '%s'}}" alt="German flag">
           <div>
@@ -161,7 +165,7 @@ id: community
             <a class="organization-link" href="https://www.bundesverband-bitcoin.de/">Bundesverband Bitcoin e.V.</a>
           </div>
         </div>
-    
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/IL.svg?{{site.time | date: '%s'}}" alt="Israeli flag">
           <div>
@@ -169,14 +173,15 @@ id: community
             <a class="organization-link" href="https://www.bitcoin.org.il/">איגוד הביטקוין הישראלי</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/IT.svg?{{site.time | date: '%s'}}" alt="Italian flag">
           <div>
             <h3 class="organization-country" id="italy">Italy</h3>
             <a class="organization-link" href="https://www.bitcoin-italia.org/">Bitcoin Foundation Italia</a>
           </div>
-        </div>
-    
+        </div>   
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/NL.svg?{{site.time | date: '%s'}}" alt="Dutch flag">
           <div>
@@ -184,14 +189,15 @@ id: community
             <a class="organization-link" href="https://stichtingbitcoin.nl/">Stichting Bitcoin Nederland</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="Polish flag">
           <div>
             <h3 class="organization-country" id="poland">Poland</h3>
             <a class="organization-link" href="https://www.bitcoin.org.pl/">Polish Bitcoin Association</a>
           </div>
-        </div>
-    
+        </div>  
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag">
           <div>
@@ -199,6 +205,7 @@ id: community
             <a class="organization-link" href="https://www.bitcoinua.org/">Bitcoin Foundation Ukraine</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/SI.svg?{{site.time | date: '%s'}}" alt="Slovenian flag">
           <div>
@@ -206,6 +213,7 @@ id: community
             <a class="organization-link" href="https://bitcoin.si/">Bitcoin Društvo Slovenije</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/ES.svg?{{site.time | date: '%s'}}" alt="Spanish flag">
           <div>
@@ -213,6 +221,7 @@ id: community
             <a class="organization-link" href="http://avalbit.org/">Avalbit</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/SE.svg?{{site.time | date: '%s'}}" alt="Swedish flag">
           <div>
@@ -220,6 +229,7 @@ id: community
             <a class="organization-link" href="http://www.bitcoinforeningen.se/">Svenska Bitcoinföreningen</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/CH.svg?{{site.time | date: '%s'}}" alt="Swiss flag">
           <div>
@@ -227,6 +237,7 @@ id: community
             <a class="organization-link" href="https://bitcoinassociation.ch/">Bitcoin Association Switzerland</a>
           </div>
         </div>
+        
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/VE.svg?{{site.time | date: '%s'}}" alt="Venezuelan flag">
           <div>


### PR DESCRIPTION
This adds the Chilean Bitcoin Association to the community page and is
scheduled to be merged on Friday, April 26th (if there is no objection).