### PR TITLE
exchanges: Remove Ripio

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -310,8 +310,6 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://argenbtc.com/">ArgenBTC</a>
           <br>
-          <a class="marketplace-link" href="https://www.ripio.com/">Ripio</a>
-          <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>
         </p>
       </div>


### PR DESCRIPTION
This removes the Ripio listing under Argentina on the exchanges page and will be merged once tests pass. During a recent review of average customer support response times for the 60+ exchanges listed on the site, Ripio did not reply to multiple inquires from separate email addresses - the earliest of which was sent approximately two weeks ago. We know the inquiries were received because we immediately received auto-generated ticket numbers after the emails were sent.

We contacted Ripio out of band via Twitter this week and were told they would look into the issue. Yesterday, we received a reply to one of our original emails, stating that they have been having problems with their SMS system, and this is why we're having trouble logging in. None of our inquiries were about having trouble logging in or accessing an account.

Cc: @khendraw