### PR TITLE
Update Bitcoin paper translators

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -216,7 +216,7 @@ id: bitcoin-paper
             href="/files/bitcoin-paper/bitcoin_hi.pdf">मानक हिन्दी </a>
           <div>
             <span>{% translate translated_by %}</span>
-            <a href="https://github.com/BlockBitMedia">Praneet Jain</a>
+            <a href="http://twitter.com/blockbitmedia">Praneet Jain</a>
           </div>
         </li>
 

--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -180,8 +180,7 @@ id: bitcoin-paper
             <a href="https://twitter.com/LohkoKettu">LohkoKettu</a>,
             <a href="https://twitter.com/locusf">Aleksi Suomalainen</a>,
             <a href="https://twitter.com/AnttiMay">Antti Majakivi</a>,
-            <a href="https://twitter.com/OmniFinn">Niko Laamanen</a>,
-            Anduck, n1kofi
+            <a href="https://twitter.com/OmniFinn">Niko Laamanen</a>
           </div>
         </li>
 


### PR DESCRIPTION
This updates a few translator credits for two different translations of the Bitcoin paper.

+ Finnish: Removes two redundant translator credits (there was a miscommunication with the submitter regarding who the people who translated it were)
+ Hindi: Updates the link for translator credit, by request of the submitter

This is scheduled to be merged on Monday, June 1st.