### PR TITLE
Update exchanges: 'bitcoin only' tag

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -431,7 +431,7 @@ id: exchanges
       <div>
         <h3 id="venezuela" class="no_toc">Venezuela</h3>
         <p>
-          <a class="marketplace-link" href="https://www.cryptobuyer.io/">Cryptobuyer</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+          <a class="marketplace-link" href="https://www.cryptobuyer.io/">Cryptobuyer</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Remove 'bitcoin only' tag:
- Cryptobuyer: https://cryptobuyer.io/en/

![ezgif-1-561e10aa0e9a](https://user-images.githubusercontent.com/8020386/111118429-bfdc9580-85a3-11eb-9a9f-a5e29b3a7cc8.gif)

