### PR TITLE
Add guidance for wallet descriptions

### DIFF
--- a/docs/managing-wallets.md
+++ b/docs/managing-wallets.md
@@ -92,7 +92,7 @@ with `optipng -o7 file.png`. The icon must fit within 96 X 96 px inside the png,
 or 85 X 85 px for square icons.
 
 **Description**: The text must go in `_translations/en.yml` alongside other
-wallets' descriptions.
+wallets' descriptions.  The description must be less than 320 characters and be consistant in style with the other descriptions.
 
 **Level**: Each wallet must have a level property assigned. A value must be in a range
 between 1 and 4. Level represents a category of a wallet:

--- a/docs/managing-wallets.md
+++ b/docs/managing-wallets.md
@@ -92,7 +92,11 @@ with `optipng -o7 file.png`. The icon must fit within 96 X 96 px inside the png,
 or 85 X 85 px for square icons.
 
 **Description**: The text must go in `_translations/en.yml` alongside other
-wallets' descriptions.  The description must be less than 320 characters and be consistant in style with the other descriptions.
+wallets' descriptions.  The description must be less than 320 characters and
+be consistent in style with the other descriptions.  Do not use superlatives
+or exclusive phrases.  For example, you might want to comment on ease of use.
+Don't write  "This wallet is the easiest to use" or "This wallet is extremely
+easy to use"; write "This wallet is easy to use."
 
 **Level**: Each wallet must have a level property assigned. A value must be in a range
 between 1 and 4. Level represents a category of a wallet:


### PR DESCRIPTION
Currently we provide no guidance for developers submitting wallet descriptions for listing and recently we have been getting descriptions that seem too long.  Without some limit, we will have descriptions that don't currently lay out well, or may not lay out well in the future.  Also, longer descriptions are obviously more verbose and are likely not in the style of the other descriptions.  Currently we have no descriptions longer than 320 characters which I propose as our limit (arbitrary sum of two powers of two).

@natiwa @alexcherman Any thoughts on the layout considerations?

When this is merged, perhaps we could ask @harding to update the schema checker.