### PR TITLE
Fix broken link to Coldcard guide in resources page

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -142,7 +142,7 @@ id: resources
         <!-- <h2 id="guides">{% translate guides %}</h2> -->
         <h2 id="guides">Guides</h2>
         <p>
-          <a href="https://mattodell.keybase.pub/coldcard.html">ColdCard</a>
+          <a href="https://coldcard.com/docs/quick/">ColdCard</a>
         </p>
         <p>
           <a href="https://bitcoiner.guide">Bitcoiner.Guide</a>


### PR DESCRIPTION
Updated the broken link for the Coldcard guide from "https://mattodell.keybase.pub/coldcard.html" to "https://coldcard.com/docs/quick/" in the Resources page. This change ensures that users are directed to the correct and functional URL for the Coldcard guide. 🚀