### PR TITLE
exchanges: Add Hodl Hodl

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -28,6 +28,8 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://bitquick.co/">BitQuick</a>
     <br>
+    <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
+    <br>
     <a class="marketplace-link" href="https://localbitcoins.com/">Local Bitcoins</a>
     <br>
     <a class="marketplace-link" href="https://paxful.com/">Paxful</a>


### PR DESCRIPTION
RE: https://github.com/bitcoin-dot-org/bitcoin.org/issues/3220

We **honestly believe** removing Hodl Hodl from the listing due to low volumes of USD and EUR offers **is unfair**. 
We request **that you reconsider** this decision for several reasons.
 1. Saturday is not the best day to check the liquidity of an exchange, because most traders don’t work weekends. (this refers to post: https://github.com/bitcoin-dot-org/bitcoin.org/issues/3220)
 2. We don’t operate in the USA (since 2018, which is public information), therefore the amount of offers in USD is not going to be very high. 
 3. However, we do operate in many other countries. Bitcoin is not USD or EUR only, and most of our volume comes from emerging markets (for example, Russia, Asian markets, Latin America, etc.). In some markets, we actually offer more liquidity than the other options listed at bitcoin.org. 
 4. And finally, our EUR and USD offer list has increased significantly since December, and most of our traders have ratings and reviews.