### PR TITLE
Remove sudo:false from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - "2.4.1"
-sudo: false
 cache: bundler
 env:
   # http://docs.travis-ci.com/user/environment-variables/#Global-Variables


### PR DESCRIPTION
Builds in sudo-disabled docker containers are no longer available as of last year and all builds happen on sudo enabled vms.

Source: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast