### PR TITLE
getting-started: Update tax compliance link to correct page

### DIFF
--- a/_templates/getting-started.html
+++ b/_templates/getting-started.html
@@ -115,7 +115,7 @@ id: getting-started
             {% translate tax %}</h2>
           <p>{% translate taxtxt %}</p>
           <div>
-            <a class="btn-bright" href="https://en.bitcoin.it/wiki/How_to_accept_Bitcoin,_for_small_businesses#Setting_Prices">{% translate taxbut %}</a>
+            <a class="btn-bright" href="https://en.bitcoin.it/wiki/Tax_compliance">{% translate taxbut %}</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This resolves an issue on the [Getting Started](https://bitcoin.org/en/getting-started) page, where the "Read More" link under "Accounting and Taxes" erroneously points to a portion of a subpage on the Bitcoin Wiki about "Setting Prices".

The link has been updated to correctly point to the [tax compliance](https://en.bitcoin.it/wiki/Tax_compliance) page on the Bitcoin Wiki, instead.

This will be merged once tests pass.