### PR TITLE
Add Coinconsume to the list of link merchants in Resources

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -60,6 +60,8 @@ id: resources
         <p>
           <a href="https://99bitcoins.com/who-accepts-bitcoins-payment-companies-stores-take-bitcoins/">{% translate linkmerchants %}</a> - 99Bitcoins.com</p>
         <p>
+          <a href="http://www.coinconsume.com/pay-with/bitcoin">{% translate linkmerchants %}</a> - CoinConsume.com</p>
+        <p>
           <a href="https://www.buybitcoinworldwide.com/">{% translate linkexchanges %}</a> - buybitcoinworldwide.com</p>
         <p>
           <a href="https://www.bitrawr.com/">{% translate linkexchanges %}</a> - bitrawr.com</p>


### PR DESCRIPTION
CoinConsume is a tool that helps you to find websites where you can spend your cryptocurrencies.
A page dedicated for Bitcoin is available : https://www.coinconsume.com/pay-with/bitcoin/
It can be great to add this to the existing list, and help people to find how and where to spend their bitcoins.