### PR TITLE
exchanges: Remove Bitex

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -310,8 +310,6 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://argenbtc.com/">ArgenBTC</a>
           <br>
-          <a class="marketplace-link" href="https://bitex.la/">Bitex</a>
-          <br>
           <a class="marketplace-link" href="https://www.ripio.com/">Ripio</a>
           <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>


### PR DESCRIPTION
This removes the Bitex listing under Argentina on the exchanges page and will be merged once tests pass. During a [recent review](https://docs.google.com/spreadsheets/d/1k90K6aCj9MMQZjDoMbQsG5_B7MZ4YHkCg_gmtP1G_ag/edit?usp=sharing) of average customer support response times for the 60+ exchanges listed on the site, Bitex did not reply to multiple inquires from separate email addresses - the earliest of which was sent approximately two weeks ago. We know the inquiries were received because we received auto-generated ticket numbers.

For measure of comparison, the average customer support response time for exchanges listed on the site is 1.32 days.

Cc: @khendraw