### PR TITLE
Added a space for EstimateFee deprecation warning.

### DIFF
--- a/_data/devdocs/en/bitcoin-core/rpcs/quick-reference.md
+++ b/_data/devdocs/en/bitcoin-core/rpcs/quick-reference.md
@@ -160,7 +160,7 @@ Use v0.n.n in abbreviation title to prevent autocrossrefing.
 {% autocrossref %}
 
 * [CreateMultiSig][rpc createmultisig]: {{summary_createMultiSig}}
-* [EstimateFee][rpc estimatefee]: {{summary_estimateFee}} {{UPDATED0_14_0}}{{DEPRECATED}}
+* [EstimateFee][rpc estimatefee]: {{summary_estimateFee}} {{UPDATED0_14_0}} {{DEPRECATED}}
 * [EstimatePriority][rpc estimatepriority]: {{summary_estimatePriority}} {{DEPRECATED}}
 * [GetMemoryInfo][rpc getmemoryinfo]: {{summary_getMemoryInfo}} {{NEW_14_0}}
 * [ValidateAddress][rpc validateaddress]: {{summary_validateAddress}} {{UPDATED0_13_0}}


### PR DESCRIPTION
EstimateFee block currently reads:

EstimateFee: estimates the transaction fee per kilobyte that needs to be paid for a transaction to be included within a certain number of blocks. Updated in 0.14.0Deprecated

There should be a space between the updated tag and deprecated tag.