### PR TITLE
events: Drop 'Portland Bitcoin Conference'

### DIFF
--- a/_events.yml
+++ b/_events.yml
@@ -13,11 +13,3 @@
   city: "Dallas"
   country: "United States"
   link: "https://BitBlockBoom.com/"
-
-- date: 2020-10-25
-  title: "Portland Bitcoin Conference"
-  venue: "Oregon Convention Center"
-  address: "777 NE Martin Luther King Jr Blvd"
-  city: "Portland"
-  country: "United States"
-  link: "https://portlandbitcoinconference.com/"


### PR DESCRIPTION
This drops the Portland Bitcoin Conference from the events page. We've
noted that their website is down, and is no longer accessible during
successive attempts to reach it, for two weeks, now.

This will be merged once tests pass.