### PR TITLE
Adding Voyager to US exchanges page

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -282,6 +282,8 @@ id: exchanges
           <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
           <br>
           <a class="marketplace-link" href="https://www.itbit.com/">itBit</a>
+          <br>
+          <a class="marketplace-link" href="https://www.investvoyager.com/">Voyager</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Voyager is a licensed crypto broker, open to residents of the United States. Voyager makes it easy for customers to trade nearly 30 top cryptocurrencies, 100% commission-free. Deposits can be made via ACH, wire transfer, and seven cryptocurrencies.

Voyager is currently available in all U.S. states except New York and is expanding internationally later this year. Users should check Voyager's [availability page](https://www.investvoyager.com/app) for updates.