### PR TITLE
Add Quebex

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -236,6 +236,8 @@ id: exchanges
       <div>
         <h3 id="canada" class="no_toc">Canada</h3>
         <p>
+          <a class="marketplace-link" href="https://quebex.com/">Quebex</a>
+          <br>
           <a class="marketplace-link" href="https://bitbuy.ca/">Bitbuy</a>
           <br>
           <a class="marketplace-link" href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a>


### PR DESCRIPTION
Add the Quebex bitcoin exchange to the list of exchanges in Canada.

See https://github.com/bitcoin-dot-org/bitcoin.org/issues/2968 and https://github.com/bitcoin-dot-org/bitcoin.org/issues/2967