### PR TITLE
community: Add 'Bitcoin Association of Northern Ireland'

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -165,6 +165,14 @@ id: community
             <a class="organization-link" href="https://www.bundesverband-bitcoin.de/">Bundesverband Bitcoin e.V.</a>
           </div>
         </div>
+
+        <div class="row organizations-item">
+          <img class="organization-img" src="/img/flags/IE.svg?{{site.time | date: '%s'}}" alt="Irish flag">
+          <div>
+            <h3 class="organization-country" id="ireland">Ireland</h3>
+            <a class="organization-link" href="https://www.bani.org.uk/">Bitcoin Association of Northern Ireland</a>
+          </div>
+        </div>
         
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/IL.svg?{{site.time | date: '%s'}}" alt="Israeli flag">


### PR DESCRIPTION
This adds the [Bitcoin Association of Northern Ireland](https://www.bani.org.uk/) to the [Community page](https://bitcoin.org/en/community) and is scheduled to be merged on Friday, May 10 (unless others object).