### PR TITLE
Add currency.com to list of Bitcoin Exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -47,6 +47,8 @@ id: exchanges
       <div>
         <h3 id="bahrain" class="no_toc">Bahrain</h3>
         <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
           <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
         </p>
       </div>
@@ -70,6 +72,8 @@ id: exchanges
           <a class="marketplace-link" href="https://bit2c.co.il/">Bit2c</a>
           <br>
           <a class="marketplace-link" href="https://www.bitsofgold.co.il/">Bits of Gold</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
     </div>
@@ -93,6 +97,8 @@ id: exchanges
       <div>
         <h3 id="kuwait" class="no_toc">Kuwait</h3>
         <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
           <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
         </p>
       </div>
@@ -103,6 +109,8 @@ id: exchanges
       <div>
         <h3 id="malaysia" class="no_toc">Malaysia</h3>
         <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
           <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
         </p>
       </div>
@@ -113,6 +121,8 @@ id: exchanges
       <div>
         <h3 id="oman" class="no_toc">Oman</h3>
         <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
           <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
         </p>
       </div>
@@ -124,8 +134,10 @@ id: exchanges
         <h3 id="singapore" class="no_toc">Singapore</h3>
         <p>
           <a class="marketplace-link" href="https://www.binance.sg/">Binance</a>
-	  <br>
-	  <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
+          <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
         </p>
       </div>
     </div>
@@ -139,6 +151,8 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://coinone.co.kr/">Coinone</a>
           <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
           <a class="marketplace-link" href="https://www.korbit.co.kr/">Korbit</a>
         </p>
       </div>
@@ -149,16 +163,20 @@ id: exchanges
       <div>
         <h3 id="saudi-arabia" class="no_toc">Saudi Arabia</h3>
         <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
           <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
         </p>
       </div>
     </div>
-      
+
     <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/TW.svg?{{site.time | date: '%s'}}" alt="Taiwanese flag">
       <div>
         <h3 id="taiwan" class="no_toc">Taiwan</h3>
         <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
           <a class="marketplace-link" href="https://max.maicoin.com/">MaiCoin MAX</a>
           <br>
           <a class="marketplace-link" href="https://www.bitopro.com/">BitoPro</a>
@@ -184,6 +202,8 @@ id: exchanges
           <a class="marketplace-link" href="https://bitoasis.net/">BitOasis</a>
           <br>
           <a class="marketplace-link" href="https://coinmama.net/">Coinmama</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://karsha.biz/">Karsha</a>
           <br>
@@ -214,6 +234,8 @@ id: exchanges
         <a class="marketplace-link" href="https://bitvavo.com/">Bitvavo</a>
         <br>
         <a class="marketplace-link" href="https://coinmama.net/">Coinmama</a>
+        <br>
+        <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         <br>
         <a class="marketplace-link" href="https://kriptomat.io/">Kriptomat</a>
         <br>
@@ -300,8 +322,11 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
         </p>
-          <p>
+        <p>
           <a class="marketplace-link" href="https://buycoins.africa/">BuyCoins</a>
+        </p>
+        <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
     </div>
@@ -310,6 +335,9 @@ id: exchanges
       <img class="marketplace-flag" src="/img/flags/ZA.svg?{{site.time | date: '%s'}}" alt="South African flag">
       <div>
         <h3 id="south-africa" class="no_toc">South Africa</h3>
+        <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+        </p>
         <p>
           <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
         </p>
@@ -322,6 +350,9 @@ id: exchanges
         <h3 id="uganda" class="no_toc">Uganda</h3>
         <p>
           <a class="marketplace-link" href="https://www.binance.co.ug/">Binance</a>
+        </p>
+        <p>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
     </div>
@@ -349,7 +380,7 @@ id: exchanges
           <a class="marketplace-link" href="https://www.coinsmart.com/">Coinsmart</a>
           <br>
 	  <a class="marketplace-link" href="https://ndax.io/">NDAX</a>
-          <br>	
+          <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>
         </p>
       </div>
@@ -361,6 +392,8 @@ id: exchanges
         <h3 id="mexico" class="no_toc">Mexico</h3>
         <p>
           <a class="marketplace-link" href="https://bitso.com/">Bitso</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.volabit.com/">Volabit</a>
         </p>
@@ -403,6 +436,8 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://argenbtc.com/">ArgenBTC</a>
           <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>
         </p>
       </div>
@@ -416,6 +451,8 @@ id: exchanges
           <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>
           <a class="marketplace-link" href="https://coinext.com.br/">Coinext</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.mercadobitcoin.com.br/">Mercado Bitcoin</a>
           <br>
@@ -432,6 +469,8 @@ id: exchanges
         <h3 id="chile" class="no_toc">Chile</h3>
         <p>
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
     </div>
@@ -442,6 +481,8 @@ id: exchanges
         <h3 id="colombia" class="no_toc">Colombia</h3>
         <p>
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
     </div>
@@ -452,6 +493,8 @@ id: exchanges
         <h3 id="peru" class="no_toc">Peru</h3>
         <p>
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
     </div>
@@ -462,6 +505,8 @@ id: exchanges
         <h3 id="venezuela" class="no_toc">Venezuela</h3>
         <p>
           <a class="marketplace-link" href="https://www.cryptobuyer.io/">Cryptobuyer</a>
+          <br>
+          <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
This PR adds currency.com to the list of Bitcoin Exchanges

Links:

Site functionality: https://currency.com/
Operational processes: https://currency.com/s-center
Rates and fees: https://currency.com/fees-charges
Order book: https://currency.com/tokenized-securities-overview
Policies, terms, and conditions: https://currency.com/agreement
Press and community feedback: https://apps.apple.com/by/app/currency-com-crypto-exchange/id1458917114
Leadership: https://currency.com/about-us

Links were added to the next locations:

Asia: Bahrain, Malaysia, Taiwan, Israel, Kuwait, Oman, South Korea, Saudi Arabia, Singapore, UAE
EU: without specification
Africa: Nigeria, South Africa, Uganda
North America: Mexico
South Africa: Argentina, Chile , Peru, Brazil, Venezuela, Colombia