### PR TITLE
Add Bitcoin Suisse AG to the European exchange-page

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -154,6 +154,8 @@ id: exchanges
         <a class="marketplace-link" href="https://www.paymium.com/">Paymium</a>
         <br>
         <a class="marketplace-link" href="https://therocktrading.com">The Rock Trading</a>
+        <br>
+        <a class="marketplace-link" href="https://www.bitcoinsuisse.com/">Bitcoin Suisse</a>
       </p>
     </div>
 

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -141,6 +141,8 @@ id: exchanges
       <p>
         <a class="marketplace-link" href="https://anycoindirect.eu">AnyCoin Direct</a>
         <br>
+        <a class="marketplace-link" href="https://www.bitcoinsuisse.com/">Bitcoin Suisse</a>
+        <br>
         <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>
         <br>
         <a class="marketplace-link" href="https://bitflyer.com/en-eu/">bitFlyer</a>
@@ -154,8 +156,6 @@ id: exchanges
         <a class="marketplace-link" href="https://www.paymium.com/">Paymium</a>
         <br>
         <a class="marketplace-link" href="https://therocktrading.com">The Rock Trading</a>
-        <br>
-        <a class="marketplace-link" href="https://www.bitcoinsuisse.com/">Bitcoin Suisse</a>
       </p>
     </div>
 


### PR DESCRIPTION
Hi,

I have made the proposal to add Bitcoin Suisse AG to the Exchange-page at Bitcoin.org - more specific; as a European exchange.

Bitcoin Suisse AG is Switzerland's biggest crypto-financial service-provider established in 2013. It is providing services like brokerage, custody, collateralized lending, crypto certificates, tokenization and a payment gateway. At the same time, Bitcoin Suisse is letting clients buy and sell as well as store 35 cryptocurrencies down to 50 CHF per trade through a user-friendly interface - everything backed by a $55 million bank guarantee according to Swiss law.

Furthermore, Bitcoin Suisse has applied for a banking license back in July 2019 (https://cointelegraph.com/news/bitcoin-suisse-applies-for-a-banking-license-in-switzerland).

More facts about Bitcoin Suisse:
• Over 110 employees in Zug, Switzerland, Copenhagen, Denmark and Vaduz, Liechtenstein
• Over $1 billion worth of cryptocurrencies is stored at the custody-solution called Bitcoin Suisse Vault
• Last week, Bitcoin Suisse signed a letter of intent with Worldline for a partnership to offer cryptocurrency payment services to Swiss merchants and consumers. The test phase is planned to go live at the beginning of 2020
• Bitcoin Suisse has been a part of some of the biggest ICO’s like OmiseGo, Tezos and Bancor
• Together with AMUN AG, Bitcoin Suisse has launched the first CHF denominated crypto ETP listed on the SIX exchange

If you have any questions related to Bitcoin Suisse, then please let me know. I will be more than happy to answer all questions.

Best regards,
Mads Eberhardt

Disclaimer: I am an employee at Bitcoin Suisse AG.