### PR TITLE
Drop unresponsive sites from Community page

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -229,14 +229,6 @@ id: community
         </div>
         
         <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/SE.svg?{{site.time | date: '%s'}}" alt="Swedish flag">
-          <div>
-            <h3 class="organization-country" id="sweden">Sweden</h3>
-            <a class="organization-link" href="http://www.bitcoinforeningen.se/">Svenska Bitcoinföreningen</a>
-          </div>
-        </div>
-        
-        <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/CH.svg?{{site.time | date: '%s'}}" alt="Swiss flag">
           <div>
             <h3 class="organization-country" id="switzerland">Switzerland</h3>

--- a/_templates/community.html
+++ b/_templates/community.html
@@ -236,15 +236,6 @@ id: community
           </div>
         </div>
         
-        <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/VE.svg?{{site.time | date: '%s'}}" alt="Venezuelan flag">
-          <div>
-            <h3 class="organization-country" id="venezuela">Venezuela</h3>
-            <a class="organization-link" href="https://www.bitcoinvenezuela.org/">Fundación Bitcoin de Venezuela</a>
-          </div>
-        </div>
-      </div>
-    
       <div class="introlink">{% translate wikiportal %}</div>
     </div>
   </div>


### PR DESCRIPTION
This drops a couple of sites that have been down and unresponsive for a couple of weeks, now, from the community page, and will be merged once tests pass:
+ [Svenska Bitcoinföreningen](http://www.bitcoinforeningen.se/)
+ [Fundación Bitcoin de Venezuela](https://www.bitcoinvenezuela.org/)

Cc: @khendraw