### PR TITLE
Update Slack URL

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -541,7 +541,7 @@ en:
     devcommunities: "Developer communities"
     devcommunitiesintro: "The following chatrooms and websites host discussions about Bitcoin development.  Please be sure to read their rules of conduct before posting."
     ircjoin: "<a href=\"https://webchat.freenode.net/?channels=bitcoin-core-dev\">IRC Channel #bitcoin-core-dev</a> on freenode."
-    slack: "<a href=\"https://slack.bitcoincore.org/\">Bitcoin Core Slack Channel</a>"
+    slack: "<a href=\"https://https://bitcoincoreslack.herokuapp.com/\">Bitcoin Core Community Slack</a>"
     stackexchange: "<a href=\"https://bitcoin.stackexchange.com/\">Bitcoin StackExchange</a>"
     bitcointalkdev: "<a href=\"https://bitcointalk.org/index.php?board=6.0\">BitcoinTalk Development &amp; Technical Discussion Forum</a>"
   download:


### PR DESCRIPTION
* Update the Slack URL to a working link 
* Alter the name of the link to clarify this is a community slack, not an official Bitcoin Core project slack