### PR TITLE
Add Rain.bh to exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -37,6 +37,16 @@ id: exchanges
   <div class="marketplace-row">
 
     <div class="row marketplace">
+      <img class="marketplace-flag" src="/img/flags/BH.svg?{{site.time | date: '%s'}}" alt="Bahrain flag">
+      <div>
+        <h3 id="bahrain" class="no_toc">Bahrain</h3>
+        <p>
+          <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/ID.svg?{{site.time | date: '%s'}}" alt="Indonesian flag">
       <div>
         <h3 id="indonesia" class="no_toc">Indonesia</h3>
@@ -71,11 +81,31 @@ id: exchanges
     </div>
 
     <div class="row marketplace">
+      <img class="marketplace-flag" src="/img/flags/KW.svg?{{site.time | date: '%s'}}" alt="Kuwait flag">
+      <div>
+        <h3 id="kuwait" class="no_toc">Kuwait</h3>
+        <p>
+          <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/MY.svg?{{site.time | date: '%s'}}" alt="Malaysian flag">
       <div>
         <h3 id="malaysia" class="no_toc">Malaysia</h3>
         <p>
           <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="row marketplace">
+      <img class="marketplace-flag" src="/img/flags/OM.svg?{{site.time | date: '%s'}}" alt="Oman flag">
+      <div>
+        <h3 id="oman" class="no_toc">Oman</h3>
+        <p>
+          <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
         </p>
       </div>
     </div>
@@ -105,6 +135,16 @@ id: exchanges
     </div>
 
     <div class="row marketplace">
+      <img class="marketplace-flag" src="/img/flags/SA.svg?{{site.time | date: '%s'}}" alt="Saudi Arabia flag">
+      <div>
+        <h3 id="saudi-arabia" class="no_toc">Saudi Arabia</h3>
+        <p>
+          <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/TR.svg?{{site.time | date: '%s'}}" alt="Turkish flag">
       <div>
         <h3 id="turkey" class="no_toc">Turkey</h3>
@@ -122,6 +162,8 @@ id: exchanges
           <a class="marketplace-link" href="https://bitoasis.net/">BitOasis</a>
           <br>
           <a class="marketplace-link" href="https://karsha.biz/">Karsha</a>
+          <br>
+          <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
         </p>
       </div>
     </div>
@@ -230,7 +272,7 @@ id: exchanges
         </p>
       </div>
     </div>
-    
+
     <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/UG.svg?{{site.time | date: '%s'}}" alt="Ugandan flag">
       <div>


### PR DESCRIPTION
Requesting to add our Middle Eastern platform, [Rain.bh](https://rain.bh).

Rain officially launched and received licensure from the Central Bank of Bahrain on [July 31, 2019](https://www.coindesk.com/crypto-exchange-rain-raises-from-bitmex-opens-trading-in-middle-east). We natively support: BHD, KWD, AED, SAR, OMR, and USD. Open for signup from all jurisdictions besides US and sanctioned countries.

Follow up to https://github.com/bitcoin-dot-org/bitcoin.org/pull/3108 with conflicts resolved