### PR TITLE
Update exchanges: 'bitcoin only' tag

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -30,11 +30,11 @@ id: exchanges
   <p>
     <a class="marketplace-link" href="https://bisq.network/">Bisq</a>
     <br>
-    <a class="marketplace-link" href="https://bitquick.co/">BitQuick</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+    <a class="marketplace-link" href="https://bitquick.co/">BitQuick</a>
     <br>
     <a class="marketplace-link" href="https://localbitcoins.com/">Local Bitcoins</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
-    <a class="marketplace-link" href="https://paxful.com/">Paxful</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+    <a class="marketplace-link" href="https://paxful.com/">Paxful</a>
   </p>
 </div>
 


### PR DESCRIPTION
Remove 'bitcoin only' tag:

- BitQuick: https://bitquick.co/
-  Paxful: https://paxful.com/

## BitQuick
![image](https://user-images.githubusercontent.com/8020386/109154299-0f9c1e00-77a9-11eb-9022-3c6cd37e386f.png)

## Paxful
![image](https://user-images.githubusercontent.com/8020386/109154479-4a9e5180-77a9-11eb-9186-de4d5fb89e73.png)
