### PR TITLE
events: Reschedule date, 'Portland Bitcoin Conference'

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -1,11 +1,3 @@
-- date: 2020-05-03
-  title: "Portland Bitcoin Conference"
-  venue: "Oregon Convention Center"
-  address: "777 NE Martin Luther King Jr Blvd"
-  city: "Portland"
-  country: "United States"
-  link: "https://portlandbitcoinconference.com/"
-
 - date: 2020-05-09
   title: "Magical Crypto Conference"
   venue: "Convene"
@@ -37,3 +29,11 @@
   city: "Dallas"
   country: "United States"
   link: "https://BitBlockBoom.com/"
+
+- date: 2020-10-25
+  title: "Portland Bitcoin Conference"
+  venue: "Oregon Convention Center"
+  address: "777 NE Martin Luther King Jr Blvd"
+  city: "Portland"
+  country: "United States"
+  link: "https://portlandbitcoinconference.com/"


### PR DESCRIPTION
This changes the date of the Portland Bitcoin Conference (#3234), which has been rescheduled due to coronavirus, and will be merged once tests pass.