### PR TITLE
bitcoin-paper: s/Bokmal/Norsk (Bokmal)

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -44,15 +44,6 @@ id: bitcoin-paper
 
         <li class="card bitcoin-paper-card">
           <a class="language-link"
-            href="/files/bitcoin-paper/bitcoin_no.pdf">Bokmål</a>
-          <div>
-            <span>{% translate translated_by %}</span>
-            <a href="https://kryptografen.no">Kryptografen.no</a>
-          </div>
-        </li>
-
-        <li class="card bitcoin-paper-card">
-          <a class="language-link"
             href="/files/bitcoin-paper/bitcoin_de.pdf">Deutsch</a>
           <div>
             <span>{% translate translated_by %}</span>
@@ -122,6 +113,15 @@ id: bitcoin-paper
           <div>
             <span>{% translate translated_by %}</span>
             <a href="https://github.com/Giftbitnl">GiftBitNL</a>
+          </div>
+        </li>
+
+        <li class="card bitcoin-paper-card">
+          <a class="language-link"
+            href="/files/bitcoin-paper/bitcoin_no.pdf">Norsk (Bokmål)</a>
+          <div>
+            <span>{% translate translated_by %}</span>
+            <a href="https://kryptografen.no">Kryptografen.no</a>
           </div>
         </li>
 


### PR DESCRIPTION
This PR makes a technical clarification / change to the listing for the
Norsk translation of the Bitcoin paper, renaming the reference to "Norsk
(Bokmål)" instead of just "Bokmål". This is because "Bokmål" is the type
of Norwegian it's written on, not the language itself.

This will be merged once tests pass.

Cc: @sandwes