### PR TITLE
Update hero-social.html

### DIFF
--- a/_includes/helpers/hero-social.html
+++ b/_includes/helpers/hero-social.html
@@ -4,10 +4,10 @@ http://opensource.org/licenses/MIT.
 {% endcomment %}
 
 <div class="row hero-social">
-  <a href="" onclick="window.open('http://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(location.href))" class="hero-social-link" target="_blank">
+  <a href="javascript:void(0);" onclick="window.open('http://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(location.href))" class="hero-social-link">
     <img src="/img/icons/ico_facebook_bright.svg?{{site.time | date: '%s'}}" alt="facebook">
   </a>
-  <a href="" onclick="window.open('https://twitter.com/share?url=' + encodeURIComponent(location.href))" class="hero-social-link" target="_blank">
+  <a href="javascript:void(0);" onclick="window.open('https://twitter.com/share?url=' + encodeURIComponent(location.href))" class="hero-social-link" >
     <img src="/img/icons/ico_twitter_bright.svg?{{site.time | date: '%s'}}" alt="twitter">
   </a>
 </div>


### PR DESCRIPTION
Issue: In Firefox two tabs is opening when click on social link, one blank tab with current page, and other tab- social share page.

With this fix we prevent opening current page in new tab.
New version tested on Chrome also - works fine.