### PR TITLE
Add River Financial as an exchange in the US

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -290,6 +290,8 @@ id: exchanges
           <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
           <br>
           <a class="marketplace-link" href="https://www.itbit.com/">itBit</a>
+          <br>
+          <a class="marketplace-link" href="https://river.com/">River Financial</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Hello maintainers. I'd like to humbly propose adding our company River Financial (https://river.com) as a US Bitcoin exchange. We offer people the ability to buy, sell and manage their Bitcoin holdings. River users can withdraw and deposit Bitcoin from/to their account on-chain or via the Lightning Network.

We are committed to always providing the latest Bitcoin functionality to our clients. You can see here (https://bitcoinops.org/en/compatibility/) that we are fully segwit compatible. We will also be rolling out some new features over the coming months for hardware wallet integration making it easy for people to move their coins from River to their self custody.

I understand that there is a review process and I will reach out to the appropriate email regarding that.