### PR TITLE
Remove Cryptobuyer from exchanges page

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -519,8 +519,6 @@ id: exchanges
       <div>
         <h3 id="venezuela" class="no_toc">Venezuela</h3>
         <p>
-          <a class="marketplace-link" href="https://cryptobuyer.com/">Cryptobuyer</a>
-          <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>


### PR DESCRIPTION
https://cryptobuyer.com/ was acquired by https://coinapult.com/acquired/ and seems to no longer be operational.

Remove reference and link from https://bitcoin.org/en/exchanges#p2p