### PR TITLE
exchanges: Add Binance to Europe

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -194,6 +194,8 @@ id: exchanges
         <div>
           <h3 id="united-kingdom" class="no_toc">United Kingdom</h3>
           <p>
+            <a class="marketplace-link" href="https://www.binance.je/">Binance</a>
+            <br>
             <a class="marketplace-link" href="https://bittylicious.com/">Bittylicious</a>
             <br>
             <a class="marketplace-link" href="https://www.coincorner.com/">CoinCorner</a>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -139,6 +139,8 @@ id: exchanges
       <p>
         <a class="marketplace-link" href="https://anycoindirect.eu">AnyCoin Direct</a>
         <br>
+        <a class="marketplace-link" href="https://www.binance.je/">Binance</a>
+        <br>
         <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>
         <br>
         <a class="marketplace-link" href="https://bitflyer.com/en-eu/">bitFlyer</a>
@@ -192,8 +194,6 @@ id: exchanges
         <div>
           <h3 id="united-kingdom" class="no_toc">United Kingdom</h3>
           <p>
-            <a class="marketplace-link" href="https://www.binance.je/">Binance</a>
-            <br>
             <a class="marketplace-link" href="https://bittylicious.com/">Bittylicious</a>
             <br>
             <a class="marketplace-link" href="https://www.coincorner.com/">CoinCorner</a>


### PR DESCRIPTION
This adds Binance's listing to Europe alongside where they were, under the United Kingdom, as per the supported countries mentioned on their website:
https://support.binance.je/hc/en-us/articles/360023983411-Supported-Banks-Jurisdictions

This is scheduled to be merged on Wednesday, May 20th.