### PR TITLE
Remove the link to Bittrex from <exchanges.html>

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -416,8 +416,6 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitflyer.com/en-us/">bitFlyer</a>
           <br>
-          <a class="marketplace-link" href="https://bittrex.com/">Bittrex</a>
-          <br>
           <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
           <br>
           <a class="marketplace-link" href="https://gemini.com/">Gemini</a>


### PR DESCRIPTION
Bittrex exchange has been shut down:

> IMPORTANT UPDATE REGARDING BITTREX GLOBAL
> It is with great regret that we announce that Bittrex Global has decided to wind down its operations. This decision was not made lightly, and we understand the inconvenience it may have on our valued customers.
https://bittrexglobal.com

This PR removes the link to Bittrex from the list of exchanges.