### PR TITLE
exchanges: Re-add bitFlyer (JP, EU)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -70,6 +70,8 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitbank.cc/">bitbank</a>
           <br>
+          <a class="marketplace-link" href="https://bitflyer.com/ja-jp/">bitFlyer</a>
+          <br>
           <a class="marketplace-link" href="https://www.btcbox.co.jp/">BtcBox</a>
         </p>
       </div>
@@ -143,6 +145,8 @@ id: exchanges
         <a class="marketplace-link" href="https://anycoindirect.eu">AnyCoin Direct</a>
         <br>
         <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>
+        <br>
+        <a class="marketplace-link" href="https://bitflyer.com/en-eu/">bitFlyer</a>
         <br>
         <a class="marketplace-link" href="https://www.bitpanda.com/">BitPanda</a>
         <br>
@@ -272,7 +276,7 @@ id: exchanges
       <div>
         <h3 id="united-states" class="no_toc">United States</h3>
         <p>
-          <a class="marketplace-link" href="https://bitflyer.com/en-us">bitFlyer</a>
+          <a class="marketplace-link" href="https://bitflyer.com/en-us/">bitFlyer</a>
           <br>
           <a class="marketplace-link" href="https://bittrex.com/">Bittrex</a>
           <br>


### PR DESCRIPTION
bitFlyer(JP, US, EU) has restarted accepting new user since July 2019.

## Ref
https://twitter.com/bitFlyer/status/1146216150230917121
> 2019-07-03
> We would like to announce that new account creation has resumed. We sincerely apologize for the inconvenience incurred by anyone considering becoming a new customer of our services during this time.

