### PR TITLE
exchanges: Drop OmniTrade

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -334,8 +334,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.mercadobitcoin.com.br/">Mercado Bitcoin</a>
           <br>
-          <a class="marketplace-link" href="https://www.omnitrade.io/">OmniTrade</a>
-          <br>
           <a class="marketplace-link" href="https://walltime.info/">Walltime</a>
         </p>
       </div>


### PR DESCRIPTION
During a recent review of exchanges listed on the site, we noted that OmniTrade (listed under Brazil) did not respond to a test inquiry we sent to their support team, posing as a new customer with questions about deposits and withdrawals (they still have yet to reply). In addition to this, we've noted that the volume being self-reported on their site is very low and non-existent in some cases. We are also noting some inconsistencies in their order book:

![Screen Shot 2020-01-26 at 13 07 39](https://user-images.githubusercontent.com/1130872/73134941-87db6180-4034-11ea-991b-a7137d429d9d.png)

For example, they're currently reporting approximately .54 BTC in trade volume over the past 24H for BTC/BRL (low volume) but showing a 0.00% change over the same time period alongside it.

Based on the above, we recommend removing OmniTrade at this time.

Cc: @khendraw