### PR TITLE
Make minimum requirements accurate to improve decentralization

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -616,7 +616,7 @@ text:
   chain_gb: 340
   ## The main difference between the datadir size and the chain size, if
   ## you don't have any extra indices
-  bitcoin_datadir_gb_pruned: 5
+  bitcoin_datadir_gb_pruned: 7
   ## the tx= field in: grep UpdateTip .bitcoin/debug.log | tail -n1
   total_tx_count_in_millions: 230
   typical_ibd_time_in_hours: 4

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -190,7 +190,7 @@ have an easy-to-use node.
 * Desktop or laptop hardware running recent versions of Windows, Mac OS
   X, or Linux.
 
-* {{site.text.bitcoin_datadir_gb}} gigabytes of free disk space,
+* {{site.text.bitcoin_datadir_gb_pruned}} gigabytes of free disk space,
   accessible at a minimum read/write speed of 100 MB/s.
 
 * 2 gigabytes of memory (RAM)


### PR DESCRIPTION
The easier it is to run a full node, the more full nodes Bitcoin will have. The more full nodes Bitcoin has, the more people use full nodes, and the fewer people use custodial solutions, making bitcoin more decentralized. By noting how only 5GB of disk space is required, we can improve the decentralization of bitcoin.

This page is the page most people land on. The wording on this page talks about "minimums". While there is a separate page on the actual minimum requirements, most people will not see it, they will see this 350GB requirement and think "better use a custodial solution."