### PR TITLE
Switch privacynetwork score of Bitcoin Wallet to checkpassprivacynetw…

### DIFF
--- a/_wallets/bitcoinwallet.md
+++ b/_wallets/bitcoinwallet.md
@@ -28,5 +28,5 @@ platform:
         privacycheck:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
           privacydisclosure: "checkfailprivacydisclosurespv"
-          privacynetwork: "checkfailprivacynetworknosupporttor"
+          privacynetwork: "checkpassprivacynetworksupporttorproxy"
 ---


### PR DESCRIPTION
…orksupporttorproxy

Bitcoin Wallet has supported Tor via the Orbot app for years. All you need to do is enable
VPN mode and select Bitcoin Wallet (amongst other apps).