### PR TITLE
Update exchanges.html adding BitcoinWell.com

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -378,6 +378,8 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitbuy.ca/">Bitbuy</a>
           <br>
+          <a class="marketplace-link" href="https://bitcoinwell.com/">Bitcoin Well</a>
+          <br>
           <a class="marketplace-link" href="https://bitvo.com/">Bitvo</a>
           <br>
           <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">


### PR DESCRIPTION
Hi, I'm a developer at Bitcoin Well.

We've been in operation since 2013. 

In 2021 we listed on the TSXV as the world’s first publicly traded non-custodial bitcoin company.

Is there any chance we could add a non-custodial tag similar to the `Bitcoin Only` tag?

We have also recently entered the U.S. market. Would we be able to list under both Canada and the United States?

More info: [https://bitcoinwell.com/about-bitcoin-well/](https://bitcoinwell.com/about-bitcoin-well/)