### PR TITLE
Cleanup exchanges.html + updated Bitcoin Well listing

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -280,7 +280,7 @@ id: exchanges
           <h3 id="poland" class="no_toc">Poland</h3>
           <p>
             <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
-	    <br>
+	          <br>
             <a class="marketplace-link" href="https://egera.com/">Egera</a>
           </p>
         </div>
@@ -387,7 +387,7 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.coinsmart.com/">Coinsmart</a>
           <br>
-	  <a class="marketplace-link" href="https://ndax.io/">NDAX</a>
+	        <a class="marketplace-link" href="https://ndax.io/">NDAX</a>
           <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>
         </p>
@@ -434,7 +434,7 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 class="exchanges-tab-title exchanges-south-america-title" id="south-america">South America</h2>
   <div class="marketplace-row">
-
+    
     <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag">
       <div>
@@ -458,11 +458,11 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://bitybank.com.br/">Bitybank</a>
           <br>
-	  <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
+	        <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>
           <a class="marketplace-link" href="https://coinext.com.br/">Coinext</a>
           <br>
-	  <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>
+	        <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>
           <br>
           <a class="marketplace-link" href="https://mercadobitcoin.com.br/">Mercado Bitcoin</a>
           <br>
@@ -556,11 +556,11 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 id="new-zealand" class="exchanges-tab-title exchanges-newzealand-title">New Zealand</h2>
   <p>
-      <a class="marketplace-link" href="https://www.bitaroo.nz/">Bitaroo</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+    <a class="marketplace-link" href="https://www.bitaroo.nz/">Bitaroo</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
     <br>
-	    <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+	  <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
   </p>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -11,7 +11,6 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 class="exchanges-tab-title exchanges-international-title" id="international">International</h2>
   <p>
-	  
     <a class="marketplace-link" href="https://www.bitfinex.com/">Bitfinex</a>
     <br>
     <a class="marketplace-link" href="https://www.bitget.com/">Bitget</a>
@@ -231,7 +230,7 @@ id: exchanges
         <a class="marketplace-link" href="https://www.binance.com">Binance</a>
         <br>
         <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>
-	      <br>
+        <br>
         <a class="marketplace-link" href="https://bitfinex.com/">Bitfinex</a>
         <br>
         <a class="marketplace-link" href="https://bitflyer.com/en-eu/">bitFlyer</a>
@@ -280,7 +279,7 @@ id: exchanges
           <h3 id="poland" class="no_toc">Poland</h3>
           <p>
             <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
-	          <br>
+            <br>
             <a class="marketplace-link" href="https://egera.com/">Egera</a>
           </p>
         </div>
@@ -307,7 +306,7 @@ id: exchanges
             <br>
             <a class="marketplace-link" href="https://www.coinfloor.co.uk/">Coinfloor</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
             <br>
-	          <a class="marketplace-link" href="https://www.coinjar.com/uk/">CoinJar</a>
+            <a class="marketplace-link" href="https://www.coinjar.com/uk/">CoinJar</a>
             <br>
             <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
           </p>
@@ -387,7 +386,7 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.coinsmart.com/">Coinsmart</a>
           <br>
-	        <a class="marketplace-link" href="https://ndax.io/">NDAX</a>
+          <a class="marketplace-link" href="https://ndax.io/">NDAX</a>
           <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>
         </p>
@@ -460,11 +459,11 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://bitybank.com.br/">Bitybank</a>
           <br>
-	        <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
+          <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>
           <a class="marketplace-link" href="https://coinext.com.br/">Coinext</a>
           <br>
-	        <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>
+          <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>
           <br>
           <a class="marketplace-link" href="https://mercadobitcoin.com.br/">Mercado Bitcoin</a>
           <br>
@@ -562,7 +561,7 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
     <br>
-	  <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+    <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
   </p>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -435,7 +435,7 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 class="exchanges-tab-title exchanges-south-america-title" id="south-america">South America</h2>
   <div class="marketplace-row">
-    
+
     <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag">
       <div>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -375,7 +375,7 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitbuy.ca/">Bitbuy</a>
           <br>
-          <a class="marketplace-link" href="https://bitcoinwell.com/">Bitcoin Well</a>
+          <a class="marketplace-link" href="https://bitcoinwell.com/">Bitcoin Well</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
           <br>
           <a class="marketplace-link" href="https://bitvo.com/">Bitvo</a>
           <br>
@@ -413,6 +413,8 @@ id: exchanges
       <div>
         <h3 id="united-states" class="no_toc">United States</h3>
         <p>
+          <a class="marketplace-link" href="https://bitcoinwell.com/usa">Bitcoin Well</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+          <br>
           <a class="marketplace-link" href="https://bitflyer.com/en-us/">bitFlyer</a>
           <br>
           <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>


### PR DESCRIPTION
Hi again, I appreciate you merging [my previous PR](https://github.com/bitcoin-dot-org/Bitcoin.org/pull/4132) from December. 

The diff looks larger on this PR. I cleaned up some alignment issues caused by a mix of spaces and tabs.

Summary:
- Cleaned up several tab+space issues to fix alignment
- Updated Bitcoin Well listing w/ 'Bitcoin Only' tag
- Added Bitcoin Well listing to the United States section