### PR TITLE
Update bitgo page to add source for wallet library

### DIFF
--- a/_wallets/bitgo.md
+++ b/_wallets/bitgo.md
@@ -15,6 +15,7 @@ platform:
         text: "walletbitgo"
         link: "https://www.bitgo.com/"
         screenshot: "bitgo.png?1528322191"
+        source: "https://github.com/bitgo/bitgojs"
         check:
           control: "checkpasscontrolmulti"
           validation: "checkfailvalidationcentralized"


### PR DESCRIPTION
As per https://github.com/bitcoin-dot-org/bitcoin.org/issues/3032, update the bitgo entry to include a link to our source