### PR TITLE
exchanges: Drop 'bitFlyer' from Japanese exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -70,8 +70,6 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitbank.cc/">bitbank</a>
           <br>
-          <a class="marketplace-link" href="https://bitflyer.jp/">bitFlyer</a>
-          <br>
           <a class="marketplace-link" href="https://www.btcbox.co.jp/">BtcBox</a>
         </p>
       </div>


### PR DESCRIPTION
This drops bitFlyer's Japanese site from the list of exchanges in Japan and will be merged once tests pass. They are no longer accepting new user registrations due to issues with regulators.