### PR TITLE
Add Wasabi Wallet for New Users

### DIFF
--- a/_wallets/wasabi.md
+++ b/_wallets/wasabi.md
@@ -6,6 +6,7 @@ id: wasabi
 title: "Wasabi Wallet"
 titleshort: "Wasabi"
 compat: "desktop windows mac linux"
+user: beginner
 level: 3
 platform:
   - desktop:


### PR DESCRIPTION
Wasabi is currently only recommended for advanced users. Providing Wasabi Wallet as a recommendation for new users makes sense now since the release of Wasabi 2.0 earlier in June 2022. The on-boarding user experience has been simplified to abstract away complexity from the end user, without compromising on privacy. A total redesign of the client was released allowing less technical users to use a bitcoin wallet that has privacy by default. More can be done to make it even simpler, of course, but it is a step in the right direction for mainstream bitcoin privacy. 