### PR TITLE
Rework exchanges page structure

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -2484,100 +2484,14 @@ br.big {
     margin-top: 70px;
     font-weight: 400;
 }
-.toc-row .toccontent .exchanges-tab-title {
-    position: relative;
-    padding-left: 95px;
-}
-.toc-row .toccontent .expanded .exchanges-tab-title {
-    padding-left: 95px;
-}
-.exchanges-tab-title::before {
-    content: '';
-    position: absolute;
-    top: 40px;
-    left: 25px;
-    width: 40px;
-    height: 40px;
-}
-.exchanges-international-title::before {
-    background: url(../img/flags/ALL.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.exchanges-europe-title::before {
-    background: url(../img/flags/EU.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.exchanges-asia-title::before {
-    background: url(../img/flags/asia.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.exchanges-south-america-title::before {
-    background: url(../img/flags/south-america.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.exchanges-north-america-title::before {
-    background: url(../img/flags/north-america.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.exchanges-australia-title::before {
-    background: url(../img/flags/australia.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.exchanges-newzealand-title::before {
-    background: url(../img/flags/newzealand.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.exchanges-africa-title::before {
-    background: url(../img/flags/africa.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.exchanges-p2p-title::before {
-    background: url(../img/flags/ALL.svg?1528322191) center no-repeat;
-    background-size: contain;
-}
-.expanded .exchanges-content-row {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-pack: justify;
-        -ms-flex-pack: justify;
-            justify-content: space-between;
-}
-.general-marketplace {
-    width: 240px;
-}
-.expanded .marketplace-row {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
-}
-.exchanges-europe .marketplace-row {
-    -webkit-box-pack: start;
-        -ms-flex-pack: start;
-            justify-content: flex-start;
-    width: 61%;
-}
-
-.marketplace {
-    width: 240px;
-    margin: 0 0 45px 0;
-}
-.exchanges-europe .marketplace:nth-child(even) {
-    width: 225px;
-}
 .marketplace h3 {
-    margin-bottom: 0;
-    text-align: left;
-}
-.marketplace img {
-    width: 40px;
-    height: 33px;
-    margin-right: 30px;
+    margin-top: 10px;
 }
 .marketplace-link {
     color: #3490E6;
+}
+.marketplace-flag {
+    height: 15px;
 }
 .exchanges-introlink {
     margin-left: 30px;

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -7,22 +7,168 @@ id: exchanges
 ---
 
 <!-- Note: this file exempt from check-for-subheading-anchors check -->
-
 <div class="toccontent-block boxexpand expanded">
-  <h2 class="exchanges-tab-title exchanges-international-title" id="international">International</h2>
+  <h2 class="exchanges-tab-title exchanges-international-title" id="international">International Exchanges</h2>
   <p>
+    <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
+    <br>
     <a class="marketplace-link" href="https://www.bitstamp.net/">Bitstamp</a>
+    <br>
+    <a class="marketplace-link" href="https://bittrex.com/">Bittrex</a>
     <br>
     <a class="marketplace-link" href="https://www.coinbase.com/">Coinbase</a>
     <br>
+    <a class="marketplace-link" href="https://www.coincorner.com/">CoinCorner</a>
+    <br>
+    <a class="marketplace-link" href="https://www.coinjar.com/">CoinJar</a>
+    <br>
     <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
     <br>
+    <a class="marketplace-link" href="https://www.itbit.com/">itBit</a>
+    <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>
+    <br>
+    <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
+    <br>
+    <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>
   </p>
 </div>
 
 <div class="toccontent-block boxexpand expanded">
-  <h2 class="exchanges-tab-title exchanges-p2p-title" id="p2p">Peer-to-Peer (P2P)</h2>
+  <h2 class="exchanges-tab-title" id="local">Local Exchanges</h2>
+
+  <div class="row marketplace">
+    <div>
+      <h3 id="africa" class="no_toc">Africa</h3>
+      <p>
+        <a class="marketplace-link" href="https://www.binance.co.ug">Binance Uganda</a> - available in <img class="marketplace-flag" src="/img/flags/UG.svg?{{site.time | date: '%s'}}" alt="Ugandan flag"> Uganda
+      </p>
+    </div>
+  </div>
+
+  <div class="row marketplace">
+    <div>
+      <h3 id="americas" class="no_toc">Americas</h3>
+      <p>
+        <a class="marketplace-link" href="https://3xbit.com.br/">3xbit</a> - available in <img class="marketplace-flag" src="/img/flags/BR.svg?{{site.time | date: '%s'}}" alt="Brazilian flag"> Brazil
+        <br>
+        <a class="marketplace-link" href="https://argenbtc.com/">ArgenBTC</a> - available in <img class="marketplace-flag" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag"> Argentina
+        <br>
+        <a class="marketplace-link" href="https://bitbuy.ca/">Bitbuy</a> - available in <img class="marketplace-flag" src="/img/flags/CA.svg?{{site.time | date: '%s'}}" alt="Canadian flag"> Canada
+        <br>
+        <a class="marketplace-link" href="https://bitex.la/">Bitex</a> - available in certain South American countries
+        <br>
+        <a class="marketplace-link" href="https://bitso.com/">Bitso</a> - available in <img class="marketplace-flag" src="/img/flags/MX.svg?{{site.time | date: '%s'}}" alt="Mexican flag"> Mexico
+        <br>
+        <a class="marketplace-link" href="https://www.buda.com/">Buda</a> - available in <img class="marketplace-flag" src="/img/flags/CL.svg?{{site.time | date: '%s'}}" alt="Chilean flag"> Chile, <img class="marketplace-flag" src="/img/flags/CO.svg?{{site.time | date: '%s'}}" alt="Colombian flag"> Colombia and <img class="marketplace-flag" src="/img/flags/PE.png?{{site.time | date: '%s'}}" alt="Peruvian flag"> Peru
+        <br>
+        <a class="marketplace-link" href="https://www.buenbit.com/">Buenbit</a> - available in <img class="marketplace-flag" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag"> Argentina
+        <br>
+        <a class="marketplace-link" href="https://www.coinsmart.com/">Coinsmart</a> - available in <img class="marketplace-flag" src="/img/flags/CA.svg?{{site.time | date: '%s'}}" alt="Canadian flag"> Canada
+        <br>
+        <a class="marketplace-link" href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a> - available in <img class="marketplace-flag" src="/img/flags/CA.svg?{{site.time | date: '%s'}}" alt="Canadian flag"> Canada
+        <br>
+        <a class="marketplace-link" href="https://bitbuy.ca/">Bitbuy</a> - available in <img class="marketplace-flag" src="/img/flags/CA.svg?{{site.time | date: '%s'}}" alt="Canadian flag"> Canada
+        <br>
+        <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a> - available in <img class="marketplace-flag" src="/img/flags/BR.svg?{{site.time | date: '%s'}}" alt="Brazilian flag"> Brazil
+        <br>
+        <a class="marketplace-link" href="https://gemini.com/">Gemini</a> - available in the <img class="marketplace-flag" src="/img/flags/US.svg?{{site.time | date: '%s'}}" alt="United States flag"> USA
+        <br>
+        <a class="marketplace-link" href="https://www.mercadobitcoin.com.br/">Mercado Bitcoin</a> - available in <img class="marketplace-flag" src="/img/flags/BR.svg?{{site.time | date: '%s'}}" alt="Brazilian flag">  Brazil
+        <br>
+        <a class="marketplace-link" href="https://www.omnitrade.io/">OmniTrade</a> - available in <img class="marketplace-flag" src="/img/flags/BR.svg?{{site.time | date: '%s'}}" alt="Brazilian flag"> Brazil
+        <br>
+        <a class="marketplace-link" href="https://www.ripio.com/">Ripio</a> - available in <img class="marketplace-flag" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag"> Argentina
+        <br>
+        <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a> - available in <img class="marketplace-flag" src="/img/flags/CA.svg?{{site.time | date: '%s'}}" alt="Canadian flag"> Canada
+        <br>
+        <a class="marketplace-link" href="https://www.volabit.com/">Volabit</a> - available in <img class="marketplace-flag" src="/img/flags/MX.svg?{{site.time | date: '%s'}}" alt="Mexican flag"> Mexico
+        <br>
+        <a class="marketplace-link" href="https://walltime.info/">Walltime</a> - available in <img class="marketplace-flag" src="/img/flags/BR.svg?{{site.time | date: '%s'}}" alt="Brazilian flag"> Brazil
+      </p>
+    </div>
+  </div>
+
+  <div class="row marketplace">
+    <div>
+      <h3 id="asia" class="no_toc">Asia</h3>
+      <p>
+        <a class="marketplace-link" href="https://www.bit2c.co.il/">Bit2C</a> - available in <img class="marketplace-flag" src="/img/flags/IL.svg?{{site.time | date: '%s'}}" alt="Israeli flag"> Israel
+        <br>
+        <a class="marketplace-link" href="https://bitbank.cc/">bitbank</a> - available in <img class="marketplace-flag" src="/img/flags/JP.svg?{{site.time | date: '%s'}}" alt="Japanese flag"> Japan
+        <br>
+        <a class="marketplace-link" href="https://www.bithumb.com/">Bithumb</a> - available in <img class="marketplace-flag" src="/img/flags/KR.svg?{{site.time | date: '%s'}}" alt="South Korean flag"> South Korea
+        <br>
+        <a class="marketplace-link" href="https://www.binance.sg/en">Binance Singapore</a> - available in <img class="marketplace-flag" src="/img/flags/SG.svg?{{site.time | date: '%s'}}" alt="Singaporean flag"> Singapore
+        <br>
+        <a class="marketplace-link" href="https://bitoasis.net/">BitOasis</a> - available in the Middle East
+        <br>
+        <a class="marketplace-link" href="https://www.bitsofgold.co.il/">Bits of Gold</a> - available in <img class="marketplace-flag" src="/img/flags/IL.svg?{{site.time | date: '%s'}}" alt="Israeli flag"> Israel
+        <br>
+        <a class="marketplace-link" href="https://www.btcbox.co.jp/">BtcBox</a> - available in <img class="marketplace-flag" src="/img/flags/JP.svg?{{site.time | date: '%s'}}" alt="Japanese flag"> Japan
+        <br>
+        <a class="marketplace-link" href="https://coinone.co.kr/">Coinone</a> - available in <img class="marketplace-flag" src="/img/flags/KR.svg?{{site.time | date: '%s'}}" alt="South Korean flag"> South Korea
+        <br>
+        <a class="marketplace-link" href="https://indodax.com/">Indodax</a> - available in <img class="marketplace-flag" src="/img/flags/ID.svg?{{site.time | date: '%s'}}" alt="Indonesian flag"> Indonesia
+        <br>
+        <a class="marketplace-link" href="https://karsha.biz/">Karsha</a> - available in the <img class="marketplace-flag" src="/img/flags/UAE.svg?{{site.time | date: '%s'}}" alt="United Arab Emirates flag"> UAE
+        <br>
+        <a class="marketplace-link" href="https://www.koinim.com/">Koinim</a> - available in <img class="marketplace-flag" src="/img/flags/TR.svg?{{site.time | date: '%s'}}" alt="Turkish flag"> Turkey
+        <br>
+        <a class="marketplace-link" href="https://www.korbit.co.kr/">Korbit</a> - available in <img class="marketplace-flag" src="/img/flags/KR.svg?{{site.time | date: '%s'}}" alt="South Korean flag"> South Korea
+      </p>
+    </div>
+  </div>
+
+  <div class="row marketplace">
+    <div>
+      <h3 id="europe" class="no_toc">Europe</h3>
+      <p>
+        <a class="marketplace-link" href="https://anycoindirect.eu">AnyCoin Direct</a> - available throughout the European Union
+        <br>
+        <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a> - available throughout the European Union
+        <br>
+        <a class="marketplace-link" href="https://www.bitpanda.com/">Bitpanda</a> - available throughout the European Union
+        <br>
+        <a class="marketplace-link" href="https://www.binance.je/">Binance Jersey</a> - available throughout the European Union
+        <br>
+        <a class="marketplace-link" href="https://bl3p.eu/">BL3P</a> - available throughout the European Union
+        <br>
+        <a class="marketplace-link" href="https://www.coinfloor.co.uk/">Coinfloor</a> - available in the <img class="marketplace-flag" src="/img/flags/UK.svg?{{site.time | date: '%s'}}" alt="United Kingdom flag"> UK
+        <br>
+        <a class="marketplace-link" href="https://kriptomat.io/">Kriptomat</a> - available throughout the European Union
+        <br>
+        <a class="marketplace-link" href="https://kuna.io/">Kuna</a> - available in <img class="marketplace-flag" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag"> Ukraine
+        <br>
+        <a class="marketplace-link" href="https://www.paymium.com/">Paymium</a> - available throughout the European Union
+        <br>
+        <a class="marketplace-link" href="https://therocktrading.com">The Rock Trading</a> - available throughout the European Union
+      </p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div>
+      <h3 id="oceania" class="no_toc">Oceania</h3>
+      <p>
+        <a class="marketplace-link" href="https://www.coinspot.com.au/">CoinSpot</a> - available in <img class="marketplace-flag" src="/img/flags/AU.svg?{{site.time | date: '%s'}}" alt="Australian flag"> Australia
+        <br>
+        <a class="marketplace-link" href="https://www.cointree.com.au/">CoinTree</a> - available in <img class="marketplace-flag" src="/img/flags/AU.svg?{{site.time | date: '%s'}}" alt="Australian flag"> Australia
+        <br>
+        <a class="marketplace-link" href="https://digitalsurge.com.au/">Digital Surge</a> - available in <img class="marketplace-flag" src="/img/flags/AU.svg?{{site.time | date: '%s'}}" alt="Australian flag"> Australia
+        <br>
+        <a class="marketplace-link" href="https://www.hardblock.net/">HardBlock</a> - available in <img class="marketplace-flag" src="/img/flags/AU.svg?{{site.time | date: '%s'}}" alt="Australian flag"> Australia
+        <br>
+        <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a> - available in <img class="marketplace-flag" src="/img/flags/AU.svg?{{site.time | date: '%s'}}" alt="Australian flag"> Australia and <img class="marketplace-flag" src="/img/flags/NZ.png?{{site.time | date: '%s'}}" alt="New Zealand flag"> New Zealand
+        <br>
+        <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a> - available in <img class="marketplace-flag" src="/img/flags/NZ.png?{{site.time | date: '%s'}}" alt="New Zealand flag"> New Zealand
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="toccontent-block boxexpand expanded">
+  <h2 class="exchanges-tab-title exchanges-p2p-title" id="p2p">Peer-to-Peer (P2P) Directories</h2>
   <p>
     <a class="marketplace-link" href="https://bisq.network/">Bisq</a>
     <br>
@@ -37,369 +183,10 @@ id: exchanges
 </div>
 
 <div class="toccontent-block boxexpand expanded">
-  <h2 class="exchanges-tab-title exchanges-asia-title" id="asia">Asia</h2>
-  <div class="marketplace-row">
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/ID.svg?{{site.time | date: '%s'}}" alt="Indonesian flag">
-      <div>
-        <h3 id="indonesia" class="no_toc">Indonesia</h3>
-        <p>
-          <a class="marketplace-link" href="https://indodax.com/">Indodax</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/IL.svg?{{site.time | date: '%s'}}" alt="Israeli flag">
-      <div>
-        <h3 id="israel" class="no_toc">Israel</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.bit2c.co.il/">Bit2C</a>
-          <br>
-          <a class="marketplace-link" href="https://www.bitsofgold.co.il/">Bits of Gold</a>
-          <br>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/JP.svg?{{site.time | date: '%s'}}" alt="Japanese flag">
-      <div>
-        <h3 id="japan" class="no_toc">Japan</h3>
-        <p>
-          <a class="marketplace-link" href="https://bitbank.cc/">bitbank</a>
-          <br>
-          <a class="marketplace-link" href="https://www.btcbox.co.jp/">BtcBox</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/MY.svg?{{site.time | date: '%s'}}" alt="Malaysian flag">
-      <div>
-        <h3 id="malaysia" class="no_toc">Malaysia</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/SG.svg?{{site.time | date: '%s'}}" alt="Singaporean flag">
-      <div>
-        <h3 id="singapore" class="no_toc">Singapore</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.binance.sg/">Binance</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/KR.svg?{{site.time | date: '%s'}}" alt="South Korean flag">
-      <div>
-        <h3 id="south-korea" class="no_toc">South Korea</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.bithumb.com/">Bithumb</a>
-          <br>
-          <a class="marketplace-link" href="https://coinone.co.kr/">Coinone</a>
-          <br>
-          <a class="marketplace-link" href="https://www.korbit.co.kr/">Korbit</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/TR.svg?{{site.time | date: '%s'}}" alt="Turkish flag">
-      <div>
-        <h3 id="turkey" class="no_toc">Turkey</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.koinim.com/">Koinim</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/UAE.svg?{{site.time | date: '%s'}}" alt="United Arab Emirates flag">
-      <div>
-        <h3 id="united-arab-emirates" class="no_toc">United Arab Emirates</h3>
-        <p>
-          <a class="marketplace-link" href="https://bitoasis.net/">BitOasis</a>
-          <br>
-          <a class="marketplace-link" href="https://karsha.biz/">Karsha</a>
-        </p>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-<div class="toccontent-block boxexpand expanded exchanges-europe">
-  <h2 class="exchanges-tab-title exchanges-europe-title" id="europe">Europe</h2>
-  <div class="exchanges-content-row">
-
-    <div class="general-marketplace">
-      <p>
-        <a class="marketplace-link" href="https://anycoindirect.eu">AnyCoin Direct</a>
-        <br>
-        <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>
-        <br>
-        <a class="marketplace-link" href="https://www.bitpanda.com/">BitPanda</a>
-        <br>
-        <a class="marketplace-link" href="https://bl3p.eu/">BL3P</a>
-        <br>
-        <a class="marketplace-link" href="https://kriptomat.io/">Kriptomat</a>
-        <br>
-        <a class="marketplace-link" href="https://www.paymium.com/">Paymium</a>
-        <br>
-        <a class="marketplace-link" href="https://therocktrading.com">The Rock Trading</a>
-      </p>
-    </div>
-
-    <div class="marketplace-row">
-
-      <div class="row marketplace">
-        <img class="marketplace-flag" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="Polish flag">
-        <div>
-          <h3 id="poland" class="no_toc">Poland</h3>
-          <p>
-            <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
-          </p>
-        </div>
-      </div>
-
-      <div class="row marketplace">
-        <img class="marketplace-flag" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag">
-        <div>
-          <h3 id="ukraine" class="no_toc">Ukraine</h3>
-          <p>
-            <a class="marketplace-link" href="https://kuna.io/">Kuna</a>
-          </p>
-        </div>
-      </div>
-
-      <div class="row marketplace">
-        <img class="marketplace-flag" src="/img/flags/UK.svg?{{site.time | date: '%s'}}" alt="United Kingdom flag">
-        <div>
-          <h3 id="united-kingdom" class="no_toc">United Kingdom</h3>
-          <p>
-            <a class="marketplace-link" href="https://www.binance.je/">Binance</a>
-            <br>
-            <a class="marketplace-link" href="https://bittylicious.com/">Bittylicious</a>
-            <br>
-            <a class="marketplace-link" href="https://www.coincorner.com/">CoinCorner</a>
-            <br>
-            <a class="marketplace-link" href="https://www.coinfloor.co.uk/">Coinfloor</a>
-          </p>
-        </div>
-      </div>
-
-    </div>
-  </div>
-</div>
-
-<div class="toccontent-block boxexpand expanded">
-  <h2 class="exchanges-tab-title exchanges-africa-title" id="africa">Africa</h2>
-  <div class="row marketplace-row">
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/NG.svg?{{site.time | date: '%s'}}" alt="Nigerian flag">
-      <div>
-        <h3 id="nigeria" class="no_toc">Nigeria</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/ZA.svg?{{site.time | date: '%s'}}" alt="South African flag">
-      <div>
-        <h3 id="south-africa" class="no_toc">South Africa</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
-        </p>
-      </div>
-    </div>
-    
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/UG.svg?{{site.time | date: '%s'}}" alt="Ugandan flag">
-      <div>
-        <h3 id="uganda" class="no_toc">Uganda</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.binance.co.ug/">Binance</a>
-        </p>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-<div class="toccontent-block boxexpand expanded">
-  <h2 class="exchanges-tab-title exchanges-north-america-title" id="north-america">North America</h2>
-  <div class="row marketplace-row">
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/CA.svg?{{site.time | date: '%s'}}" alt="Canadian flag">
-      <div>
-        <h3 id="canada" class="no_toc">Canada</h3>
-        <p>
-          <a class="marketplace-link" href="https://bitbuy.ca/">Bitbuy</a>
-          <br>
-          <a class="marketplace-link" href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a>
-          <br>
-          <a class="marketplace-link" href="https://www.coinsmart.com/">Coinsmart</a>
-          <br>
-          <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/MX.svg?{{site.time | date: '%s'}}" alt="Mexican flag">
-      <div>
-        <h3 id="mexico" class="no_toc">Mexico</h3>
-        <p>
-          <a class="marketplace-link" href="https://bitso.com/">Bitso</a>
-          <br>
-          <a class="marketplace-link" href="https://www.volabit.com/">Volabit</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/US.svg?{{site.time | date: '%s'}}" alt="United States flag">
-      <div>
-        <h3 id="united-states" class="no_toc">United States</h3>
-        <p>
-          <a class="marketplace-link" href="https://bitflyer.com/en-us">bitFlyer</a>
-          <br>
-          <a class="marketplace-link" href="https://bittrex.com/">Bittrex</a>
-          <br>
-          <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
-          <br>
-          <a class="marketplace-link" href="https://www.itbit.com/">itBit</a>
-        </p>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-<div class="toccontent-block boxexpand expanded">
-  <h2 class="exchanges-tab-title exchanges-south-america-title" id="south-america">South America</h2>
-  <div class="marketplace-row">
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag">
-      <div>
-        <h3 id="argentina" class="no_toc">Argentina</h3>
-        <p>
-          <a class="marketplace-link" href="https://argenbtc.com/">ArgenBTC</a>
-          <br>
-          <a class="marketplace-link" href="https://bitex.la/">Bitex</a>
-          <br>
-          <a class="marketplace-link" href="https://www.buenbit.com/">Buenbit</a>
-          <br>
-          <a class="marketplace-link" href="https://www.ripio.com/">Ripio</a>
-          <br>
-          <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/BR.svg?{{site.time | date: '%s'}}" alt="Brazilian flag">
-      <div>
-        <h3 id="brazil" class="no_toc">Brazil</h3>
-        <p>
-          <a class="marketplace-link" href="https://3xbit.com.br/">3xbit</a>
-          <br>
-          <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
-          <br>
-          <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>
-          <br>
-          <a class="marketplace-link" href="https://www.mercadobitcoin.com.br/">Mercado Bitcoin</a>
-          <br>
-          <a class="marketplace-link" href="https://www.omnitrade.io/">OmniTrade</a>
-          <br>
-          <a class="marketplace-link" href="https://walltime.info/">Walltime</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/CL.svg?{{site.time | date: '%s'}}" alt="Chilean flag">
-      <div>
-        <h3 id="chile" class="no_toc">Chile</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/CO.svg?{{site.time | date: '%s'}}" alt="Colombian flag">
-      <div>
-        <h3 id="colombia" class="no_toc">Colombia</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/PE.png?{{site.time | date: '%s'}}" alt="Peruvian flag">
-      <div>
-        <h3 id="peru" class="no_toc">Peru</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
-        </p>
-      </div>
-    </div>
-
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/VE.svg?{{site.time | date: '%s'}}" alt="Venezuelan flag">
-      <div>
-        <h3 id="venezuela" class="no_toc">Venezuela</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.cryptobuyer.io/">Cryptobuyer</a>
-        </p>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-<div class="toccontent-block boxexpand expanded">
-  <h2 class="exchanges-tab-title exchanges-australia-title" id="australia">Australia</h2>
+  <h2 class="exchanges-tab-title" id="comparison">Comparison Platforms</h2>
   <p>
-    <a class="marketplace-link" href="https://www.coinjar.com/">CoinJar</a>
+    <a class="marketplace-link" href="https://www.buybitcoinworldwide.com/">BuyBitcoinWorldwide</a> - read reviews on some of the above exchanges
     <br>
-    <a class="marketplace-link" href="https://www.coinspot.com.au/">CoinSpot</a>
-    <br>
-    <a class="marketplace-link" href="https://www.cointree.com.au/">CoinTree</a>
-    <br>
-    <a class="marketplace-link" href="https://digitalsurge.com.au/">Digital Surge</a>
-    <br>
-    <a class="marketplace-link" href="https://www.hardblock.net/">HardBlock</a>
-    <br>
-    <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
+    <a class="marketplace-link" href="https://cryptoradar.co/">Cryptoradar</a> - compare exchanges based on real-time prices, fees, features and user reviews
   </p>
 </div>
-
-<div class="toccontent-block boxexpand expanded">
-  <h2 id="new-zealand" class="exchanges-tab-title exchanges-newzealand-title">New Zealand</h2>
-  <p>
-    <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
-    <br>
-    <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a>
-  </p>
-</div>
-
-<p class="introlink exchanges-introlink exchanges-buy-link">Visit
-  <a href="https://www.buybitcoinworldwide.com/">Buy Bitcoin Worldwide</a> for user reviews on some of the above exchanges, or <a href="https://cryptoradar.co">Cryptoradar</a> for comparisons based on prices, fees and features.
-</p>
-<p class="introlink exchanges-introlink">Visit
-  <a href="https://coinatmradar.com/">Coin ATM Radar</a> to find local Bitcoin ATMs.
-</p>


### PR DESCRIPTION
The current [Bitcoin Exchanges page](https://bitcoin.org/en/exchanges) has been forked many times in recent years and grown a lot without paying too much consideration on site structure. In my opinion the page is a bit cluttered and there are multiple things that could be improved:
* The structure of the page is not consistent: main sidebar menu items are “International”, “P2P”, continents and even small countries like “New Zealand” (no offense); there is no logic to the order of menu items either (such as alphabetical listing).
* The structure within the sections is not consistent: exchanges in “North America” are listed by country-of-origin, whereas there is no sub-section in “Europe” for many exchanges (e.g. AnyCoin Direct should be listed as “Netherlands” if we follow a country-of-origin-approach).
* Many of the exchanges listed in local markets have been listed in their country of origin (e.g. itBit, Coinfloor, BitBay), but are available internationally; other exchanges have been listed multiple times based on availability in different countries (e.g. Bitpanda, Buda).
* There are additional platforms listed without a headline at the very bottom of the page.
 
Therefore, I would like to propose a new structure for the site, listing exchanges based on type and availability. Exchanges operating in more than one continent should be listed as “International”. Each exchange will only be listed once and in alphabetical order.

Proposed new structure:
* International Exchanges
* Local Exchanges
  * Africa
  * Americas
  * Asia
  * Europe
  * Oceania
* P2P Directories
* Review & Comparison Platforms

To accomodate the new structure, I moved a few exchanges which are available internationally from local sections to the “International Exchanges” section. Furthermore, the following sites were removed:
* Cryptobuyer - reason for removal: no information on supported countries and currencies available
* Bitcoin ATM Radar - reason for removal: this website is neither a Bitcoin exchange nor a comparison platform; the alternative of using ATMs to buy Bitcoin is already discussed at https://bitcoin.org/en/buy

Screenshot of the new structure:
![image](https://user-images.githubusercontent.com/1945577/60248062-25fe2200-98c2-11e9-9c52-992aa4c5566d.png)

