### PR TITLE
Update Wasabi fee control override

### DIFF
--- a/_wallets/wasabi.md
+++ b/_wallets/wasabi.md
@@ -22,7 +22,7 @@ platform:
         transparency: "checkgoodtransparencydeterministic"
         environment: "checkfailenvironmentdesktop"
         privacy: "checkgoodprivacyimproved"
-        fees: "checkpassfeecontroldynamic"
+        fees: "checkgoodfeecontrolfull"
       privacycheck:
         privacyaddressreuse: "checkpassprivacyaddressrotation"
         privacydisclosure: "checkpassprivacydisclosurefullnode"

--- a/_wallets/wasabi.md
+++ b/_wallets/wasabi.md
@@ -22,7 +22,7 @@ platform:
         transparency: "checkgoodtransparencydeterministic"
         environment: "checkfailenvironmentdesktop"
         privacy: "checkgoodprivacyimproved"
-        fees: "checkgoodfeecontrolfull"
+        fees: "checkpassfeecontroloverride"
       privacycheck:
         privacyaddressreuse: "checkpassprivacyaddressrotation"
         privacydisclosure: "checkpassprivacydisclosurefullnode"


### PR DESCRIPTION
By default, Wasabi shows the Bitcoin Core smart fee estimate for transaction fees. However, in the settings, the user can toggle the option to [manually set a custom feerate](https://docs.wasabiwallet.io/FAQ/FAQ-UseWasabi.html#how-do-i-set-custom-fee-rate).

I am not sure if I understand it correctly, but I believe that the correct level for this in the score is `checkgoodfeecontrolfull`. If I am mistaken, then please disregard and close the PR. Thank You!