### PR TITLE
Add Zebpay to the list of Australia exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -385,6 +385,8 @@ id: exchanges
     <a class="marketplace-link" href="https://www.hardblock.net/">HardBlock</a>
     <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
+    <br>
+    <a class="marketplace-link" href="https://www.zebpay.com/au/">Zebpay</a>
   </p>
 </div>
 


### PR DESCRIPTION
Request to list Zebpay in Australia section of List of exchanges page (https://bitcoin.org/en/exchanges#australia).