### PR TITLE
Add Bitcoin Well to - exchanges.html

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -378,6 +378,8 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitbuy.ca/">Bitbuy</a>
           <br>
+          <a class="marketplace-link" href="https://www.bitcoinwell.com/">Bitcoin Well</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+          <br>
           <a class="marketplace-link" href="https://bitvo.com/">Bitvo</a>
           <br>
           <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">


### PR DESCRIPTION
Adding Bitcoin Well to the list of exchanges in North America. 

We have been helping people buy, sell and learn about bitcoin since 2013. We have been publically traded in Canada since 2021. 

We are the fastest and safest way to buy non-custodial bitcoin in Canada