### PR TITLE
Prevent firmware downgrades

### DIFF
--- a/docs/managing-wallets.md
+++ b/docs/managing-wallets.md
@@ -54,6 +54,7 @@ recovery process.
   - Uses the push model (computer malware cannot sign a transaction without user
     input)
   - Protects the seed against unsigned firmware upgrades
+  - Has capability to prevent firmware downgrades
   - Supports importing custom seeds
   - Provides source code created for all open components and provides detailed specification for blackbox testing of
     any closed-source secure elements
@@ -69,8 +70,6 @@ Optional criteria (some could become requirements):
   - Uses a strong KDF and key stretching for wallet storage and backups
   - On desktop platform:
     - Encrypt the wallet by default
-- For hardware wallets:
-  - Prevents downgrading the firmware
 
 ### Adding a wallet
 


### PR DESCRIPTION
There has been an optional criterion for many years on hardware wallet listings to avoid attacks by preventing the downgrading of firmware to a potentially vulnerable version.   Some currently listed hardware wallets simply prevent downgrades while others allow the capability of the current firmware to prohibit the installation of specified versions.

I propose making this a required criterion.   The original criterion was slightly reworded to take into account both implementations described above.

