### PR TITLE
Add dzengi.com to list of Bitcoin Exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -11,7 +11,7 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 class="exchanges-tab-title exchanges-international-title" id="international">International</h2>
   <p>
-	  
+
     <a class="marketplace-link" href="https://www.bitfinex.com/">Bitfinex</a>
     <br>
     <a class="marketplace-link" href="https://www.bitstamp.net/">Bitstamp</a>
@@ -55,6 +55,8 @@ id: exchanges
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -65,6 +67,8 @@ id: exchanges
         <h3 id="indonesia" class="no_toc">Indonesia</h3>
         <p>
           <a class="marketplace-link" href="https://indodax.com/">Indodax</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -131,6 +135,8 @@ id: exchanges
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.rain.bh/">Rain</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -405,6 +411,8 @@ id: exchanges
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.volabit.com/">Volabit</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -448,6 +456,8 @@ id: exchanges
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -474,6 +484,8 @@ id: exchanges
           <a class="marketplace-link" href="https://pagcripto.com.br/">PagCripto</a>
           <br>
           <a class="marketplace-link" href="https://ripio.com/">Ripio</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -486,6 +498,8 @@ id: exchanges
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -498,6 +512,8 @@ id: exchanges
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -510,6 +526,8 @@ id: exchanges
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
+          <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
         </p>
       </div>
     </div>
@@ -566,6 +584,8 @@ id: exchanges
 	    <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
+    <br>
+    <a class="marketplace-link" href="https://dzengi.com/">Dzengi.com</a>
   </p>
 </div>
 


### PR DESCRIPTION
This PR adds [dzengi.com](http://dzengi.com/) to the list of Bitcoin Exchanges

Links:

Site functionality: https://dzengi.com/
Operational processes: https://dzengi.com/s-center
Rates and fees: https://dzengi.com/fees-charges
Order book: https://dzengi.com/tokenized-securities-overview
Policies, terms, and conditions: https://dzengi.com/agreement
Press and community feedback: https://apps.apple.com/by/app/dzengi-com-crypto-exchange/id1458917114
Leadership: https://dzengi.com/about-us 

Links were added to the next locations:
 
Asia: Bahrain, Indonesia, Oman
EU: without specification
Afrika: without specification
North America: Mexico
South America: Argentina, Brazil, Chile, Colombia, Peru
New Zealand: New Zealand