### PR TITLE
Reflect correct transaction version type

### DIFF
--- a/_data/devdocs/en/references/transactions.md
+++ b/_data/devdocs/en/references/transactions.md
@@ -219,7 +219,7 @@ A raw transaction has the following top-level format:
 
 | Bytes    | Name         | Data Type           | Description
 |----------|--------------|---------------------|-------------
-| 4        | version      | uint32_t            | Transaction version number; currently version 1 or 2.  Programs creating transactions using newer consensus rules may use higher version numbers. Version 2 means that [BIP 68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki#specification) applies.
+| 4        | version      | int32_t            | Transaction version number (note, this is signed); currently version 1 or 2.  Programs creating transactions using newer consensus rules may use higher version numbers. Version 2 means that [BIP 68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki#specification) applies.
 | *Varies* | tx_in count  | compactSize uint    | Number of inputs in this transaction.
 | *Varies* | tx_in        | txIn                | Transaction inputs.  See description of txIn below.
 | *Varies* | tx_out count | compactSize uint    | Number of outputs in this transaction.


### PR DESCRIPTION
Per bitcoin source code, the transaction version is of type `int32_t`. Documentation currently lists it as a `uint32_t`.

bitcoin source: https://github.com/bitcoin/bitcoin/blob/c65c77c721b69f1782509145d62978d31c9a1d78/src/primitives/transaction.h#L289