### PR TITLE
Edit copy for “Download Bitcoin Core, Latest Version 22.0” on bitcoin.org 

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -551,7 +551,7 @@ en:
   download:
     title: "Download - Bitcoin"
     pagetitle: "Download Bitcoin Core"
-    latestversion: "Latest version:"
+    latestversion: "Version:"
     download: "Download Bitcoin Core"
     downloados: "Or choose your operating system"
     downloadsig: "Verify release signatures"


### PR DESCRIPTION
Currently, [ https://bitcoin.org/en/download](https://bitcoin.org/en/download) says “Download Bitcoin Core Latest Version: 22.0”. This is confusing because[ https://bitcoincore.org/en/download/](https://bitcoincore.org/en/download/) points to 24.0.1 as the latest version.

It would be more accurate to drop the word “latest” and simply say “Download Bitcoin Core Version: X” 

Note, someone will need to update the same page in different languages. 

Additionally, this page could point to [ bitcoincore.org](http://bitcoincore.org/) and say something like “More information about past releases and the latest version can be found on[ bitcoincore.org](http://bitcoincore.org/).”