### PR TITLE
exchanges: Add Bitvavo to Netherlands

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -162,6 +162,16 @@ id: exchanges
     <div class="marketplace-row">
 
       <div class="row marketplace">
+        <img class="marketplace-flag" src="/img/flags/NL.svg?{{site.time | date: '%s'}}" alt="Dutch flag">
+        <div>
+          <h3 id="netherlands" class="no_toc">Netherlands</h3>
+          <p>
+            <a class="marketplace-link" href="https://bitvavo.com/">Bitvavo</a>
+          </p>
+        </div>
+      </div>
+
+      <div class="row marketplace">
         <img class="marketplace-flag" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="Polish flag">
         <div>
           <h3 id="poland" class="no_toc">Poland</h3>


### PR DESCRIPTION
This adds Bitvavo (recently reviewed and added under Europe in #3183), to the Netherlands - the country where they are based - so that Dutch users know that they have a local/domestic option.

This will be merged once tests pass.

Cc: @VoxPopulus 