### PR TITLE
exchanges: Drop Cryptoradar and revise string

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -402,7 +402,7 @@ id: exchanges
 </div>
 
 <p class="introlink exchanges-introlink exchanges-buy-link">Visit
-  <a href="https://www.buybitcoinworldwide.com/">Buy Bitcoin Worldwide</a> for user reviews on some of the above exchanges, or <a href="https://cryptoradar.co">Cryptoradar</a> for comparisons based on prices, fees and features.
+  <a href="https://www.buybitcoinworldwide.com/">Buy Bitcoin Worldwide</a> for reviews on some of the above exchanges.
 </p>
 <p class="introlink exchanges-introlink">Visit
   <a href="https://coinatmradar.com/">Coin ATM Radar</a> to find local Bitcoin ATMs.


### PR DESCRIPTION
In the spirit of what was previously discussed in #2697 where we decided to remove the News section from the Resources page due to an observed trend away from a specific focus on Bitcoin and more-so toward blockchain technologies and cryptocurrencies in general, this drops a link to Cryptoradar off of the Exchanges page.

The page that is linked to is more-so of a directory of price comparisons for many cryptocurrencies and where to buy them (bitcoin being just one), rather than a specific site where users can focus primarily on finding the best rate when exchanging fiat for bitcoin.

Unless others object, this is scheduled to be merged on Monday, June 24.

