### PR TITLE
Add Bitclude.com to Polish exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -165,7 +165,9 @@ id: exchanges
           <h3 id="poland" class="no_toc">Poland</h3>
           <p>
             <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
-          </p>
+            <br>
+            <a class="marketplace-link" href="https://bitclude.com/">BitClude</a>
+	  </p>
         </div>
       </div>
 


### PR DESCRIPTION
Bitclude is first Polish crypto exchange which receive license 
for financial activities in Poland and is regulated under 
financial supervision commission in terms of FIAT operations.