### PR TITLE
Fixing visibility of a footer link

### DIFF
--- a/_includes/layout/base/footer-menu.html
+++ b/_includes/layout/base/footer-menu.html
@@ -38,9 +38,9 @@ http://opensource.org/licenses/MIT.
         <li{% if page.id == 'you-need-to-know' %} class="active"{% endif %}>
           <a href="/{{ page.lang }}/{% translate you-need-to-know url %}">{% translate menu-you-need-to-know layout %}</a>
         </li>
-        {% if page.lang == 'en' %}<li{% if page.id == 'bitcoin-paper' %} class="active"{% endif %}>
+        <li{% if page.id == 'bitcoin-paper' %} class="active"{% endif %}>
           <a href="/{{ page.lang }}/{% translate bitcoin-paper url %}">{% translate menu-white-paper layout %}</a>
-        </li>{% endif %}
+        </li>
       </ul>
     </div>
     


### PR DESCRIPTION
The footer link to the whitepapers page is only visible in the English version, despite the page exists in almost all of the translated languages.

Some examples
ES: https://bitcoin.org/es/bitcoin-documento
IT: https://bitcoin.org/it/documento-bitcoin
NL: https://bitcoin.org/nl/bitcoin-document