### PR TITLE
Remove postponed events from Events page

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -14,14 +14,6 @@
   country: "Spain"
   link: "https://lightninghackday.fulmo.org/"
 
-- date: 2020-04-24
-  title: "The Bitcoin Reformation"
-  venue: "Zuiderkroon"
-  address: "Vlaamsekaai 81/83"
-  city: "Antwerp"
-  country: "Belgium"
-  link: "https://thebitcoinreformation.com/"
-
 - date: 2020-05-03
   title: "Portland Bitcoin Conference"
   venue: "Oregon Convention Center"

--- a/_events.yml
+++ b/_events.yml
@@ -6,14 +6,6 @@
   country: "Spain"
   link: "https://www.mallorcablockchaindays.com"
 
-- date: 2020-03-27
-  title: "Bitcoin 2020"
-  venue: "SVN West"
-  address: "10 S Van Ness Ave., 94103"
-  city: "San Francisco"
-  country: "United States"
-  link: "https://www.bitcoin2020conference.com/"
-
 - date: 2020-04-04
   title: "Lightning Hackday Barcelona"
   venue: "Polis Parallela"


### PR DESCRIPTION
This removes a couple of postponed events as a result of corona virus (new dates TBD), and will be merged once tests pass. We'll continue to check other events on a regular basis and remove those that are canceled or postponed.

Closes #3290. 