### PR TITLE
Add CoinConsume to "navigate a business directory" section

### DIFF
--- a/_translations/de.yml
+++ b/_translations/de.yml
@@ -1018,7 +1018,7 @@ de:
     products-online: "Finden Sie Produkte, die online zum Verkauf stehen"
     products-online-text: "Ein gebräuchlicher Verwendungszweck für Bitcoin ist der Online-Kauf. Es gibt hunderte Online-Shops und Einzelhändler, die Bitcoin akzeptieren. Mit einer Suchmaschine wie <a href=\"https://spendabit.co/\">Spendabit</a> können Sie nach Millionen von Produkten suchen, die alle mit Bitcoins bezahlt werden können."
     directory: "Durchstöbern Sie ein Branchenverzeichnis"
-    directory-text: "Sie können auch viele Unternehmen über <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">Online-Verzeichnisse</a> finden."
+    directory-text: "Sie können auch viele Unternehmen über Online-Verzeichnisse finden : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Finden Sie lokale Unternehmen"
     business-map-text: "Es gibt auch viele lokale Unternehmen wie Cafés und Restaurants, die Bitcoin akzeptieren. Sie können <a href=\"https://coinmap.org/\">Coinmap.org</a> nutzen, um Tausende von Unternehmen auf der ganzen Welt zu finden."
   support-bitcoin:

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -1044,7 +1044,7 @@ en:
     products-online: "Find products for sale online"
     products-online-text: "One common use for Bitcoin is making purchases online. There are hundreds of online shops and retailers that accept Bitcoin. Using a search engine like <a href=\"https://spendabit.co/\">Spendabit</a> you can search through millions of products, all available for purchase with bitcoins."
     directory: "Navigate a business directory"
-    directory-text: "You can also find many businesses listed in <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">online directories</a>."
+    directory-text: "You can also find many businesses listed in online directories : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Find local businesses"
     business-map-text: "There are also many local businesses, like cafes and restaurants, that accept Bitcoin. You can use <a href=\"https://coinmap.org/\">Coinmap.org</a> to browse thousands of businesses across the globe."
     business-search: "Global local and online business search"

--- a/_translations/hu.yml
+++ b/_translations/hu.yml
@@ -933,7 +933,7 @@ hu:
     products-online: "Eladó termékek keresése online"
     products-online-text: "A bitcoin egyik szokásos felhasználási területe az online vásárlás. Ma már több száz online üzletben és kereskedőnél lehet bitcoinnal fizetni. Az olyan keresőszolgáltatásokkal, mint például a <a href=\"https://spendabit.co/\">Spendabit</a> milliónyi, bitcoinnal megvásárolható termék között kereshetünk."
     directory: "Keresés a cégnyilvántartásban"
-    directory-text: "Számos vállalkozást találhatsz az <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">online címjegyzékben</a> is."
+    directory-text: "Számos vállalkozást találhatsz az online címjegyzékben is : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Helyi vállalkozások keresése"
     business-map-text: "Rengeteg helyi vállalkozás van, mint kávézók és éttermek, amik elfogadnak bitcoint. Használd a <a href=\"https://coinmap.org/\">Coinmap.org</a> oldalt, hogy világszerte több ezer vállalkozás között böngészhess."
   support-bitcoin:

--- a/_translations/id.yml
+++ b/_translations/id.yml
@@ -1007,7 +1007,7 @@ id:
     products-online: "Mencari produk yang dijual online"
     products-online-text: "Salah satu kegunaan Bitcoin adalah untuk melakukan pembelian online. Terdapat ratusan toko online dan pengecer yang menerima Bitcoin. Dengan menggunakan mesin pencarian seperti <a href=\"https://spendabit.co/\">Spendabit</a> Anda bisa melihat jutaan produk, yang semua tersedia untuk dibeli dengan bitcoin."
     directory: "Menjelajah direktori bisnis"
-    directory-text: "Anda juga bisa mencari banyak bisnis yang terdaftar di <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">direktori online</a>."
+    directory-text: "Anda juga bisa mencari banyak bisnis yang terdaftar di direktori online : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Mencari bisnis lokal"
     business-map-text: "Terdapat pula banyak bisnis lokal, seperti kafe dan restoran, yang menerima Bitcoin. Anda bisa menggunakan <a href=\"https://coinmap.org/\">Coinmap.org</a> untuk mencari ribuan bisnis di seluruh dunia."
   support-bitcoin:

--- a/_translations/it.yml
+++ b/_translations/it.yml
@@ -1011,7 +1011,7 @@ it:
     products-online: "Trova prodotti in vendita online"
     products-online-text: "Un uso comune dei Bitcoin è lo shopping online. Ci sono centinaia di negozi online e rivenditori che accettano Bitcoin. Usando un motore di ricerca come <a href=\"https://spendabit.co/\">Spendabit</a> puoi cercare tra milioni di prodotti, tutti acquistabili tramite i bitcoins."
     directory: "Naviga in una categoria di commercio"
-    directory-text: "Puoi anche trovare altre attività elencate in <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">categorie online</a>"
+    directory-text: "Puoi anche trovare altre attività elencate in categorie online : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Trova attività commerciali locali"
     business-map-text: "Ci sono anche molte attività commerciali, come bar e ristoranti, che accettano Bitcoin. Puoi utilizzare <a href=\"https://coinmap.org/\">Coinmap.org</a> per esplorare migliaia di attività commerciali situate in tutto il mondo."
   support-bitcoin:

--- a/_translations/ja.yml
+++ b/_translations/ja.yml
@@ -937,7 +937,7 @@ ja:
     products-online: "オンライン上で販売されている製品を探す。"
     products-online-text: "ビットコインの一般的な利用方法の一つはオンラインでの商品購入です。ビットコインを利用可能なオンラインショップや小売業者は数百件にものぼります。<a href=\"https://spendabit.co/\">Spendabit</a>等の検索エンジンを使用し、ビットコインで購入可能な数百万点の製品を検索可能です。"
     directory: "ビジネスディレクトリの案内"
-    directory-text: "<a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">オンライン・ディレクトリ</a>にも沢山のビジネスがリストアップされています。"
+    directory-text: "<ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul> : オンライン・ディレクトリ にも沢山のビジネスがリストアップされています。"
     business-map: "各地域のビジネスを探す。"
     business-map-text: "カフェやレストラン等、ビットコインを受け付けている多くの地域ビジネスが存在します。<a href=\"https://coinmap.org/\">Coinmap.org</a>にアクセスすれば、世界中に存在する数千のビジネスを閲覧する事ができます。"
   support-bitcoin:

--- a/_translations/nl.yml
+++ b/_translations/nl.yml
@@ -1012,7 +1012,7 @@ nl:
     products-online: "Vind producten die online te koop zijn"
     products-online-text: "Een veel voorkomend gebruik voor Bitcoin is het doen van online aankopen. Er zijn honderden online winkels en winkeliers die Bitcoin accepteren. Met behulp van een zoekmachine als <a href=\"https://spendabit.co/\">Spendabit</a> kunt u door miljoenen producten zoeken, die allemaal beschikbaar zijn om met bitcoins te kopen."
     directory: "Navigeer door de bedrijvengids."
-    directory-text: "U kunt ook veel bedrijven vinden die in online <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">directories</a> staan vermeld."
+    directory-text: "U kunt ook veel bedrijven vinden die in online directories staan vermeld : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Vind bedrijven bij u in de buurt"
     business-map-text: "Er zijn ook veel lokale ondernemingen, zoals cafés en restaurants die Bitcoin accepteren. U kunt <a href=\"https://coinmap.org/\">Coinmap.org</a> gebruiken om te bladeren door duizenden van deze  ondernemingen over de hele wereld."
   support-bitcoin:

--- a/_translations/pt_BR.yml
+++ b/_translations/pt_BR.yml
@@ -1007,7 +1007,7 @@ pt_BR:
     products-online: "Encontre produtos à venda online"
     products-online-text: "Um dos usos comuns do Bitcoin é fazer compras online. Existem centenas de lojas online e varejos que aceitam Bitcoin. Usando um buscador como <a href=\"https://spendabit.co/\">Spendabit</a>, você consegue pesquisar por milhões de produtos, todos disponíveis para compra com bitcoins."
     directory: "Navegue por um diretório comercial"
-    directory-text: "Você também pode encontrar muitas empresas listadas em <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">diretórios online</a>."
+    directory-text: "Você também pode encontrar muitas empresas listadas em diretórios online : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Encontre empresas locais"
     business-map-text: "Há também muitos negócios locais, como cafeterias e restaurantes, que aceitam Bitcoin. Você pode usar <a href=\"https://coinmap.org/\">Coinmap.org</a> para pesquisar milhares de negócios em todo o mundo."
   support-bitcoin:

--- a/_translations/ru.yml
+++ b/_translations/ru.yml
@@ -714,7 +714,7 @@ ru:
     products-online: "Найти товары в продаже онлайн"
     products-online-text: "Биткойн часто используется для покупок онлайн. Существуют сотни онлайн-магазинов и продавцов, которые принимают Биткойн. Используя поисковую систему по типу <a href=\"https://spendabit.co/\">Spendabit</a> Вы можете найти миллионы товаров доступные за Биткойн."
     directory: "Просмотрите каталог предприятий"
-    directory-text: "Вы также можете найти множество предприятий, перечисленных в <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">онлайн каталогах</a>."
+    directory-text: "Вы также можете найти множество предприятий, перечисленных в онлайн каталогах : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Найдите местные предприятия"
     business-map-text: "Существует также много локальных компаний, например, кафе и рестораны, которые принимают Биткойн. Вы можете использовать  <a href=\"https://coinmap.org/\">Coinmap.org</a>, чтобы просмотреть тысячи предприятий по всей планете."
   support-bitcoin:

--- a/_translations/sr.yml
+++ b/_translations/sr.yml
@@ -1004,7 +1004,7 @@ sr:
     products-online: "Nađite proizvode koji se prodaju na internetu"
     products-online-text: "Jedno učestalo svojstvo korišćenja Bitkoina je kupovina preko interneta. Na stotine prodavnica i trgovaca prihvata Bitkoin. Koristite pretraživač poput <a href=\"https://spendabit.co/\">Spendhabit-a</a> kako bi pretražili milione proizvoda koje možete platiti bitkoinima."
     directory: "Surfujte direktorujmom poslovnih subjekta"
-    directory-text: "Možete naći veliki broj listi biznisa koje prihvataju Bitkoin na <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">onlajn direktorijumima</a>."
+    directory-text: "Možete naći veliki broj listi biznisa koje prihvataju Bitkoin na onlajn direktorijumima : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Nađite lokalni biznis"
     business-map-text: "Postoji mnoštvo lokalnih poslovnih subjeata, poput kafića, restorana, koji prihvataju Bitkoin. Možete koristiti <a href=\"https://coinmap.org/\">Coinmap.org</a> kako pretražili na hiljade restorana i trgovaca širom sveta koji prihvataju Bitkoin."
   support-bitcoin:

--- a/_translations/sv.yml
+++ b/_translations/sv.yml
@@ -1005,7 +1005,7 @@ sv:
     products-online: "Hitta produkter att köpa på nätet"
     products-online-text: "Ett vanligt sätt att använda Bitcoin är att handla online. Det finns hundratals butiker och återförsäljare på internet som accepterar Bitcoin. Genom att använda en sökmotor som <a href=\"https://spendabit.co/\">Spendabit</a> kan du söka bland miljontals produkter som alla går att köpa med bitcoin."
     directory: "Bläddra i en företagskatalog"
-    directory-text: "Du kan också hitta många företag listade i <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">onlinekataloger</a>."
+    directory-text: "Du kan också hitta många företag listade i onlinekataloger : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Hitta lokala företag"
     business-map-text: "Det finns också många lokala företag, till exempel kaféer och restauranger, som accepterar Bitcoin. Du kan använda <a href=\"https://coinmap.org/\">Coinmap.org</a> för att bläddra bland tusentals företag runt om i världen som accepterar Bitcoin."
   support-bitcoin:

--- a/_translations/uk.yml
+++ b/_translations/uk.yml
@@ -788,7 +788,7 @@ uk:
     products-online: "Знайти продукти для покупок онлайн"
     products-online-text: "Одне спільне використання біткойн - це робити покупки в Інтернеті. Є сотні інтернет-магазинів та роздрібних торговців, які приймають біткойн. Використовуючи пошукову систему, таку як <a href=\"https://spendabit.co/\">Spendabit</a>, ви можете знайти мільйони продуктів, усі доступні для покупки біткойнами."
     directory: "Перегляньте бізнес-каталог"
-    directory-text: "Ви також можете знайти багато підприємств, перелічених у <a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">онлайн-каталогах</a>."
+    directory-text: "Ви також можете знайти багато підприємств, перелічених у онлайн-каталогах : <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "Знайдіть місцевий бізнес"
     business-map-text: "Є також багато місцевих підприємств, таких як кафе та ресторани, які приймають біткойни. Ви можете використовувати <a href=\"https://coinmap.org/\">Coinmap.org</a> для перегляду тисяч підприємств у всьому світі."
   support-bitcoin:

--- a/_translations/zh_CN.yml
+++ b/_translations/zh_CN.yml
@@ -741,7 +741,7 @@ zh_CN:
     products-online: "寻找在线销售的产品"
     products-online-text: "一个共同的比特币使用就是在线购物。有成百上千的在线商店与零售商都接受比特币。使用像<a href=\"https://spendabit.co/\">Spendabit</a>这样的搜索引擎您就可以搜索几百万种产品，这些都是用比特币可以购买的商品。"
     directory: "浏览一个企业目录"
-    directory-text: "您也可以在<a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">在线目录</a>中找到许多企业。"
+    directory-text: "您也可以在 在线目录 中找到许多企业。: <ul><li><a href=\"https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/\">99bitcoins.com</a></li><li><a href=\"https://www.coinconsume.com/pay-with/bitcoin/\">CoinConsume</a></li></ul>"
     business-map: "找到本地企业"
     business-map-text: "也有许多本地企业，例如咖啡馆和餐馆，他们也接受比特币。您可以使用<a href=\"https://coinmap.org/\">coinmap.org</a>来浏览全球成千上万的企业。"
   support-bitcoin:


### PR DESCRIPTION
CoinConsume is a tool that helps you to find websites where you can spend your cryptocurrencies.
A page dedicated for Bitcoin is available : https://www.coinconsume.com/pay-with/bitcoin/
I moved 99bitcoins.com into a list with CoinConsume below.