### PR TITLE
Add AmberApp as Bitcoin Only exchange in Australian exchanges list

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -529,6 +529,8 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 class="exchanges-tab-title exchanges-australia-title" id="australia">Australia</h2>
   <p>
+    <a class="marketplace-link" href="https://amber.app/">AmberApp</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+    <br>
     <a class="marketplace-link" href="https://www.bitaroo.com.au/">Bitaroo</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://www.btcmarkets.net/">BTC Markets</a>


### PR DESCRIPTION
This PR adds Amber Bitcoin Only exchange to Australian exchanges list