### PR TITLE
Linking the Catalan whitepaper

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -43,6 +43,15 @@ id: bitcoin-paper
 
         <li class="card bitcoin-paper-card">
           <a class="language-link"
+            href="/files/bitcoin-paper/bitcoin_ca.pdf">Català</a>
+          <div>
+            <span>{% translate translated_by %}</span>
+            <a href="https://vsus.io">Vicent Sus</a>
+          </div>
+        </li>
+
+        <li class="card bitcoin-paper-card">
+          <a class="language-link"
             href="/files/bitcoin-paper/bitcoin_de.pdf">Deutsch</a>
           <div>
             <span>{% translate translated_by %}</span>


### PR DESCRIPTION
In case of approval of my previous commit adding the Catalan translation of the whitepaper in a .pdf version, I'm just updating the whitepapers page to link that document. 