### PR TITLE
HSTS preload for wallets

### DIFF
--- a/docs/managing-wallets.md
+++ b/docs/managing-wallets.md
@@ -25,8 +25,10 @@ in the future
 - Website supports HTTPS and 301 redirects HTTP requests
 - SSL certificate passes [Qualys SSL Labs SSL
   test](https://www.ssllabs.com/ssltest/)
-- Website serving executable code or requiring authentication uses HSTS with a
-  max-age of at least 180 days
+- Website serving or linking to executable code or requiring authentication uses HSTS
+  - Existing listings: With a max-age of at least 180 days
+  - New listings: With a max-age of at least 1 year, and preload and includeSubDomains directives to qualify for browser preload list inclusion
+  `e.g. Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
 - The identity of CEOs and/or developers is public
 - Avoid address reuse by displaying a new receiving address for each transaction
   in the wallet UI


### PR DESCRIPTION
Closes #3111

There have been concerns about the issue that our existing optional HSTS preload criterion relies on a list maintained by a third party (Google) outside of our control.  This PR attempts to mitigate that by specifying which HSTS directives are to be used to qualify for HSTS preload by all major browsers and does not require the Google preload list.

As an aside, I believe this is an important conceptual difference, but I will admit in practice it does not make much difference because we already retain complete control of revisions to the criterion.  I don't see this being significantly different, in terms of control, from referencing a BIP or an IETF informational RFC.

This PR requires the preload directives for new listings, but not does not require existing listing to be updated (all new listing in the last few years have been compliant).  The actual preload list membership remains optional.