### PR TITLE
Clarify wallet private key criterion

### DIFF
--- a/docs/managing-wallets.md
+++ b/docs/managing-wallets.md
@@ -32,7 +32,7 @@ in the future
   in the wallet UI
 - Avoid address reuse by using a new change address for each transaction
 - Uses deterministic ECDSA nonces (RFC 6979)
-- User has access to private keys
+- User has access to private keys for all major components of the wallet
 - If private keys or encryption keys are stored online:
   - Refuses weak passwords (short passwords and/or common passwords) used to
     secure access to any funds, or provides an aggressive account lock-out


### PR DESCRIPTION
Resolves #3173 with a clarification that can apply to layer 2 components, such as Lightning Network, as well as clarify how I believe exchange components have been handled for the last few years.  The new clarified wording of the criterion is 

* User has access to private keys for all major components of the wallet