### PR TITLE
en: Fix typos

### DIFF
--- a/_data/devdocs/en/bitcoin-core/rpcs/rpcs/getdifficulty.md
+++ b/_data/devdocs/en/bitcoin-core/rpcs/rpcs/getdifficulty.md
@@ -21,7 +21,7 @@ The `getdifficulty` RPC {{summary_getDifficulty}}
 - n: "`result`"
   t: "number (real)"
   p: "Required<br>(exactly 1)"
-  d: "The difficulty of creating a block with the same target threshold (nBits) as the highest-height block in the local best block chain.  The number is a a multiple of the minimum difficulty"
+  d: "The difficulty of creating a block with the same target threshold (nBits) as the highest-height block in the local best block chain.  The number is a multiple of the minimum difficulty"
 
 {% enditemplate %}
 

--- a/_data/devdocs/en/bitcoin-core/rpcs/rpcs/verifychain.md
+++ b/_data/devdocs/en/bitcoin-core/rpcs/rpcs/verifychain.md
@@ -45,7 +45,7 @@ The `verifychain` RPC {{summary_verifyChain}}
 
 *Example from Bitcoin Core 0.10.0*
 
-Verify the most recent 10,000 blocks in the most through way:
+Verify the most recent 10,000 blocks in the most thorough way:
 
 {% highlight bash %}
 bitcoin-cli -testnet verifychain 4 10000

--- a/_data/devdocs/en/guides/mining.md
+++ b/_data/devdocs/en/guides/mining.md
@@ -110,7 +110,7 @@ In both solo and pool mining, the mining software needs to get the
 information necessary to construct block headers. This subsection
 describes, in a linear way, how that information is transmitted and
 used. However, in actual implementations, parallel threads and queuing
-are used to keep ASIC hashers working at maximum capacity,
+are used to keep ASIC hashers working at maximum capacity.
 
 {% endautocrossref %}
 

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -967,7 +967,7 @@ en:
     anonymoustxt: "Some effort is required to protect your privacy with Bitcoin. All Bitcoin transactions are stored publicly and permanently on the network, which means anyone can see the balance and transactions of any Bitcoin address. However, the identity of the user behind an address remains unknown until information is revealed during a purchase or in other circumstances. This is one reason why Bitcoin addresses should only be used once. Always remember that it is your responsibility to adopt good practices in order to protect your privacy. <a href=\"#protect-your-privacy#\">Read more about protecting your privacy</a>."
     instant: "Unconfirmed transactions aren't secure"
     instanttxt: "Transactions don't start out as irreversible. Instead, they get a <i>confirmation</i> score that indicates how hard it is to reverse them (see table).  Each confirmation takes between a few seconds and 90 minutes, with 10 minutes being the average. If the transaction pays too low a fee or is otherwise atypical, getting the first confirmation can take much longer."
-    confirmations: "Confirm&shy;ations"
+    confirmations: "Confirmations"
     lightweight_wallets: "Lightweight wallets"
     bitcoin_core: "<a href=\"#download#\">Bitcoin Core</a>"
     unconfirmed_only_safe: "Only safe if you trust the person paying you"


### PR DESCRIPTION
This fixes at typo in one of the English strings where "Confirmations"
is misspelled as "Confirm&shy;ations", and will be merged once tests
pass.