### PR TITLE
en: Add missing meta description to Wallet wizard

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -177,6 +177,7 @@ en:
     wikiportal: "Visit the <a href=\"https://en.bitcoin.it/wiki/Bitcoin:Community_portal\">Community portal</a> on the wiki."
   choose-your-wallet:
     title: "Choose your wallet - Bitcoin"
+    metadescription: "Get help finding a bitcoin wallet. Answer a few basic questions to create a list of wallets that might match your needs."
     pagetitle: "Choose your Bitcoin wallet"
     pagedesc: "Select a wallet to store your bitcoin so you can start transacting on the network."
     helper-illustration: "people and wallet"


### PR DESCRIPTION
We've noted that for the [Choose your wallet](https://bitcoin.org/en/choose-your-wallet) landing page, a meta description is missing. Meta descriptions are the text that search engines generally display alongside web page search results; it is the text that describes the web page. If this text is missing, a search engine will automatically try to extract copy from the page in order to present an accurate description of the page alongside the search result.

In the case of the choose your wallet page, while the search result on Google is acceptable, DuckDuckGo is erroneously extracting the wallet feature description for "2FA" and listing it as the search engine result description:

![image](https://user-images.githubusercontent.com/1130872/64928666-b3934300-d81b-11e9-8199-133b64fb2fe9.png)

This adds the missing meta-description, along with a correct description, so that it displays properly across search engines, and will be merged once tests pass.