### PR TITLE
Remove optional security audit wallet criteria

### DIFF
--- a/docs/managing-wallets.md
+++ b/docs/managing-wallets.md
@@ -58,7 +58,6 @@ recovery process.
 
 Optional criteria (some could become requirements):
 
-- Received independent security audit(s)
 - Does not show "received from" Bitcoin addresses in the UI
 - Website serving executable code or requiring authentication is included in the
   [HSTS preload list](https://hstspreload.org/)


### PR DESCRIPTION
This PR is to remove the optional wallet security audit criterion.   Note that we still have a required criterion that specifies

* Sufficient users and/or developers feedback can be found without concerning issues, or independent security audit(s) is available

such that a security audit is an acceptable alternative to sufficient feedback.

Over the last few years, our optional criteria section has served as a place to list criteria that we think are good ideas and we want to convey that to the community and encourage developers to consider them, while not precluding any wallets that have not yet met the optional criteria.

I believe that security audit is certainly a good idea, but I don't believe we will be making it a requirement in the foreseeable future.    One reason is because of the difficulty and the cost to developers.  However the major reason is that I don't think that we can reasonably specify the definition and the scope of an audit to the point that this requirement is actually meaningful.
For that reason, and for the reason above that it is already mentioned elsewhere in the requirements, I recommend removing it from the optional section.