### PR TITLE
Update <exchanges.html> with valid link to Binance

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -140,8 +140,6 @@ id: exchanges
       <div>
         <h3 id="singapore" class="no_toc">Singapore</h3>
         <p>
-          <a class="marketplace-link" href="https://www.binance.sg/">Binance</a>
-          <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
@@ -229,6 +227,8 @@ id: exchanges
     <div class="general-marketplace">
       <p>
         <a class="marketplace-link" href="https://anycoindirect.eu">AnyCoin Direct</a>
+        <br>
+        <a class="marketplace-link" href="https://www.binance.com">Binance</a>
         <br>
         <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>
 	      <br>
@@ -355,9 +355,6 @@ id: exchanges
       <img class="marketplace-flag" src="/img/flags/UG.svg?{{site.time | date: '%s'}}" alt="Ugandan flag">
       <div>
         <h3 id="uganda" class="no_toc">Uganda</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.binance.co.ug/">Binance</a>
-        </p>
         <p>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>


### PR DESCRIPTION
The links to the Binance exchange in <exchanges.html> are outdated and not valid anymore. This PR fixes that.