### PR TITLE
exchanges: Drop Luno from Singapore

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -91,8 +91,6 @@ id: exchanges
         <h3 id="singapore" class="no_toc">Singapore</h3>
         <p>
           <a class="marketplace-link" href="https://www.binance.sg/">Binance</a>
-          <br>
-          <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
This drops Luno from the list of exchanges in Singapore and will be merged once tests pass. They continue to be listed under other countries (Malaysia, Nigeria, South Africa), however, Singapore is no longer in the list of countries they support, [as per their website](https://www.luno.com/en/countries/).