### PR TITLE
Removing 3xbit Brazilian exchange.

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -316,8 +316,6 @@ id: exchanges
       <div>
         <h3 id="brazil" class="no_toc">Brazil</h3>
         <p>
-          <a class="marketplace-link" href="https://3xbit.com.br/">3xbit</a>
-          <br>
           <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>
           <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>


### PR DESCRIPTION
This exchange is suffering delay on withdrawals:

- https://cointimes.com.br/situacao-comeca-a-ficar-desesperadora-para-clientes-da-3xbit/
- https://cointimes.com.br/3xbit-eletropay-perde-investimento-de-r32-milhoes-do-shark-tank/
- https://www.reclameaqui.com.br/empresa/3xbit/
- https://webitcoin.com.br/leasing-da-3xbit-atrasos-e-promessas-20-out/
- https://portaldobitcoin.com/3xbit-atrasa-saques-em-reais-e-em-bitcoin-e-pede-ate-tres-semanas-para-devolver-dinheiro/

It is best to wait until everything returns to normal (if it become the case) to add it again.

It was already removed from:

- https://bitvalor.com/
- https://www.cointradermonitor.com/preco-bitcoin-brasil

and many other sites.