### PR TITLE
eclairmobile: Point to mainnet version

### DIFF
--- a/_wallets/eclairmobile.md
+++ b/_wallets/eclairmobile.md
@@ -13,7 +13,7 @@ platform:
     os:
       - name:  android
         text: "walleteclairmobile"
-        link: "https://play.google.com/store/apps/details?id=fr.acinq.eclair.wallet"
+        link: "https://play.google.com/store/apps/details?id=fr.acinq.eclair.wallet.mainnet2"
         source: "https://github.com/ACINQ/eclair-mobile"
         screenshot: "eclairmobile.png"
         features: "legacy_addresses lightning segwit"


### PR DESCRIPTION
This resolves #3239. The developer, [ACINQ](https://play.google.com/store/apps/developer?id=ACINQ), has two versions of Eclair Mobile on Google Play:

+ [Eclair Mobile v0.4.9](https://play.google.com/store/apps/details?id=fr.acinq.eclair.wallet.mainnet2)
+ [Eclair Mobile v0.4.9 Testnet](https://play.google.com/store/apps/details?id=fr.acinq.eclair.wallet)

This PR changes the URL that the install button on the [Eclair Mobile wallet page](https://bitcoin.org/en/wallets/mobile/android/eclairmobile/?step=5&platform=android) is pointing to, from the testnet version to the mainnet version.

Cc: @crwatkins, @dpad85

Related: [Eclair Mobile v0.4.9 on GitHub](https://github.com/ACINQ/eclair-mobile/releases/tag/v0.4.9-MAINNET)
