### PR TITLE
bitbox02: fix source code URL

### DIFF
--- a/_wallets/bitbox.md
+++ b/_wallets/bitbox.md
@@ -14,7 +14,7 @@ platform:
       - name: hardware
         text: "walletbitbox"
         link: "https://shiftcrypto.ch/bitbox02/"
-        source: "https://github.com/digitalbitbox/bitbox02-firmware"
+        source: "https://github.com/BitBoxSwiss/bitbox02-firmware"
         screenshot: "bitbox02.png"
         features: "bech32 hardware_wallet legacy_addresses segwit"
         check:


### PR DESCRIPTION
https://github.com/digitalbitbox/bitbox02-firmware/ is now at https://github.com/BitBoxSwiss/bitbox02-firmware/.