### PR TITLE
FIX OS name line-height on wallet pages (#3427)

### DIFF
--- a/_sass/_wallets.scss
+++ b/_sass/_wallets.scss
@@ -328,6 +328,7 @@ $scores: good $black 600, pass $black 600, neutral $black 600, fail $black 600;
   padding: 0 25px 0 37px;
   text-transform: uppercase;
   color: #ff7e00;
+  line-height: 50px;
 }
 .wallet-accordion-btn {
   display: none;


### PR DESCRIPTION
Minor design issue with the OS name dropdown on wallet pages (mobile only) - fix #3427 

![gif](https://user-images.githubusercontent.com/8020386/88120024-9de96980-cbf4-11ea-81d4-54bb41b40d32.gif)