### PR TITLE
Add mirror(s) below the official website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Current Build Status: ![Build Status](https://travis-ci.org/bitcoin-dot-org/bitc
 
 Live site: [Bitcoin.org](https://bitcoin.org)
 
+Mirror sites: [Bitcoin.melroy.org](https://bitcoin.melroy.org)
+
 Report problems or help improve the site by opening a [new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new) or [pull request](https://github.com/bitcoin-dot-org/bitcoin.org/compare).
 
 ## Earn Bitcoin for Contributing


### PR DESCRIPTION
Due to censorship, but GitHub.com is not blocked. According to [OONI](https://explorer.ooni.org/)

Fixes #3712