### PR TITLE
Gemfile: Upgrade RedCloth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development do
   gem 'json', '>= 1.9'
   gem 'less', '2.4.0'
   gem 'kramdown'
-  gem 'RedCloth'
+  gem 'RedCloth', ">= 4.3.0"
   gem 'therubyracer' # required by less
   gem 'jshintrb', '~>0.3.0'
   gem 'safe_yaml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    RedCloth (4.2.9)
+    RedCloth (4.3.2)
     addressable (2.4.0)
     colorator (0.1)
     colored (1.2)
@@ -73,7 +73,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  RedCloth
+  RedCloth (>= 4.3.0)
   ffi-icu
   html-proofer (= 2.1.0)
   jekyll (~> 3.0)
@@ -89,4 +89,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
This upgrades the redcloth gem to >= 4.3.0 to patch against an XSS
vulnerability and will be merged once tests pass.