### PR TITLE
Add Swan Bitcoin to US exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -355,6 +355,8 @@ id: exchanges
           <a class="marketplace-link" href="https://www.itbit.com/">itBit</a>
           <br>
           <a class="marketplace-link" href="https://river.com/">River Financial</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+          <br>
+          <a class="marketplace-link" href="https://www.swanbitcoin.com/">Swan Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
         </p>
       </div>
     </div>


### PR DESCRIPTION
[Swan Bitcoin](https://www.swanbitcoin.com/) is bitcoin-only.