### PR TITLE
Add Hodl Hodl to the list of Peer-to-Peer (P2P) exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -35,6 +35,8 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://bitquick.co/">BitQuick</a>
     <br>
+    <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
+    <br>
     <a class="marketplace-link" href="https://localbitcoins.com/">Local Bitcoins</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://paxful.com/">Paxful</a>


### PR DESCRIPTION
Dear Bitcoin.org team,
We would like to submit a request to be listed in the Peer-to-Peer (P2P) section on https://bitcoin.org/en/exchanges#international
Regards,
Hodl Hodl team