### PR TITLE
travis: Fix deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - BITCOINORG_BUILD_TYPE=deployment
 
 before_install:
-  - "gem update --system"
+  - "gem update --system 3.0.6"
   - "gem install bundler -v 1.17.3"
 
 script: make travis

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ build:
 ## Jekyll annoyingly returns success even when it emits errors and
 ## exceptions, so we'll grep its output for error strings
 check-for-build-errors:
-	$S egrep -i '(error|exception)' $(JEKYLL_LOG) \
+	$S egrep -i '(error|warn|exception)' $(JEKYLL_LOG) \
 	    | grep -vi 'rouge/lexers/shell.rb' \
 	    | eval $(ERROR_ON_OUTPUT)
 


### PR DESCRIPTION
This applies a specific version to Rubygems to resolve a deprecation warning that Travis was reporting during builds.

**Before:**
![image](https://user-images.githubusercontent.com/1130872/82066979-64feb700-96d0-11ea-9db3-c66b07c165d1.png)

**After:**
![image](https://user-images.githubusercontent.com/1130872/82067455-0d148000-96d1-11ea-869f-ec8063123b9e.png)

The Makefile has also been tweaked to ensure that going forward, builds will fail if any warnings are reported in the log.

This will be merged once tests pass.