### PR TITLE
_wallets/bitbox: add multisig to the features list

### DIFF
--- a/_wallets/bitbox.md
+++ b/_wallets/bitbox.md
@@ -16,7 +16,7 @@ platform:
         link: "https://shiftcrypto.ch/bitbox02/"
         source: "https://github.com/digitalbitbox/bitbox02-firmware"
         screenshot: "bitbox02.png"
-        features: "bech32 hardware_wallet legacy_addresses segwit"
+        features: "bech32 hardware_wallet legacy_addresses multisig segwit"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"


### PR DESCRIPTION
The BitBox02 has had multisig support for quite a while.

https://hwi.readthedocs.io/en/latest/devices/index.html#support-matrix

https://github.com/digitalbitbox/bitbox02-firmware/pulls?q=is%3Apr+multisig+is%3Aclosed