### PR TITLE
Add optional indicator to wallet selection wizard

### DIFF
--- a/_includes/layout/base/helper-step-3.html
+++ b/_includes/layout/base/helper-step-3.html
@@ -11,6 +11,7 @@ http://opensource.org/licenses/MIT. {% endcomment %}
       <h2 id="wizardCriteriaTitle" class="helper-title">
         {% translate wizard-criteria-title choose-your-wallet %}
       </h2>
+      <div>{% translate wizard-optional choose-your-wallet %}</div>
       <div class="helper-selected-block">
         <div class="row">
           <div class="helper-selected-filter"></div>

--- a/_includes/layout/base/helper-step-4.html
+++ b/_includes/layout/base/helper-step-4.html
@@ -9,6 +9,7 @@ http://opensource.org/licenses/MIT.
   <div class="helper-header">
     <div class="helper-header-row">
       <h2 id="wizardFeaturesTitle" class="helper-title">{% translate wizard-feature-title choose-your-wallet %}</h2>
+      <div>{% translate wizard-optional choose-your-wallet %}</div>
       <div class="helper-selected-block">
         <div class="row">
           <div class="helper-selected-filter"></div>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -188,6 +188,7 @@ en:
     helper-note: "Note"
     helper-or: "or"
     helper-feature-unavailable: "This option is unavailable based on your previous selections."
+    wizard-optional: "(Optional)"
     wizard-os-title: "What’s your operating system?"
     wizard-mobile-title: "Mobile wallets"
     wizard-mobile-pro1: "Portable and convenient; ideal when making transactions face-to-face"


### PR DESCRIPTION
This adds a note under the Criteria and Feature selection portions in the new wallet selection wizard, so that people know they don't have to select criteria or features that are important to them, if they don't want to. This also covers a use case where people might not necessarily be sure which criteria or features are important to them.

### Screenshots

__Desktop__:

![image](https://user-images.githubusercontent.com/1130872/64801452-c8cf4f80-d545-11e9-9f86-27a7b7b160f2.png)

__Tablet__:

![image](https://user-images.githubusercontent.com/1130872/64801538-f1efe000-d545-11e9-8e2c-77c805d8845e.png)

__Handheld__:

![image](https://user-images.githubusercontent.com/1130872/64801606-16e45300-d546-11e9-9814-58e0fdb158b2.png)
