### PR TITLE
translations: Update/standardize social media links

### DIFF
--- a/_translations/ar.yml
+++ b/_translations/ar.yml
@@ -87,8 +87,8 @@ ar:
     chanmarket: "(إقتباسات مباشرة من الأسواق)"
     chanmining: "(المواضيع المتعلقة بالتنقيب عن البت كوين)"
     social: "الشبكات الإجتماعية"
-    linktwitter: "البحث عن البت كوين على تويتر"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">صفحة البت كوين على فيسبوك</a>"
+    linktwitter: "تويتر"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">موقع التواصل الاجتماعي الفيسبوك</a>'
     meetups: "اللقاءات"
     meetupevents: "أحداث ومؤتمرات البت كوين"
     meetupgroup: "مجموعات التلاقي الخاصة بالبت كوين"

--- a/_translations/bg.yml
+++ b/_translations/bg.yml
@@ -87,8 +87,8 @@ bg:
     chanmarket: "(Канал за съобщения за пазарите в реално време)"
     chanmining: "(Канал за Биткойн добив)"
     social: "Социални мрежи"
-    linktwitter: "Търсене в Twitter"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook страница</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Срещи"
     meetupevents: "Биткойн конференции и събития"
     meetupgroup: "Биткойн групи за срещи"

--- a/_translations/da.yml
+++ b/_translations/da.yml
@@ -87,8 +87,8 @@ da:
     chanmarket: "(markedsnoteringer i realtid)"
     chanmining: "(relateret til Bitcoin-mining)"
     social: "Sociale netværk"
-    linktwitter: "Twitter-søgning"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook-side</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Sammenkomster"
     meetupevents: "Bitcoin-konferencer og -begivenheder"
     meetupgroup: "Bitcoin-sammenkomstgrupper"

--- a/_translations/de.yml
+++ b/_translations/de.yml
@@ -159,8 +159,8 @@ de:
     chanmarket: "(Echtzeit-Kurse verschiedener Börsen, englisch)"
     chanmining: "(Bitcoin-Mining, englisch)"
     social: "Soziale Netzwerke"
-    linktwitter: "Twitter-Suche"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook-Seite</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Meetups"
     meetupevents: "Bitcoin-Konferenzen und -Events"
     meetupgroup: "Bitcoin Meetup-Gruppen"

--- a/_translations/el.yml
+++ b/_translations/el.yml
@@ -87,8 +87,8 @@ el:
     chanmarket: "(Ζωντάνες προσφορές από τις αγορές)"
     chanmining: "(σχετικά με την εξόρυξη Bitcoin)"
     social: "Κοινωνικά δίκτυα"
-    linktwitter: "Αναζήτηση στο Twitter"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Σελίδα στο Facebook</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Συναντήσεις"
     meetupevents: "Συνέδρια και Eκδηλώσεις Bitcoin"
     meetupgroup: "Bitcoin Ομάδες Συνάντησης"

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -166,8 +166,8 @@ en:
     chanmarket: "(Live quotes from markets)"
     chanmining: "(Bitcoin mining related)"
     social: "Social networks"
-    linktwitter: "Twitter Search"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook Page</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Meetups"
     meetupevents: "Bitcoin Conferences And Events"
     meetupgroup: "Bitcoin Meetup Groups"

--- a/_translations/es.yml
+++ b/_translations/es.yml
@@ -94,7 +94,7 @@ es:
     chanmarket: "(Cotizaciones de los mercados en tiempo real, en inglés)"
     chanmining: "(Relacionado con la minería Bitcoin, en inglés)"
     social: "Redes sociales"
-    linktwitter: "Buscar en Twitter"
+    linktwitter: "Twitter"
     facebook: "<a href=\"https://www.facebook.com/bitcoins\">Página de Facebook</a>"
     meetups: "Encuentros"
     meetupevents: "Conferencias y eventos Bitcoin"

--- a/_translations/fa.yml
+++ b/_translations/fa.yml
@@ -87,8 +87,8 @@ fa:
     chanmarket: "(مظنه دادن از بازارها بصورت زنده)"
     chanmining: "(در مورد استخراج بیت کوین)"
     social: "شبکه های اجتماعی"
-    linktwitter: "جست و جوی  توئیتری"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">صفحه فیس بوک</a>"
+    linktwitter: "توییتر"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">فیس بوک</a>'
     meetups: "نشست ها"
     meetupevents: "کنفرانس‌ها و رویداد‌های بیت‌کوین"
     meetupgroup: "گروههای نشست های بیت کوینی"

--- a/_translations/fr.yml
+++ b/_translations/fr.yml
@@ -87,8 +87,8 @@ fr:
     chanmarket: "(Cotations en direct, anglais)"
     chanmining: "(Minage de bitcoins, anglais)"
     social: "Réseaux sociaux"
-    linktwitter: "Recherche Twitter"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Page Facebook (anglais)</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Rencontres"
     meetupevents: "Conférences et événements Bitcoin"
     meetupgroup: "Groupes Meetup Bitcoin"

--- a/_translations/hi.yml
+++ b/_translations/hi.yml
@@ -87,8 +87,8 @@ hi:
     chanmarket: "( बाजार से लाइव उद्धरण) "
     chanmining: "( Bitcoin खनन से संबंधित ) "
     social: " सोशल नेटवर्क"
-    linktwitter: "Twitter खोज "
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\"> Facebook  पृष्ठ </a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: " मिलाप"
     meetupevents: " Bitcoin सम्मेलन और घटनाएं"
     meetupgroup: " Bitcoin  समूह मिलाप"

--- a/_translations/hu.yml
+++ b/_translations/hu.yml
@@ -153,8 +153,8 @@ hu:
     chanmarket: "(élő jegyzés a piacokról)"
     chanmining: "(bitcoin-bányászati témák)"
     social: "Közösségi hálózatok"
-    linktwitter: "Keresés a Twitteren"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook oldal</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Meetupok"
     meetupevents: "Bitcoin-konferenciák és egyéb rendezvények"
     meetupgroup: "Bitcoin-meetupcsoportok"

--- a/_translations/id.yml
+++ b/_translations/id.yml
@@ -153,8 +153,8 @@ id:
     chanmarket: "(Kutipan langsung dari pasar)"
     chanmining: "(Hal-hal terkait penambangan Bitcoin)"
     social: "Jejaring sosial"
-    linktwitter: "Pencarian Twitter"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Halaman Facebook</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Pertemuan"
     meetupevents: "Konferensi dan Acara Bitcoin"
     meetupgroup: "Kelompok Pertemuan Bitcoin"

--- a/_translations/it.yml
+++ b/_translations/it.yml
@@ -157,8 +157,8 @@ it:
     chanmarket: "(Quotazioni in tempo reale dai mercati)"
     chanmining: "(Discussioni sul mining di Bitcoin)"
     social: "Social network"
-    linktwitter: "Ricerca Twitter"
-    facebook: "<a href=\"https://www.facebook.com/groups/144961585575245\"> La Pagina Facebook</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Incontri"
     meetupevents: "Conferenze ed eventi Bitcoin"
     meetupgroup: "Incontri dei Gruppi Bitcoin"

--- a/_translations/ja.yml
+++ b/_translations/ja.yml
@@ -127,8 +127,8 @@ ja:
     chanmarket: "（市場からのリアルタイム相場）"
     chanmining: "（ビットコインマイニング関連）"
     social: "ソーシャル・ネットワーク"
-    linktwitter: "Twitterでの検索"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebookページ</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "ミートアップ"
     meetupevents: " ビットコイン・カンファレンスとイベント "
     meetupgroup: "ビットコインのミートアップグループ"

--- a/_translations/ko.yml
+++ b/_translations/ko.yml
@@ -87,8 +87,8 @@ ko:
     chanmarket: "(실시간 시장 거래가)"
     chanmining: "(비트코인 채굴 관련)"
     social: "소셜 네트워크"
-    linktwitter: "트위터 검색"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">페이스북 페이지</a>"
+    linktwitter: "트위터"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">페이스 북</a>'
     meetups: "모임"
     meetupevents: "비트코인 컨퍼런스 및 이벤트"
     meetupgroup: "비트코인 모임 그룹들"

--- a/_translations/nl.yml
+++ b/_translations/nl.yml
@@ -159,8 +159,8 @@ nl:
     chanmarket: "(Live quotes van verschillende markten)"
     chanmining: "(Over Bitcoin-mining)"
     social: "Sociale netwerken"
-    linktwitter: "Zoek op Twitter"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook-pagina</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Meetups"
     meetupevents: "Bitcoin-conferenties en -evenementen"
     meetupgroup: "Bitcoin-meetupgroepen"

--- a/_translations/pl.yml
+++ b/_translations/pl.yml
@@ -87,8 +87,8 @@ pl:
     chanmarket: "(Cytaty z rynku na żywo)"
     chanmining: "(O wydobywaniu bitcoinów)"
     social: "Sieci społecznościowe"
-    linktwitter: "Wyszukaj na Twitterze"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Strona na Facebook</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Spotkania"
     meetupevents: "Konferencje i wydarzenia Bitcoin"
     meetupgroup: "Grupy spotkań Bitcoin"

--- a/_translations/pt_BR.yml
+++ b/_translations/pt_BR.yml
@@ -158,8 +158,8 @@ pt_BR:
     chanmarket: "(Cotações do mercado em tempo real)"
     chanmining: "(Sobre mineração Bitcoin)"
     social: "Redes sociais"
-    linktwitter: "Buscas Twitter"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Página no Facebook</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Encontros"
     meetupevents: "Conferências e Eventos sobre Bitcoin"
     meetupgroup: "Grupos de Encontro sobre Bitcoin"

--- a/_translations/ro.yml
+++ b/_translations/ro.yml
@@ -87,8 +87,8 @@ ro:
     chanmarket: "(Cursuri live ale burselor)"
     chanmining: "(Discuţii despre minerit Bitcoin)"
     social: "Reţele de socializare"
-    linktwitter: "Căutare pe Twitter"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Pagina de Facebook</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Întâlniri"
     meetupevents: "Conferințe și evenimente Bitcoin"
     meetupgroup: "Grupuri de întâlniri Bitcoin"

--- a/_translations/ru.yml
+++ b/_translations/ru.yml
@@ -134,8 +134,8 @@ ru:
     chanmarket: "(Онлайн котировки)"
     chanmining: "(Майнинг)"
     social: "Социальные сети"
-    linktwitter: "Поиск в Twitter"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Страница на Facebook</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Встречи"
     meetupevents: "События и Биткойн-конференции"
     meetupgroup: "Организация Биткойн собраний"

--- a/_translations/sl.yml
+++ b/_translations/sl.yml
@@ -87,8 +87,8 @@ sl:
     chanmarket: "(Trenutni podatki s trgov)"
     chanmining: "(Povezano z rudarjenjem)"
     social: "Družbena omrežja"
-    linktwitter: "Twitter Iskalnik"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Stran na Facebooku</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Srečanja"
     meetupevents: "Konference in dogodki"
     meetupgroup: "Bitcoin skupine na Meetupu"

--- a/_translations/sr.yml
+++ b/_translations/sr.yml
@@ -152,8 +152,8 @@ sr:
     chanmarket: "Uživo cene na tržištu"
     chanmining: "(Vezano za Bitkoin rudarenje)"
     social: "Socijalne mreže"
-    linktwitter: "Twitter Pretraga"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook Stranica</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Okupljanja"
     meetupevents: "Bitkoin Konferencije i Događaji"
     meetupgroup: "Bitkoin Okupljanja"

--- a/_translations/sv.yml
+++ b/_translations/sv.yml
@@ -94,8 +94,8 @@ sv:
     chanmarket: "(Marknadsnoteringar i realtid)"
     chanmining: "(Bitcoin-utvinning relaterat)"
     social: "Sociala nätverk"
-    linktwitter: "Twitter-sökning"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook Sida</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Meetups"
     meetupevents: "Bitcoin - Konferenser och evenemang"
     meetupgroup: "Bitcoin Meetup Grupper"

--- a/_translations/tr.yml
+++ b/_translations/tr.yml
@@ -87,8 +87,8 @@ tr:
     chanmarket: "(Marketlerden canlı alıntı)"
     chanmining: "(Bitcoin madenciliğiyle ilgili)"
     social: "Sosyal ağlar"
-    linktwitter: "Twitter Araması"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook Sayfası</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Toplantılar"
     meetupevents: "Bitcoin Konferans ve Etkinlikleri"
     meetupgroup: "Bitcoin Toplanma Grupları"

--- a/_translations/uk.yml
+++ b/_translations/uk.yml
@@ -135,8 +135,8 @@ uk:
     chanmarket: "(Онлайн котирування)"
     chanmining: "(Видобуток біткоїнів)"
     social: "Соціальні мережі"
-    linktwitter: "Пошук у Твіттері"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Сторінка у Фейсбуці</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Зустрічі"
     meetupevents: "Біткойн конференції та події"
     meetupgroup: "Групи зустрічей Біткойн"

--- a/_translations/zh_CN.yml
+++ b/_translations/zh_CN.yml
@@ -125,8 +125,8 @@ zh_CN:
     chanmarket: "（交易市场实时报价）"
     chanmining: "（比特币挖矿相关）"
     social: "社交网络"
-    linktwitter: "Twitter搜索"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">比特币的Facebook页</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "聚会"
     meetupevents: "比特币会议和活动"
     meetupgroup: "比特币聚会群"

--- a/_translations/zh_TW.yml
+++ b/_translations/zh_TW.yml
@@ -87,8 +87,8 @@ zh_TW:
     chanmarket: "(市場即時報價)"
     chanmining: "(Bitcoin 挖礦相關)"
     social: "社交網路"
-    linktwitter: "Twitter 搜尋"
-    facebook: "<a href=\"https://www.facebook.com/bitcoins\">Facebook 頁面</a>"
+    linktwitter: "Twitter"
+    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "聚會"
     meetupevents: "Bitcoin 研討會與活動"
     meetupgroup: "Bitcoin 社群聚會"


### PR DESCRIPTION
When reviewing #3231, we noted that on the [Community page](https://bitcoin.org/en/community) in the `Social Networks` section, the Facebook link points to a [specific page](https://www.facebook.com/bitcoins) that is outdated. This PR updates the section to make each entry uniform and follow the convention of the Twitter link, so that both links point users to a hashtag search, rather than a specific page. 

Unless others object, this is scheduled to be merged on Friday, January 10th.