### PR TITLE
Fix broken link

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -143,7 +143,7 @@ id: resources
           <a href="https://bitcoiner.guide">Bitcoiner.Guide</a>
         </p>
         <p>
-          <a href="https://node.guide">Node.Guide</a>
+          <a href="http://node.guide">Node.Guide</a>
         </p>
       </div>
 


### PR DESCRIPTION
Fix a broken link after some website consolidation. 

node.guide now resolves to bitcoiner.guide/node