### PR TITLE
exchanges: Remove Bit2C

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -55,10 +55,7 @@ id: exchanges
       <div>
         <h3 id="israel" class="no_toc">Israel</h3>
         <p>
-          <a class="marketplace-link" href="https://www.bit2c.co.il/">Bit2C</a>
-          <br>
           <a class="marketplace-link" href="https://www.bitsofgold.co.il/">Bits of Gold</a>
-          <br>
         </p>
       </div>
     </div>


### PR DESCRIPTION
This removes Bit2C from the exchanges page and will be merged once tests pass. Their site is down and it appears their service has been discontinued.