### PR TITLE
exchanges: Remove Buenbit

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -312,8 +312,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://bitex.la/">Bitex</a>
           <br>
-          <a class="marketplace-link" href="https://www.buenbit.com/">Buenbit</a>
-          <br>
           <a class="marketplace-link" href="https://www.ripio.com/">Ripio</a>
           <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>


### PR DESCRIPTION
This removes [Buenbit](https://buenbit.com/index.php), an exchange in Argentina, from the Exchanges page. They're now focused primarily on the exchange of DAI, which is reflected throughout their homepage.

A user visiting the exchange from bitcoin.org would no doubt be confused by this, were they looking to buy and sell bitcoin.

Examples from the homepage:

**1**
![image](https://user-images.githubusercontent.com/1130872/84910533-47e64b00-b0b7-11ea-916b-96cdf103e707.png)

**2**
![image](https://user-images.githubusercontent.com/1130872/84910572-52a0e000-b0b7-11ea-867f-ead008b7b5a9.png)

**3**
![image](https://user-images.githubusercontent.com/1130872/84910625-64828300-b0b7-11ea-8370-8a6ff71c81b5.png)

**4**
![image](https://user-images.githubusercontent.com/1130872/84910666-7532f900-b0b7-11ea-8dd6-80df1b95267a.png)

We also noted that during a recent check of support team response times for exchanges listed on bitcoin.org, that they still haven't replied to our message:

![image](https://user-images.githubusercontent.com/1130872/84910903-c04d0c00-b0b7-11ea-9070-75049526b880.png)

This will be merged once tests pass.