### PR TITLE
Add Norwegian Block Exchange to Denmark & Sweden sections of exchange list

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -253,6 +253,16 @@ id: exchanges
     <div class="marketplace-row">
 
       <div class="row marketplace">
+        <img class="marketplace-flag" src="/img/flags/DK.svg?{{site.time | date: '%s'}}" alt="Danish flag">
+        <div>
+          <h3 id="denmark" class="no_toc">Denmark</h3>
+          <p>
+            <a class="marketplace-link" href="https://nbx.com/">Norwegian Block Exchange</a>
+          </p>
+        </div>
+      </div>
+
+      <div class="row marketplace">
         <img class="marketplace-flag" src="/img/flags/NL.svg?{{site.time | date: '%s'}}" alt="Dutch flag">
         <div>
           <h3 id="netherlands" class="no_toc">Netherlands</h3>
@@ -267,7 +277,7 @@ id: exchanges
         <div>
           <h3 id="norway" class="no_toc">Norway</h3>
           <p>
-            <a class="marketplace-link" href="https://nbx.com/">Norwegian Block Exchange</a>
+            <a class="marketplace-link" href="https://nbx.com/no">Norwegian Block Exchange</a>
           </p>
         </div>
       </div>
@@ -278,8 +288,18 @@ id: exchanges
           <h3 id="poland" class="no_toc">Poland</h3>
           <p>
             <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
-	    <br>
+            <br>
             <a class="marketplace-link" href="https://bitclude.com/">BitClude</a>
+          </p>
+        </div>
+      </div>
+
+      <div class="row marketplace">
+        <img class="marketplace-flag" src="/img/flags/SE.svg?{{site.time | date: '%s'}}" alt="Swedish flag">
+        <div>
+          <h3 id="sweden" class="no_toc">Sweden</h3>
+          <p>
+            <a class="marketplace-link" href="https://nbx.com/sv">Norwegian Block Exchange</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
Adds Norwegian Block Exchange to new Denmark & Sweden sub-sections of the exchange list, since we now support DKK & SEK.

See https://nbx.com & https://nbxsupport.zendesk.com/hc/en-us/articles/360061188391-SEK-DKK-currencies-available-for-depositing