### PR TITLE
config: Update block reward from 12.5 to 6.25

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -617,7 +617,7 @@ text:
   ##   bitcoin_org_docs_maintainer_email_link
   ## For increasing variables, like chain size, choose a somewhat higher
   ##   value so we don't need to update too often
-  subsidy_in_decimal_bitcoins: 12.5
+  subsidy_in_decimal_bitcoins: 6.25
   ## cd ~ ; du -sh .bitcoin/ --exclude=testnet3 --exclude=regtest
   bitcoin_datadir_gb: 200
   ## Slightly smaller than the total datadir size


### PR DESCRIPTION
This updates the block reward from 12.5 to 6.25 in `_config.yml` and
will be merged once tests pass.