### PR TITLE
Adding list of Taiwanese exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -143,6 +143,18 @@ id: exchanges
         </p>
       </div>
     </div>
+      
+    <div class="row marketplace">
+      <img class="marketplace-flag" src="/img/flags/TW.svg?{{site.time | date: '%s'}}" alt="Taiwanese flag">
+      <div>
+        <h3 id="taiwan" class="no_toc">Taiwan</h3>
+        <p>
+          <a class="marketplace-link" href="https://max.maicoin.com/">MaiCoin MAX</a>
+          <br>
+          <a class="marketplace-link" href="https://www.bitopro.com/">BitoPro</a>
+        </p>
+      </div>
+    </div>
 
     <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/TR.svg?{{site.time | date: '%s'}}" alt="Turkish flag">


### PR DESCRIPTION
- Added new section for Taiwan
- Added the 2 major Taiwanese exchanges: MaiCoin MAX and BitoPro

![image](https://user-images.githubusercontent.com/8020386/88749835-bcb4a680-d186-11ea-8d2f-48d253fb4e6c.png)
