### PR TITLE
Add bit2c.co.il into exchanges.html

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -67,6 +67,8 @@ id: exchanges
       <div>
         <h3 id="israel" class="no_toc">Israel</h3>
         <p>
+          <a class="marketplace-link" href="https://bit2c.co.il/">Bit2c</a>
+          <br>
           <a class="marketplace-link" href="https://www.bitsofgold.co.il/">Bits of Gold</a>
         </p>
       </div>


### PR DESCRIPTION
Bit2C is the only exchange based in Israel and one of the first in the world.

About Bit2c: [https://bit2c.co.il/home/about](https://bit2c.co.il/home/about)

> Bit2C (ביטוסי בע"מ 514879683) was established as a cryptocurrency exchange platform in March 2013 and is one of the first exchanges to be found in the world.

> Bit2C holds a permit (No. 56980) to provide financial services according to the Financial Services Inspection Law (2016) and is pending to receive its permanent license from The Capital Market Authority.

![image](https://user-images.githubusercontent.com/8020386/109406005-8fe0a000-79b0-11eb-9453-73531d3b372f.png)

