### PR TITLE
Update mSigna link

### DIFF
--- a/en/bitcoin-core/features/user-interface.md
+++ b/en/bitcoin-core/features/user-interface.md
@@ -191,7 +191,7 @@ chain, and then start mSigna---it will automatically connect to your
 Bitcoin Core full node.
 
 {:.right-hanger}
-[Get mSigna](https://ciphrex.com/redirect/?referer=bitcoin.org)
+[Get mSigna](https://github.com/ciphrex/mSIGNA)
 </div>
 
 </div>


### PR DESCRIPTION
The original link for mSigna throws a connection error. Perhaps the website's certificate expired?