### PR TITLE
Add Binance.US to United States exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -275,6 +275,8 @@ id: exchanges
       <div>
         <h3 id="united-states" class="no_toc">United States</h3>
         <p>
+          <a class="marketplace-link" href="https://www.binance.us/en">Binance US</a>
+          <br>
           <a class="marketplace-link" href="https://bitflyer.com/en-us/">bitFlyer</a>
           <br>
           <a class="marketplace-link" href="https://bittrex.com/">Bittrex</a>


### PR DESCRIPTION
Binance.US was recently released using technology licensed from Binance - Capable of the same speed and matching in security. 

It currently services most states in the US, with the exception of a few. However, they're expanding to new states regularly.