### PR TITLE
Remove disappeared torrent trackers

### DIFF
--- a/_build/update_torrent.sh
+++ b/_build/update_torrent.sh
@@ -23,7 +23,7 @@ version=''
 for f in `find "$BINDIR" -maxdepth 1 ! -path "$BINDIR"`; do
 
 	f=${f##*/}
-	
+
 	# Ignore directories that don't end with a version number.
 	if [[ $f =~ [^0-9]$ ]]; then
 		continue
@@ -110,7 +110,7 @@ tmpdir=`mktemp -d`
 rsync -rt -f '- /*/' --delete "$BINDIR/$PREFIX$version/" "$tmpdir/$PREFIX$version/"
 
 # Build new torrent file.
-buildtorrent -a "udp://tracker.openbittorrent.com:80/announce" -A "udp://tracker.openbittorrent.com:80/announce,udp://tracker.publicbt.com:80/announce,udp://tracker.ccc.de:80/announce,udp://tracker.coppersurfer.tk:6969,udp://open.demonii.com:1337" -w "https://bitcoin.org/bin/" -D -C "$tmpdir/$PREFIX$version" "$BINDIR/$PREFIX$version/bitcoin-$version.torrent"
+buildtorrent -a "udp://tracker.openbittorrent.com:80/announce" -A "udp://tracker.openbittorrent.com:80/announce,udp://tracker.coppersurfer.tk:6969" -w "https://bitcoin.org/bin/" -D -C "$tmpdir/$PREFIX$version" "$BINDIR/$PREFIX$version/bitcoin-$version.torrent"
 
 # Update last combined hash and version.
 echo $currenthash > $DATADIR/lasthash


### PR DESCRIPTION
The following trackers are dead:

* `publicbt.com`: unreachable, since at least 2016: https://gist.github.com/mcandre/eab4166938ed4205bef4#gistcomment-1687275 
* `tracker.ccc.de:80`: same as above
* `open.demonii.com:1337`: unreachable, permanently closed in 2015: https://torrents.io/site/demonii

I tested that the other trackers still work as of today.

See also #1141 (@laanwj).

Not included in this PR, if people are interested, I setup my own tracker at `udp://tracker.bitcoin.sprovoost.nl:6969`. It's whitelisted, so shouldn't suffer the same fate as these folks: https://torrentfreak.com/running-a-torrent-tracker-for-fun-can-be-a-headache-160828/

Currently it tracks the 0.18.1 and 0.17.1 release torrents. I'm happy to keep whitelisting new releases. 