### PR TITLE
Slovencina is not Slovenščina

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -181,7 +181,7 @@ id: bitcoin-paper
 
         <li class="card bitcoin-paper-card">
           <a class="language-link"
-            href="/files/bitcoin-paper/bitcoin_sk.pdf">Slovenščina</a>
+            href="/files/bitcoin-paper/bitcoin_sk.pdf">Slovenčina</a>
           <div>
             <span>{% translate translated_by %}</span>
             <a href="https://github.com/OndroS">Ondrej Sarnecký</a>


### PR DESCRIPTION
While we will upload the Slovenian translation of the whitepaper very soon, there's a conflict with a typo in the Slovak whitepaper version title that I've fixed with this pull request. 

**Explanation**

_Slovenčina_ is the Slovak language. In comparison, _Slovenščina_ is the Slovene language. Two different countries and nations.

Can you see the difference where one "š" is missing?

🇸🇰 (sk) Slovak language = Slovenčina
🇸🇮 (si) Slovenian language = Slovenščina

Country flags are also very similar

