### PR TITLE
Updated whitepaper Romanian translator name in web page to match the pdf

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -167,7 +167,7 @@ id: bitcoin-paper
             href="/files/bitcoin-paper/bitcoin_ro.pdf">Română</a>
           <div>
             <span>{% translate translated_by %}</span>
-            <a href="https://github.com/IkeGDB">IkeGDB</a>
+            <a href="https://bitcointalk.org/index.php?action=profile;u=1285797">Gazeta Bitcoin</a>
           </div>
         </li>
 


### PR DESCRIPTION
Hi.

As discussed in the actual whitepaper (Romanian translation) related pull request ( https://github.com/bitcoin-dot-org/Bitcoin.org/pull/3630 ) I've made the update in the actual web page's template too.

Thank you.
