### PR TITLE
correct GET getutxos output format description

### DIFF
--- a/_data/devdocs/en/bitcoin-core/rest/requests/get_getutxos.md
+++ b/_data/devdocs/en/bitcoin-core/rest/requests/get_getutxos.md
@@ -45,7 +45,7 @@ GET /getutxos/<checkmempool>/<txid>-<n>/<txid>-<n>/.../<txid>-<n>.<bin|hex|json>
 - n: "Format"
   t: "suffix"
   p: "Required<br>(exactly 1)"
-  d: "Set to `.json` for decoded block contents in JSON, or `.bin` or `hex` for a serialized block in binary or hex"
+  d: "Set to `.json` for decoded UTXO set content in JSON, or `.bin` or `hex` for a serialized UTXO set in binary or hex"
 
 {% enditemplate %}
 


### PR DESCRIPTION
Location: https://bitcoin.org/en/developer-reference#get-getutxos

The current description seems to be copied from `GET Block`. Changed from 'block' to 'UTXO set' in the output format description.

