### PR TITLE
Add new sites to communities page

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -58,6 +58,12 @@ id: community
         <p>
           <a href="https://bitcoin.stackexchange.com/">{% translate stackexchange %}</a>
         </p>
+        <p>
+          <a href="https://stacker.news">{% translate stackernews %}</a>
+        </p>
+        <p>
+          <a href="https://github.com/aljazceru/awesome-nostr">{% translate nostr %}</a>
+        </p>
       </div>
     
       <div class="community-card card">

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -162,6 +162,8 @@ en:
     bitcointalk: "<a href=\"https://bitcointalk.org/\">BitcoinTalk Forum</a>"
     reddit: "Reddit's Bitcoin Community"
     stackexchange: "Bitcoin StackExchange (Q&amp;A)"
+    stackernews: "Stacker News"
+    nostr: "Nostr (Bitcoin social network)"
     irc: "IRC Chat"
     ircjoin: "<a href=\"https://web.libera.chat/#bitcoin-core-dev\">IRC Channel #bitcoin-core-dev</a> on Libera."
     chanbitcoin: "(General Bitcoin-related)"


### PR DESCRIPTION
Stacker News (https://stacker.news) and Nostr are two platforms where an increasingly larger number of people are joining to discuss about Bitcoin. I might even say they have more genuine discussion on them than some of the older bitcoin sites listed like Reddit and Bitcointalk.

Therefore it would be of great benefit to the community for new bitcoiners to hear about these communities straight away.

In the case of Nostr, I linked a Github repository of all the Nostr clients since the network is decentralized.

1) Would it be better to link to https://nostr.com/ instead?
2) English translations have been provided, though obviously additional translations are required for this to be useful, so we will have to work on those. Although in the case of Stacker News, it is an English-only site. And while Nostr is used by people of all languages, neither of the Nostr resources I cited are available in another language. Will this be a problem?