### PR TITLE
Update regtest block generation command

### DIFF
--- a/_data/devdocs/en/examples/testing.md
+++ b/_data/devdocs/en/examples/testing.md
@@ -67,8 +67,11 @@ Start `bitcoind` in regtest mode to create a private block chain.
 ## Bitcoin Core 0.10.1 and earlier
 bitcoin-cli -regtest setgenerate true 101
 
-## Bitcoin Core master (as of commit 48265f3)
+## Bitcoin Core 17.1 and earlier
 bitcoin-cli -regtest generate 101
+
+## Bitcoin Core 18.0 and later
+bitcoin-cli -regtest generatetoaddress 101 $(bitcoin-cli -regtest getnewaddress)
 ~~~
 
 {% autocrossref %}


### PR DESCRIPTION
The command `generate` is deprecated from Bitcoin Core 18.0. This PR adds the workaround proposed in the PR that deprecated it (https://github.com/bitcoin/bitcoin/issues/14299#issuecomment-424138977).