### PR TITLE
blog: Add 'Recognizing Recent Efforts By Volunteer Contributors on the Translation Team

### DIFF
--- a/_posts/2019-09-26-recognizing-efforts-contributors-to-translation-team.md
+++ b/_posts/2019-09-26-recognizing-efforts-contributors-to-translation-team.md
@@ -1,0 +1,133 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+type: posts
+layout: post
+category: blog
+
+title: "Recognizing Recent Efforts By Volunteer Contributors on the Translation Team"
+permalink: /en/posts/recognizing-recent-efforts-of-volunteer-translators.html
+date: 2019-09-26
+author: |
+  <a href="https://github.com/wbnns">Will Binns</a>
+---
+
+Through continued donations and support from the community, we're thankful to
+have recently been able to send out over $15,000 USD worth of bitcoin as a
+gesture of gratitude to people who volunteer to help translate bitcoin.org and
+spread the word about Bitcoin. Each month, contributors are helping localize
+bitcoin.org so that more people around the world can easily get started and
+learn more about Bitcoin in their own languages.
+
+## Thank you
+
+- 22296107f24ef76cb1766bc35fd2b3d6
+- Aliak
+- Balaxi
+- Btc4Arab
+- ChenPoWei
+- CoinColors
+- Deadlyweapon
+- GDP
+- GIANNAT
+- Henray0607
+- JurgenH
+- Komodorpudel
+- Rasakila
+- Sreysros
+- Trofo
+- UBS
+- Vinifire
+- YummyPT
+- alanst
+- amore111
+- andrew1992
+- annetypt
+- bitcoinstein
+- cocoklogi
+- cyrilblondel
+- dalovar
+- dende93
+- echo4py
+- elybon
+- fariascl
+- gwb3
+- hakka
+- hantolegionosug_gtc_YmM1MT
+- hoangton
+- iluvbitcoins
+- jodaki84
+- josefelip
+- klicman
+- lomik
+- mareo
+- mateusnds
+- meatfreak
+- miswo
+- nedved
+- nejlika
+- ordtrogen
+- pansvetadielu456
+- phung237337
+- pryds
+- quellobiondo
+- raindogdance
+- rudygodoy
+- shimhyemin
+- sitthykun
+- telstar
+- thisistolis
+- tramyargabam
+- triplay
+- tsb
+- vit05
+- xendez
+- zshilor
+- æ‘é•·
+
+## How to get involved
+
+Anyone who is fluent in a language that isn't English can help translate the
+site. You can get started by following a few basic steps:
+
+1. Create a free [Transifex account](https://www.transifex.com/signup/).
+
+2. Browse to the [bitcoin.org translation
+project](https://www.transifex.com/bitcoinorg/bitcoinorg/), find the language
+you're fluent in, and join the translation team associated with it.
+
+3. Once you're on the team you can start translating. Go to the
+"Dashboard" on the top of the page, then to "Languages" and select your
+language. You will see a lot of different resources and their progress. Each
+resource consists of a number of strings. A string is a "string" of text on
+bitcoin.org. The first resource ("bitcoin.org") contains all strings for the
+main site. You can start there.
+
+4. Join the [Telegram group](https://t.me/bitcoinaroundtheworld), feel free to
+introduce yourself and let people know if you have questions. :)
+
+## Special acknowledgments
+
+In addition to the many volunteers, many of the advances and recent progress in
+the translation project wouldn't be possible without the help of Simon
+Hinterreiter and Koichi Hendrawan, who help manage and organize the translation
+project, as well as the teams.
+
+## About bitcoin.org
+
+Bitcoin.org was originally registered and owned by Satoshi Nakamoto and Martti
+Malmi. When Satoshi left the project, he gave ownership of the domain to
+additional people, separate from the Bitcoin developers, to spread
+responsibility and prevent any one person or group from easily gaining control
+over the Bitcoin project. Since then, the site has been developed and
+maintained by different members of the Bitcoin community.
+
+Despite being a privately owned site, its code is open-source and there have
+been thousands of commits from hundreds of contributors from all over the
+world. In addition to this, over a thousand translators have helped to make the
+site display natively to visitors in their own languages — now 25 different
+languages and growing.
+
+Bitcoin.org receives millions of visitors a year from people all over the world
+who want to get started with and learn more about Bitcoin.

--- a/_posts/2019-09-26-recognizing-efforts-contributors-to-translation-team.md
+++ b/_posts/2019-09-26-recognizing-efforts-contributors-to-translation-team.md
@@ -114,6 +114,9 @@ the translation project wouldn't be possible without the help of Simon
 Hinterreiter and Koichi Hendrawan, who help manage and organize the translation
 project, as well as the teams.
 
+A special thanks is also owed to Transifex, for providing us with special access
+to their platform.
+
 ## About bitcoin.org
 
 Bitcoin.org was originally registered and owned by Satoshi Nakamoto and Martti


### PR DESCRIPTION
Thanks to continued donations and support from the community, we've recently been able to send out over $15,000 USD worth of bitcoin as a gesture of appreciation to people who volunteer to help translate bitcoin.org. This blog post recognizes these people and thanks them for their efforts.