### PR TITLE
Fix link styling on Community and Exchange pages

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -2466,7 +2466,6 @@ br.big {
 }
 .organization-link {
     font-size: 112.5%;
-    color: #4D5060;
     line-height: 34px;
 }
 .introlink{

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -2577,7 +2577,7 @@ br.big {
     margin-right: 30px;
 }
 .marketplace-link {
-    color: #4D5060;
+    color: #3490E6;
 }
 .exchanges-introlink {
     margin-left: 30px;


### PR DESCRIPTION
This resolves an issue where link colors weren't correctly styled (they should be blue, to match the other links they reside with in the center content area) on the Community and Exchange pages, and will be merged once tests pass --

**Before:**

<img width="750" alt="image" src="https://user-images.githubusercontent.com/1130872/57254869-ea717500-7041-11e9-8c63-561fad7113a8.png">

**After:**

<img width="761" alt="image" src="https://user-images.githubusercontent.com/1130872/57254906-037a2600-7042-11e9-9b79-fff626531ad6.png">

