### PR TITLE
bitcoin-paper: Finnish translator credits

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -176,8 +176,12 @@ id: bitcoin-paper
             href="/files/bitcoin-paper/bitcoin_fi.pdf">Suomen kieli</a>
           <div>
             <span>{% translate translated_by %}</span>
-            Biocycle, LohkoKettu, Aleksi Suomalainen, locusf, Antti Majakivi,
-            Anduck, Niko Laamanen, n1kofi
+            <a href="https://twitter.com/bio_bitcoin">Biocycle</a>,
+            <a href="https://twitter.com/LohkoKettu">LohkoKettu</a>,
+            <a href="https://twitter.com/locusf">Aleksi Suomalainen</a>,
+            <a href="https://twitter.com/AnttiMay">Antti Majakivi</a>,
+            <a href="https://twitter.com/OmniFinn">Niko Laamanen</a>,
+            Anduck, n1kofi
           </div>
         </li>
 


### PR DESCRIPTION
This updates the credits for each translator of the Finnish translation
of the Bitcoin paper (similarly to other translations), and will be
merged once tests pass.