### PR TITLE
Add Bitrawr to list of exchange resources

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -62,6 +62,8 @@ id: resources
         <p>
           <a href="https://www.buybitcoinworldwide.com/">{% translate linkexchanges %}</a> - buybitcoinworldwide.com</p>
         <p>
+          <a href="https://www.bitrawr.com/">{% translate linkexchanges %}</a> - bitrawr.com</p>
+        <p>
           <a href="https://en.bitcoin.it/wiki/Category:Shopping_Cart_Interfaces">{% translate linkmerchantstools %}</a> - en.bitcoin.it</p>
         <p>
           <a href="http://www.bitcoinprojects.net/">{% translate linkprojects %}</a> - BitcoinProjects.net</p>


### PR DESCRIPTION
Bitrawr allows users to filter exchanges in their country based on price, fees, features, security, reputation, and more. With over 50k organic users per month, Bitrawr is now one of the first sites that new users see before getting their first bitcoins.