### PR TITLE
Updating brazilian exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -465,7 +465,7 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.novadax.com.br/">NovaDAX</a>
           <br>
-          <a class="marketplace-link" href="https://walltime.info/">Walltime</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+          <a class="marketplace-link" href="https://bipa.app/">Bipa</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
         </p>
       </div>
     </div>


### PR DESCRIPTION
Walltime was discontinued (source: https://twitter.com/walltimedotinfo/status/1623532135041888256)

Bipa is a bitcoin-only exchange operating for about 3 years:
https://bipa.app/
https://twitter.com/usebipa