### PR TITLE
Fix download page to use pruned size

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -560,7 +560,7 @@ en:
     source: "Source code"
     versionhistory: "Show version history"
     notelicense: "Bitcoin Core is a community-driven <a href=\"https://www.fsf.org/about/what-is-free-software\">free software</a> project, released under the <a href=\"http://opensource.org/licenses/mit-license.php\">MIT license</a>."
-    notesync: "Bitcoin Core initial synchronization will take time and download a lot of data. You should make sure that you have enough bandwidth and storage for the full block chain size (over {{site.text.bitcoin_datadir_gb}}GB). If you have a good Internet connection, you can help strengthen the network by keeping your PC running with Bitcoin Core and port 8333 open."
+    notesync: "Bitcoin Core initial synchronization will take time and download a lot of data. You should make sure that you have enough bandwidth and storage for the block chain size ({{site.text.bitcoin_datadir_gb_pruned}}GB). If you have a good Internet connection, you can help strengthen the network by keeping your PC running with Bitcoin Core and port 8333 open."
     full_node_guide: "Read the <a href=\"/en/full-node\">full node guide</a> for details."
     patient: "Check your bandwidth and space"
     releasekeys: "Bitcoin Core Release Signing Keys"


### PR DESCRIPTION
This is a follow up to #3624. (In summary, a pruned node is a fully verifying node, capable of strengthening Bitcoin in the hands of economic actors and away from custodians that operate full nodes. It uses significantly less disk space, which encourages more people to run full nodes.)

> You should make sure that you have enough bandwidth and storage for the full block chain size (over 350GB).

This pull request changes it to the following:

> You should make sure that you have enough bandwidth and storage for the block chain size (7GB).

- Changes "full block chain size" to "block chain size"
- Changes "over 350GB" to "7GB"

This only changes the English version.

There is an open draft pull request to my version to add translations: crazypython/Bitcoin.org#1

Translators are welcome to translate this change. I would do it myself (removing words that I guess mean "over" and "full"), though there is a chance I will make a mistake while doing so.