### PR TITLE
Remove TradeBlock & broken link from resource link

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -87,9 +87,6 @@ id: resources
           <a href="https://mempool.space">mempool.space</a>
         </p>
         <p>
-          <a href="https://tradeblock.com/bitcoin">TradeBlock</a>
-        </p>
-        <p>
           <a href="https://bitcoincharts.com/charts/">Bitcoincharts.com</a>
         </p>
         <p>


### PR DESCRIPTION
Removed the broken link to TradeBlock (http://tradeblock.com) from the Resources page as the website is currently unreachable and there are reports that TradeBlock has been shut down by the Digital Currency Group (DCG) due to regulatory and economic conditions.

Updated the Resources page by removing TradeBlock and link from list entirely to reflect this change.

Alternatively, we can add this source for on-chain data and charts, such as The Block's On-Chain Data page (https://www.theblock.co/data/on-chain-metrics/bitcoin).

This ensures users have access to reliable and current sources for Bitcoin data and statistics. 🚀