### PR TITLE
Add Bitclude.com into exchanges.html 

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -233,6 +233,8 @@ id: exchanges
           <h3 id="poland" class="no_toc">Poland</h3>
           <p>
             <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
+	    <br>
+            <a class="marketplace-link" href="https://bitclude.com/">BitClude</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
Second biggest exchange in Poland, operate in Bitcoin mainly, regulated in Poland.