### PR TITLE
exchanges: Drop 'iCE3X' from South African exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -221,8 +221,6 @@ id: exchanges
       <div>
         <h3 id="south-africa" class="no_toc">South Africa</h3>
         <p>
-          <a class="marketplace-link" href="https://www.ice3x.com/">iCE3X</a>
-          <br>
           <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
         </p>
       </div>


### PR DESCRIPTION
This drops iCE3X from the list of South African exchanges:

+ The footer of the website appears to be broken and is missing links to things such as their Terms of Service, Privacy Policy and Support pages when a user isn't logged in.
+ The Help link in the header of the site doesn't appear to be loading and redirects to a login page.
+ We reset our password on an existing account but did not receive a temporary password along with reset instructions.
+ When creating a new account, all emails received that were pertaining to the new account went to Spam.
+ The exchange doesn't have any SPF records configured for the primary domain that emails are sent on behalf of which will cause emails sent on behalf of the company to go to spam, and also make it easier for others to spoof the exchange in attempt to phish customer account information (since legitimate and illegitimate emails will both end up in spam).

This will be merged once tests pass.