### PR TITLE
exchanges: Drop 'Bitcoin Australia'

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -376,8 +376,6 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 class="exchanges-tab-title exchanges-australia-title" id="australia">Australia</h2>
   <p>
-    <a class="marketplace-link" href="https://bitcoin.com.au/">Bitcoin Australia</a>
-    <br>
     <a class="marketplace-link" href="https://www.coinjar.com/">CoinJar</a>
     <br>
     <a class="marketplace-link" href="https://www.coinloft.com.au/">CoinLoft</a>


### PR DESCRIPTION
This drops [Bitcoin Australia](https://bitcoin.com.au/) from the Exchanges page and will be merged once tests pass. Upon additional review, we discovered that this website maintains almost an identical content-based layout as two websites that were not added to the Exchanges page in #2949:

+ [bitcoin.co.uk](https://bitcoin.co.uk/)
+ [bitcoin.ca](https://bitcoin.ca)

Searching for 'The Trusted Cryptocurrency Exchange' - an excerpt of the title tag that all of these websites share - revealed two more sites that also share the same/similar content, metadata and layout:

+ [bitcoin.eu](https://bitcoin.eu)
+ [bitcoin.com.tr](https://bitcoin.com.tr)

At some point Google will drop all of these sites from their index because they are all sharing similar/duplicate content. Ensuring they are not linked to from bitcoin.org will help protect our placement in search results, domain authority and page rank.