### PR TITLE
exchanges: Drop BL3P

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -147,8 +147,6 @@ id: exchanges
         <br>
         <a class="marketplace-link" href="https://bitvavo.com/">Bitvavo</a>
         <br>
-        <a class="marketplace-link" href="https://bl3p.eu/">BL3P</a>
-        <br>
         <a class="marketplace-link" href="https://kriptomat.io/">Kriptomat</a>
         <br>
         <a class="marketplace-link" href="https://www.paymium.com/">Paymium</a>


### PR DESCRIPTION
This removes BL3P from the European section of the Exchanges page. They are only allowing people to sign up who have invite codes, which we've confirmed during review, and also with their team. This would preclude the majority of people discovering the exchange via bitcoin.org from transacting with them.

This will be merged once tests pass.