### PR TITLE
Adding Coinmama to Intl, UK and UAE exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -19,7 +19,6 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
     <br>
-     <!-- Coinmama operates in 188 different countries and has been around since 2013. It deserves inclusion in here  -->
     <a class="marketplace-link" href="https://www.coinmama.com/">Coinmama</a>
     <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>
@@ -184,7 +183,6 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitoasis.net/">BitOasis</a>
           <br>
-            <!-- Coinmama operates in UAE and has been around since 2013. It deserves inclusion in here  -->
           <a class="marketplace-link" href="https://www.coinmama.com/">Coinmama</a>
           <br>
           <a class="marketplace-link" href="https://karsha.biz/">Karsha</a>
@@ -274,7 +272,6 @@ id: exchanges
           <p>
             <a class="marketplace-link" href="https://www.binance.je/">Binance</a>
             <br>
-              <!-- Coinmama operates in UK and has been around since 2013. It deserves inclusion in here  -->
             <a class="marketplace-link" href="https://www.coinmama.com/">Coinmama</a>
             <br>
             <a class="marketplace-link" href="https://bittylicious.com/">Bittylicious</a>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -19,6 +19,9 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
     <br>
+     <!-- Coinmama operates in 188 different countries and has been around since 2013. It deserves inclusion in here  -->
+    <a class="marketplace-link" href="https://www.coinmama.com/">Coinmama</a>
+    <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>
     <br>
     <a class="marketplace-link" href="https://www.okcoin.com/">OKCoin</a>
@@ -181,6 +184,9 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitoasis.net/">BitOasis</a>
           <br>
+            <!-- Coinmama operates in UAE and has been around since 2013. It deserves inclusion in here  -->
+          <a class="marketplace-link" href="https://www.coinmama.com/">Coinmama</a>
+          <br>
           <a class="marketplace-link" href="https://karsha.biz/">Karsha</a>
           <br>
           <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
@@ -267,6 +273,9 @@ id: exchanges
           <h3 id="united-kingdom" class="no_toc">United Kingdom</h3>
           <p>
             <a class="marketplace-link" href="https://www.binance.je/">Binance</a>
+            <br>
+              <!-- Coinmama operates in UK and has been around since 2013. It deserves inclusion in here  -->
+            <a class="marketplace-link" href="https://www.coinmama.com/">Coinmama</a>
             <br>
             <a class="marketplace-link" href="https://bittylicious.com/">Bittylicious</a>
             <br>


### PR DESCRIPTION
Coinmama is a reputable broker-dealer servicing customers across 188 for 8 years now. They make it super easy and secure to buy Bitcoin and should therefore be included in the Bitcoin.org exchanges section. 