### PR TITLE
Add Bitvavo to European exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -147,6 +147,8 @@ id: exchanges
         <br>
         <a class="marketplace-link" href="https://www.bitpanda.com/">BitPanda</a>
         <br>
+        <a class="marketplace-link" href="https://bitvavo.com/">Bitvavo</a>
+        <br>
         <a class="marketplace-link" href="https://bl3p.eu/">BL3P</a>
         <br>
         <a class="marketplace-link" href="https://kriptomat.io/">Kriptomat</a>


### PR DESCRIPTION
Bitvavo is an Amsterdam based fiat exchange with 2.4m EUR volume today, with 850k on BTC-EUR. All 50+ assets have both a EUR and BTC pair.
Please check https://coinmarketcap.com/exchanges/bitvavo/ or https://account.bitvavo.com/markets/BTC-EUR for more information.