### PR TITLE
Donation: Ensure address link has full URI (incl amount)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -460,6 +460,8 @@ function generateDonationQrCode() {
 
     var text = 'bitcoin:' + generateDonationUrl(address, amount, message);
 
+    $('.donation-btc-address').attr('href', text)
+
     $('#donation-qr-code').qrcode({
         width: 150,
         height: 150,


### PR DESCRIPTION
The link on the donation link that has the URI `bitcoin:<address>` does not update when the QR code is updated. As a result clicking the link will not relay the selected amount to the application that handles it. This PR fixes this.

![image](https://user-images.githubusercontent.com/11529637/106619380-72164b80-6568-11eb-81fa-f70ca9e44e2f.png)
