### PR TITLE
Add Coinext, a Brazilian exchange

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -381,6 +381,8 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>
+          <a class="marketplace-link" href="https://coinext.com.br/">Coinext</a>
+          <br>
           <a class="marketplace-link" href="https://www.mercadobitcoin.com.br/">Mercado Bitcoin</a>
           <br>
           <a class="marketplace-link" href="https://www.novadax.com.br/">NovaDAX</a>


### PR DESCRIPTION
Coinext is one of the top Brazilian exchanges.

This is an update to the PR https://github.com/bitcoin-dot-org/Bitcoin.org/pull/2864, which was sent a few months ago. Tell me if you guys need a test account.