### PR TITLE
Broken links to GitHub repo in bitcoin.org/en/bitcoin-paper

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -139,7 +139,7 @@ en:
     summary: "The paper that first introduced Bitcoin"
     description: "Satoshi Nakamoto's original paper is still recommended reading for anyone studying how Bitcoin works. Choose which translation of the paper you want to read:"
     translated_by: "translated by"
-    submit_new_translation: 'Do you want to translate the paper into your language? Visit the <a href="https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md#assisting-with-translations">Bitcoin white paper repository on GitHub</a> for instructions and <a href="https://github.com/wbnns/bitcoinwhitepaper/issues/new">open an issue</a> if you have any questions.'
+    submit_new_translation: 'Do you want to translate the paper into your language? Visit the <a href="https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md#assisting-with-translations">Bitcoin white paper repository on GitHub</a> for instructions and <a href="https://github.com/bitcoin-dot-org/Bitcoin.org/issues/new">open an issue</a> if you have any questions.'
   buy:
     title: "Buy Bitcoin"
     pagetitle: "How to buy bitcoin"

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -139,7 +139,7 @@ en:
     summary: "The paper that first introduced Bitcoin"
     description: "Satoshi Nakamoto's original paper is still recommended reading for anyone studying how Bitcoin works. Choose which translation of the paper you want to read:"
     translated_by: "translated by"
-    submit_new_translation: 'Do you want to translate the paper into your language? Visit the <a href="https://github.com/wbnns/bitcoinwhitepaper">Bitcoin white paper repository on GitHub</a> for instructions and <a href="https://github.com/wbnns/bitcoinwhitepaper/issues/new">open an issue</a> if you have any questions.'
+    submit_new_translation: 'Do you want to translate the paper into your language? Visit the <a href="https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md#assisting-with-translations">Bitcoin white paper repository on GitHub</a> for instructions and <a href="https://github.com/wbnns/bitcoinwhitepaper/issues/new">open an issue</a> if you have any questions.'
   buy:
     title: "Buy Bitcoin"
     pagetitle: "How to buy bitcoin"


### PR DESCRIPTION
While viewing `bitcoin.org/en/bitcoin-paper` I stumbled upon two broken links, at the very bottom of the page.

I believe `_translations/en.yml` is the file that is expected to be edited in this case.

I searched through @wbnns 's visible repos for replacement links since the old ones originated from one of his repos, without success, so I settled for links pointing to this repo.

0397df9 Replaces link to now point to [Assisting-with-translations.md](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md#assisting-with-translations)
f8d0420 Replaces link to now point to [Issue creation](https://github.com/bitcoin-dot-org/Bitcoin.org/issues/new)

Available if I was mistaken in the file needed to be edited and changes being needed.
