### PR TITLE
Remove BuyCoins Africa from exchanges page

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -331,9 +331,6 @@ id: exchanges
           <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
         </p>
         <p>
-          <a class="marketplace-link" href="https://buycoins.africa/">BuyCoins</a>
-        </p>
-        <p>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>


### PR DESCRIPTION
Within https://bitcoin.org/en/exchanges#africa >> BuyCoins Nigeria >>  https://buycoins.africa/ >> "This service has been suspended by its owner." >> 503 Error

Removing exchange and associated URL from page.