### PR TITLE
Switch privacydisclosure score of Bitcoin Wallet to checkpassprivacydisclosurefullnode

### DIFF
--- a/_wallets/bitcoinwallet.md
+++ b/_wallets/bitcoinwallet.md
@@ -27,6 +27,6 @@ platform:
           fees: "checkgoodfeecontrolfull"
         privacycheck:
           privacyaddressreuse: "checkpassprivacyaddressrotation"
-          privacydisclosure: "checkfailprivacydisclosurespv"
+          privacydisclosure: "checkpassprivacydisclosurefullnode"
           privacynetwork: "checkpassprivacynetworksupporttorproxy"
 ---


### PR DESCRIPTION
Since version 8, an improved privacy mode of blockchain sync can be selected. It does
not set a filter and reads all blocks and transactions. This makes it privacy-equivalent
to a full node. Everyone with a high enough data allowance is recommended to use this
mode.