### PR TITLE
Rename coinmana.net to coinmana.com. Remove obsolete binance.je (Jersey)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -206,7 +206,7 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitoasis.net/">BitOasis</a>
           <br>
-          <a class="marketplace-link" href="https://coinmama.net/">Coinmama</a>
+          <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
@@ -228,10 +228,8 @@ id: exchanges
       <p>
         <a class="marketplace-link" href="https://anycoindirect.eu">AnyCoin Direct</a>
         <br>
-        <a class="marketplace-link" href="https://www.binance.je/">Binance</a>
-        <br>
         <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>
-	<br>
+	      <br>
         <a class="marketplace-link" href="https://bitfinex.com/">Bitfinex</a>
         <br>
         <a class="marketplace-link" href="https://bitflyer.com/en-eu/">bitFlyer</a>
@@ -240,7 +238,7 @@ id: exchanges
         <br>
         <a class="marketplace-link" href="https://bitvavo.com/">Bitvavo</a>
         <br>
-        <a class="marketplace-link" href="https://coinmama.net/">Coinmama</a>
+        <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
         <br>
         <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         <br>
@@ -301,17 +299,15 @@ id: exchanges
         <div>
           <h3 id="united-kingdom" class="no_toc">United Kingdom</h3>
           <p>
-            <a class="marketplace-link" href="https://www.binance.je/">Binance</a>
-            <br>
             <a class="marketplace-link" href="https://bittylicious.com/">Bittylicious</a>
             <br>
             <a class="marketplace-link" href="https://www.coincorner.com/">CoinCorner</a>
             <br>
             <a class="marketplace-link" href="https://www.coinfloor.co.uk/">Coinfloor</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
             <br>
-	    <a class="marketplace-link" href="https://www.coinjar.com/uk/">CoinJar</a>
+	          <a class="marketplace-link" href="https://www.coinjar.com/uk/">CoinJar</a>
             <br>
-            <a class="marketplace-link" href="https://coinmama.net/">Coinmama</a>
+            <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
           </p>
         </div>
       </div>
@@ -418,7 +414,7 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://bittrex.com/">Bittrex</a>
           <br>
-          <a class="marketplace-link" href="https://coinmama.net/">Coinmama</a>
+          <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
           <br>
           <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
           <br>


### PR DESCRIPTION
Update exchanges page. See title.