### PR TITLE
community: Drop 'Bitcoin Foundation Ukraine'

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -213,14 +213,6 @@ id: community
         </div>  
         
         <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag">
-          <div>
-            <h3 class="organization-country" id="ukraine">Ukraine</h3>
-            <a class="organization-link" href="https://www.bitcoinua.org/">Bitcoin Foundation Ukraine</a>
-          </div>
-        </div>
-        
-        <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/SI.svg?{{site.time | date: '%s'}}" alt="Slovenian flag">
           <div>
             <h3 class="organization-country" id="slovenia">Slovenia</h3>


### PR DESCRIPTION
This drops the Bitcoin Foundation of Ukraine from the Community page and will be merged once tests pass. The website is no longer available:

<img width="1262" alt="Screen Shot 2019-05-29 at 20 16 34" src="https://user-images.githubusercontent.com/1130872/58580978-ecdc7e80-823d-11e9-82c7-682360274eb6.png">

Cc: @khendraw 
