### PR TITLE
exchanges: Remove Foxbit

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -328,8 +328,6 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>
-          <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>
-          <br>
           <a class="marketplace-link" href="https://www.mercadobitcoin.com.br/">Mercado Bitcoin</a>
           <br>
           <a class="marketplace-link" href="https://www.novadax.com.br/">NovaDAX</a>


### PR DESCRIPTION
This removes Foxbit, a Brazilian exchange, from the Exchanges page. It was [recently mentioned](https://ourbitcoinnews.com/caixa-economica-closes-accounts-of-at-least-five-bitcoin-companies-in-10-days/) in the news that one of the larger banks in Brazil has begun closing accounts of some of the local exchanges.

Whether related or not, yesterday, we received an automated email from Foxbit that account holders must log in to the site within the next two weeks (by June 30th), and provide updated account holder information, or the account will be permanently closed:

![image](https://user-images.githubusercontent.com/1130872/84860451-56a90f80-b06f-11ea-828c-507acb461bda.png)

The email states that should an account holder not update their information by the 30th, and would like to use the platform after that date, that they will need to create a new account. This is concerning because this will potentially lead to issues with account holders such as being:

+ Unable to access funds/potential loss of funds, after the 30th, if unaware of the change
+ Unable to access transaction histories for the purposes of being able to establish a cost basis and determine profits and/or losses to report capital gains/losses

We noted that despite this being an automated email sent out to Foxbit users, there is no mention of this on their social media, on their blog, or in their support portal. We confirmed the authenticity of the email.

We recommend that the exchange be proactively removed for a period of at least 3-6 months to confirm there are no adverse effects as a result of the above change, for the reasons stated.

This is scheduled to be merged on Monday, June 22nd.