### PR TITLE
Add environment score for DIY hardware wallets

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -352,6 +352,8 @@ en:
     checkfailtransparencynewtxt: "This wallet has not been tested and publicly reviewed by a significant number of people. This means this app might be more at risk of hiding dangerous code or doing something you wouldn't agree to."
     checkgoodenvironmenthardware: "Very secure environment"
     checkgoodenvironmenthardwaretxt: "This wallet is loaded from a secure specialized environment provided by the device. This provides very strong protection against computer vulnerabilities and malware since no software can be installed on this environment."
+    checkpassenvironmentbyod: "User sourced environment"
+    checkpassenvironmentbyodtxt: "This wallet is loaded on a device sourced by the user. This can provide reasonable protection against malware as long as you source your hardware correctly and secure it sufficiently."
     checkpassenvironmentmobile: "Secure environment"
     checkpassenvironmentmobiletxt: "This wallet is loaded on mobiles where apps are usually isolated. This provides a good protection against malware, although mobiles are usually easier to steal or lose. Encrypting your mobile and backing up your wallet can reduce that risk."
     checkpassenvironmenttwofactor: "Two-factor authentication"


### PR DESCRIPTION
This PR is to add a new option for the hardware wallet environment score.  This score is meant for hardware wallets that allow the user to provide their own hardware.  It is important to note:
* This PR alone makes no visible change to the site.  This update is for use on future wallet listings.
* Historically the community has been hesitant to add new scoring that might only apply to only one or two wallets.
* Currently there are two open PRs for wallets ([SeedSigner](https://github.com/bitcoin-dot-org/Bitcoin.org/pull/4179) and [AirGap Vault](https://github.com/bitcoin-dot-org/Bitcoin.org/pull/4019)) that this could apply to, and other wallets exist that could qualify (e.g. Specter-DIY, Krux).
* The icon that will appear to users in the comparison charts for this new score will be labelled *Acceptable*.
* The term "hardware wallet" may be a bit of a misnomer, but that's an issue for another time.
