### PR TITLE
gitignore: Adds '.jekyll-cache/'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 vendor
 _cache
 .jekyll-metadata
+.jekyll-cache/
 .sass-cache/
 
 # To prevent accidental push of translations from


### PR DESCRIPTION
We will be updating Jekyll soon, and the newer version utilizes a
caching API. This adds its cache folder (`.jekyll-cache/`), which is set
aside for site builds, to the `.gitignore` to ensure that it isn't
getting tracked along with  repository changes and accidentally included
in people's pull requests.

This will be merged once tests pass.