### PR TITLE
Add Bitcoin Core 25.1 release

### DIFF
--- a/_releases/v25.1.md
+++ b/_releases/v25.1.md
@@ -1,0 +1,147 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 25.1
+title: Bitcoin Core 25.1
+id: en-release-25.1
+name: release-25.1
+permalink: /en/releases/25.1/
+excerpt: Bitcoin Core version 25.1 is now available
+date: 2023-10-20
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [25, 1]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink: "magnet:?xt=urn:btih:aa13e74abc8e389d4271813e9d0415890f9d8058&dn=bitcoin-core-25.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969&ws=http%3A%2F%2Fbitcoincore.org%2Fbin%2F"
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+
+{% githubify https://github.com/bitcoin/bitcoin %}
+25.1 Release Notes
+==================
+
+Bitcoin Core version 25.1 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-25.1/>
+
+This release includes various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and extensively tested on operating systems
+using the Linux kernel, macOS 10.15+, and Windows 7 and newer.  Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them.  It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### P2P
+
+- #27626 Parallel compact block downloads, take 3
+- #27743 p2p: Unconditionally return when compact block status == READ_STATUS_FAILED
+
+### Fees
+
+- #27622 Fee estimation: avoid serving stale fee estimate
+
+### RPC
+
+- #27727 rpc: Fix invalid bech32 address handling
+
+### Rest
+
+- #27853 rest: fix crash error when calling /deploymentinfo
+- #28551 http: bugfix: allow server shutdown in case of remote client disconnection
+
+### Wallet
+
+- #28038 wallet: address book migration bug fixes
+- #28067 descriptors: do not return top-level only funcs as sub descriptors
+- #28125 wallet: bugfix, disallow migration of invalid scripts
+- #28542 wallet: Check for uninitialized last processed and conflicting heights in MarkConflicted
+
+### Build
+
+- #27724 build: disable boost multi index safe mode in debug mode
+- #28097 depends: xcb-proto 1.15.2
+- #28543 build, macos: Fix qt package build with new Xcode 15 linker
+- #28571 depends: fix unusable memory_resource in macos qt build
+
+### Gui
+
+- gui#751 macOS, do not process actions during shutdown
+
+### Miscellaneous
+
+- #28452 Do not use std::vector = {} to release memory
+
+### CI
+
+- #27777 ci: Prune dangling images on RESTART_CI_DOCKER_BEFORE_RUN
+- #27834 ci: Nuke Android APK task, Use credits for tsan
+- #27844 ci: Use podman stop over podman kill
+- #27886 ci: Switch to amd64 container in "ARM" task
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Abubakar Sadiq Ismail
+- Andrew Chow
+- Bruno Garcia
+- Gregory Sanders
+- Hennadii Stepanov
+- MacroFake
+- Matias Furszyfer
+- Michael Ford
+- Pieter Wuille
+- stickies-v
+- Will Clark
+
+As well as to everyone that helped with translations on
+[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+
+{% endgithubify %}
+
+</div>


### PR DESCRIPTION
Similar to #4078.
See also https://github.com/bitcoin-core/bitcoincore.org/pull/991.