### PR TITLE
bitcoin-paper: Fix typo

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -238,7 +238,7 @@ id: bitcoin-paper
 
         <li class="card bitcoin-paper-card">
           <a class="language-link"
-            href="/files/bitcoin-paper/bitcoin_fa.pdf">فارسیة</a>
+            href="/files/bitcoin-paper/bitcoin_fa.pdf">پارسی</a>
           <div>
             <span>{% translate translated_by %}</span>
             <a href="https://github.com/ZeeAmini">ZeeAmini</a>


### PR DESCRIPTION
This resolves a typo [mentioned](https://github.com/wbnns/bitcoinwhitepaper/issues/85#issue-530743956) by a contributor who is doing Persian language translation work, and will be merged once tests pass.

Cc: @ZeeAmini  