### PR TITLE
index: Fix missing translation on homepage - 'What is Bitcoin?'

### DIFF
--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -10,7 +10,7 @@
     </div>
 
     <div class="mainvideo">
-      <button class="mainvideo-btn-open" onclick="loadYoutubeVideo(event);" ontouchstart="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/{% if page.lang == 'ro' %}JPNwbWu0tMQ{% else %}Gc2en3nHxA4{% endif %}?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">What is Bitcoin?</button>
+      <button class="mainvideo-btn-open" onclick="loadYoutubeVideo(event);" ontouchstart="loadYoutubeVideo(event);" data-youtubeurl="//www.youtube.com/embed/{% if page.lang == 'ro' %}JPNwbWu0tMQ{% else %}Gc2en3nHxA4{% endif %}?rel=0&amp;showinfo=0&amp;wmode=opaque&amp;autoplay=1{% if page.lang != 'en' %}&amp;cc_load_policy=1&amp;hl={{ page.lang }}&amp;cc_lang_pref={{ page.lang }}{% endif %}">{% translate whatisbitcoin faq %}</button>
     </div>
     {% include helpers/hero-social.html %}
   </div>


### PR DESCRIPTION
This resolves an issue on the home page where the phrase "What is Bitcoin?" that was appearing next to the video play button wasn't getting translated, and will be merged once tests pass.

**Before:**

![image](https://user-images.githubusercontent.com/1130872/59602239-880e9880-9106-11e9-9a41-1cc4c56acf88.png)


**After:**

![image](https://user-images.githubusercontent.com/1130872/59602260-952b8780-9106-11e9-9bd8-d7b65f91f121.png)


