### PR TITLE
Small P2P Network document fix

### DIFF
--- a/_data/devdocs/en/references/p2p_networking.md
+++ b/_data/devdocs/en/references/p2p_networking.md
@@ -286,7 +286,7 @@ message can be empty.
 | Bytes    | Name    | Data Type        | Description
 |----------|---------|------------------|-----------------
 | *Varies* | count   | compactSize uint | Number of block headers up to a maximum of 2,000.  Note: headers-first sync assumes the sending node will send the maximum number of headers whenever possible.
-| *Varies* | headers | block_header     | Block headers: each 80-byte block header is in the format described in the [block headers section][section block header] with an additional 0x00 suffixed.  This 0x00 is called the transaction count, but because the headers message doesn't include any transactions, the transaction count is always zero.
+| 81       | headers | block_header     | Block headers: each 80-byte block header is in the format described in the [block headers section][section block header] with an additional 0x00 suffixed.  This 0x00 is called the transaction count, but because the headers message doesn't include any transactions, the transaction count is always zero.
 
 The following annotated hexdump shows a `headers` message.  (The message
 header has been omitted.)


### PR DESCRIPTION
Headers in a `headers` message are fixed 81 bytes (80 bytes block header + 1 byte tx count equal to zero).