### PR TITLE
Change Neutral wallet score label to Not applicable

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -269,7 +269,7 @@ en:
     wallet-scoring-good: "Good"
     wallet-scoring-pass: "Acceptable"
     wallet-scoring-fail: "Caution"
-    wallet-scoring-neutral: "Neutral"
+    wallet-scoring-neutral: "Not applicable"
     walletcatmobile: "Mobile"
     walletcatmobile-description: "Wallets are available for Android and iOS based operating systems."
     walletcatdesktop: "Desktop"


### PR DESCRIPTION
Resolves #3136 

This change is to replace the confusing term "Neutral" with a more accurate "Not applicable".  This only affects hardware wallets.

@nvk 