### PR TITLE
Update Events Page

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -30,7 +30,7 @@
   country: "United States"
   link: "https://www.magicalcryptoconference.com/"
 
-- date: 2020-06-30
+- date: 2020-06-02
   title: "Value of Bitcoin Conference 2020"
   venue: "Alte Kongresshalle"
   address: "Am Bavariapark 14"

--- a/_events.yml
+++ b/_events.yml
@@ -1,11 +1,3 @@
-- date: 2020-03-20
-  title: "Mallorca Blockchain Days 2020"
-  venue: "Hotel Valparaiso"
-  address: "Carrer de Francesc Vidal I Sureda, 23"
-  city: "Palma de Mallorca"
-  country: "Spain"
-  link: "https://www.mallorcablockchaindays.com"
-
 - date: 2020-04-04
   title: "Lightning Hackday Barcelona"
   venue: "Polis Parallela"

--- a/_events.yml
+++ b/_events.yml
@@ -1,11 +1,3 @@
-- date: 2020-04-04
-  title: "Lightning Hackday Barcelona"
-  venue: "Polis Parallela"
-  address: "Carrer de Jaume Puigvert, 13"
-  city: "Barcelona"
-  country: "Spain"
-  link: "https://lightninghackday.fulmo.org/"
-
 - date: 2020-05-03
   title: "Portland Bitcoin Conference"
   venue: "Oregon Convention Center"


### PR DESCRIPTION
This revises the date for the upcoming Value of Bitcoin Conference, and removes two events that have been postponed due to coronavirus (Mallorca Blockchain Days & Lightning Hackday Barcelona).

This will be merged once tests pass.