### PR TITLE
Request to be included in Australian Exchanges - paybtc

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -388,6 +388,8 @@ id: exchanges
     <a class="marketplace-link" href="https://www.hardblock.net/">HardBlock</a>
     <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
+    <br>
+    <a class="marketplace-link" href="https://paybtc.com.au/">paybtc</a>
   </p>
 </div>
 


### PR DESCRIPTION
Frustrations of existing exchange services are what inspired and pushed us to build paybtc - focusing on speed, ease of use and security. Since launch in March, we believe it's now one of the fastest and most reliable tools available, and we're working hard to improve it continuously.

We recently announced Osko support, allowing funds to clear in less than one hour. Users are really enjoying this feature.

You can read more about us and see our reviews here:

About: https://paybtc.com.au/about
FAQ: https://paybtc.com.au/faq

It would be an absolute honour to be included in the list of Australian exchanges on bitcoin.org. If you need any more information, please let me know.