### PR TITLE
exchanges: Drop 'CoinLoft'

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -378,8 +378,6 @@ id: exchanges
   <p>
     <a class="marketplace-link" href="https://www.coinjar.com/">CoinJar</a>
     <br>
-    <a class="marketplace-link" href="https://www.coinloft.com.au/">CoinLoft</a>
-    <br>
     <a class="marketplace-link" href="https://www.coinspot.com.au/">CoinSpot</a>
     <br>
     <a class="marketplace-link" href="https://www.cointree.com.au/">CoinTree</a>


### PR DESCRIPTION
This drops CoinLoft from the Australian section of the Exchanges page and will be merged once tests pass. Their price to buy bitcoin is ~7% higher than the market average. Their price to sell bitcoin is ~2.5% lower than the market average, which is also being advertised as a no commission trade. We have been observing this over the past week, before the recent bitcoin price up-swings, and contacted the exchange who confirmed that the rates are correctly advertised.

If a user were to use this exchange to buy bitcoin, the price of bitcoin would need to increase ~9.5% from the price they bought at just for the user to be able to break even if they were going to subsequently sell their bitcoin back to this exchange at some point in the future.