### PR TITLE
Update Events Page

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -1,11 +1,3 @@
-- date: 2020-06-02
-  title: "Value of Bitcoin Conference 2020"
-  venue: "Alte Kongresshalle"
-  address: "Am Bavariapark 14"
-  city: "Munich"
-  country: "Germany"
-  link: "https://vob-conference.com/"
-
 - date: 2020-07-22
   title: "Mining Disrupt 2020"
   venue: "DoubleTree Hilton MACC"

--- a/_events.yml
+++ b/_events.yml
@@ -1,11 +1,3 @@
-- date: 2020-05-09
-  title: "Magical Crypto Conference"
-  venue: "Convene"
-  address: "225 Liberty Street"
-  city: "New York"
-  country: "United States"
-  link: "https://www.magicalcryptoconference.com/"
-
 - date: 2020-06-02
   title: "Value of Bitcoin Conference 2020"
   venue: "Alte Kongresshalle"


### PR DESCRIPTION
This updates the events page to remove the Magical Crypto Conference (postponed until next year), as well as the Value of Bitcoin Conference (the ticketing system on their website has been disabled).

This will be merged once tests pass.