### PR TITLE
wallet-selector: Do not override anchor link style

### DIFF
--- a/_sass/_wallet-selector.scss
+++ b/_sass/_wallet-selector.scss
@@ -327,7 +327,6 @@ label.disabled + .sidebar-selector-info .sidebar-selector-info-text {
 .wallet-label {
 	font-weight: 600;
 	font-size: 17px;
-	color: #13161F;
 	line-height: 1.4;
 	vertical-align: middle;
 }


### PR DESCRIPTION
This ensures that the wallet name that appears in the wallet selector
results table, which is an active link, isn't overridden to appear as
black text, potentially making it more difficult to discern as something
that can be clicked on or touched to navigate to an individual wallet's
landing page:

![image](https://user-images.githubusercontent.com/1130872/65820557-f9dc9f00-e22a-11e9-98f3-d2da4bba2bb1.png)

Cc: @crwatkins 