### PR TITLE
Add P2P exchange LocalCoinSwap to list

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -26,6 +26,8 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://bitquick.co/">BitQuick</a>
     <br>
+    <a class="marketplace-link" href="https://localcoinswap.com/">LocalCoinSwap</a>
+    <br>
     <a class="marketplace-link" href="https://localbitcoins.com/">Local Bitcoins</a>
     <br>
     <a class="marketplace-link" href="https://paxful.com/">Paxful</a>


### PR DESCRIPTION
I am the CTO of LocalCoinSwap, a pro-Bitcoin P2P exchange.

We offer KYC-free trading in over 250 different payment methods, in every country of the world (except for Iran and North Korea), and have been operational since August 2018. We have a great reputation, meaningful daily volume, and plenty of loyal traders.

We hope to do our part to promote mainstream adoption of Bitcoin world-wide, and so it is my honour to present this Pull Request to Bitcoin.org for inclusion.

Thank you.