### PR TITLE
Bitcoin Core Download: redirect to BitcoinCore.org download page

### DIFF
--- a/_includes/bitcoin-core/download-bitcoin-core.html
+++ b/_includes/bitcoin-core/download-bitcoin-core.html
@@ -4,9 +4,8 @@ http://opensource.org/licenses/MIT.
 {% endcomment %}
 
 <div class="callout">
-  <a class="callout-btn btn-bright" href="/{{page.lang}}/{% translate download url %}">Download Bitcoin Core</a>
+  <a class="callout-btn btn-bright" href="https://bitcoincore.org/en/download/">Download Bitcoin Core</a>
   <div class="row callout-row">
-    <span class="btn-subtext">Bitcoin Core {{ site.DOWNLOAD_VERSION }}</span>
     <div>
       <img class="callout-img" src="/img/os/windows.png?{{site.time | date: '%s'}}" alt="Windows">
       <img class="callout-img" src="/img/os/mac.png?{{site.time | date: '%s'}}" alt="Mac">


### PR DESCRIPTION
All Bitcoin Core download links on the website currently use version 22.0, which was released in September 2021.  Newer releases are being published on BitcoinCore.org, so this PR updates the download box to redirect to that website.

I've previewed this update locally; the updated download box looks like this:

![latest](https://user-images.githubusercontent.com/61096/225974910-bbaecf9e-0155-4b7f-aef7-5e1be4d793ab.png)

(The main difference from the existing box being that it doesn't list a specific version.)

When running tests, I encountered pre-existing errors unrelated to this change so I was not able to fully test.