### PR TITLE
Remove Coinmama from list of exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -15,8 +15,6 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://www.coinbase.com/">Coinbase</a>
     <br>
-    <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
-    <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>
   </p>
 </div>


### PR DESCRIPTION
This removes Coinmama from the list of exchanges. The exchange was added to the site relatively quickly back in 2018 (https://github.com/bitcoin-dot-org/bitcoin.org/pull/2351).

I don't think this exchange has enough clout to be listed right at the top of the page as an "international" exchange, there are many more reputable exchanges.