### PR TITLE
resources: Drop 'Bitcoin Volatility Index'

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -83,9 +83,6 @@ id: resources
         <p>
           <a href="https://bitcoinaverage.com/{% if 'en,fr,de,it,es,pl,ru,ht,pt,tr,uk' contains page.lang %}{{ page.lang }}/bitcoin-price/btc-to-usd{% endif %}">BitcoinAverage</a>
         </p>
-        <p>
-          <a href="https://bitvol.info/">Bitcoin Volatility Index</a>
-        </p>
       </div>
 
       <div class="card resources-card">


### PR DESCRIPTION
This drops a link to the 'Bitcoin Volatility Index' from the Resources page and will be merged once tests pass. The existing link is redirecting to another site that doesn't appear to have a web server configured, resulting in an error message.