### PR TITLE
New documentation for adding exchanges (related: #3174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following quick guides will help you get started:
 + [Setting Up Your Environment](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/setting-up-your-environment.md)
 + [Improving Developer Documentation](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/contributing-to-developer-documentation.md)
 + [Assisting with Translations](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md)
++ [Adding Exchanges](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-exchanges.md)
 + [Managing Wallets](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/managing-wallets.md)
 + [Adding Events, Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
 + [Adding Blog Posts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-blog-posts.md)

--- a/docs/adding-exchanges.md
+++ b/docs/adding-exchanges.md
@@ -1,0 +1,55 @@
+## Adding Exchanges
+
+Exchanges seeking to be added to Bitcoin.org should add themselves to the
+respective area(s) they serve in `exchanges.html` in the `_templates` directory,
+via [pull request](https://github.com/bitcoin-dot-org/bitcoin.org/pull/new/master).
+
+Shortly after the pull request is made, a Travis CI job will be added to [our
+queue](https://travis-ci.org/bitcoin-dot-org/bitcoin.org). This will build the
+site and run some basic checks. If the job fails, you will be emailed a link to
+the build log and the pull request will indicate a failed job. Please read the
+build report and try to correct the problem.
+
+If you're not comfortable with GitHub pull requests, please open a
+[new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new) requesting
+to be added.
+
+### Review Criteria
+
+Exchanges are reviewed before potentially being added to the site, focusing on
+the following areas:
+
++ Site functionality
++ Operational processes
++ Rates and fees
++ Order book
++ Policies, terms and conditions
++ Press and community feedback
++ Leadership
+
+Once added, exchanges are also re-reviewed at regular intervals in order to
+maintain quality assurance in-line with the above, and may be removed should
+severe and/or unresolved issues be encountered.
+
+### Review Fee
+
+In an effort to help provide funding towards the operation of Bitcoin.org, and
+to remain ad-free and without reliance on corporate sponsorships, an annual
+non-refundable review fee of $2500 USD, payable in bitcoin, is requested of
+exchanges seeking to be added to the site. Payment of this fee does not
+guarantee inclusion, nor does it prevent removal should problems arise
+post-inclusion.
+
+Exchanges should email [exchanges@bitcoin.org](mailto:exchanges@bitcoin.org) in
+order to make payment arrangements.
+
+### Fee Waiver
+
+Exchanges may request review fees to be waived if an independent third party
+review has been procured in the past 90 days that satisfactorily addresses the
+Review Criteria mentioned above.
+
+### Questions
+
+Please contact the [Exchange team](mailto:exchanges@bitcoin.org) if you have
+questions or require assistance when adding an exchange.

--- a/docs/adding-exchanges.md
+++ b/docs/adding-exchanges.md
@@ -36,9 +36,9 @@ severe and/or unresolved issues be encountered.
 In an effort to help provide funding towards the operation of Bitcoin.org, and
 to remain ad-free and without reliance on corporate sponsorships, an annual
 non-refundable review fee of $2500 USD, payable in bitcoin, is requested of
-exchanges seeking to be added to the site. Payment of this fee does not
+exchanges seeking to be added to the site. **Payment of this fee does not
 guarantee inclusion, nor does it prevent removal should problems arise
-post-inclusion.
+post-inclusion.**
 
 Exchanges should email [exchanges@bitcoin.org](mailto:exchanges@bitcoin.org) in
 order to make payment arrangements.


### PR DESCRIPTION
Closes #3174 and provides documentation that can be referenced for how to add an exchange, review fee details plus instruction for waiving fee.

Cc: @Cobra-Bitcoin 