### PR TITLE
wallets-menu: Upcase selected item

### DIFF
--- a/_sass/_wallets-menu.scss
+++ b/_sass/_wallets-menu.scss
@@ -205,7 +205,7 @@ $oses:
     font-size: 18px;
     color: #FF7E00;
     line-height: 20px;
-    text-transform: capitalize;
+    text-transform: uppercase;
 }
 
 .accordion-tab {


### PR DESCRIPTION
This resolves an issue in the wallet selector for mobile / handheld devices where the `capitalize` value for the `text-transform` property in the `selected-item` class doesn't play nice with words that follow a non-standard convention for capitalization (e.g. iOS):

<img width="372" alt="image" src="https://user-images.githubusercontent.com/1130872/57301725-33b8d780-70c9-11e9-9234-6c2624a3f38a.png">

The value has been changed to `uppercase` in order to standardize the appearance of the form fields, above, once selected:

<img width="372" alt="image" src="https://user-images.githubusercontent.com/1130872/57302026-cb1e2a80-70c9-11e9-85b3-cf3aeaddebfa.png">

This is scheduled to be merged on Friday, May 10 (unless others object).
