### PR TITLE
Cryptomkt added to southamerican exchange's lists

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -448,6 +448,8 @@ id: exchanges
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>
+          <br>
+          <a class="marketplace-link" href="https://www.cryptomkt.com/">Cryptomkt</a>
         </p>
       </div>
     </div>
@@ -474,6 +476,8 @@ id: exchanges
           <a class="marketplace-link" href="https://pagcripto.com.br/">PagCripto</a>
           <br>
           <a class="marketplace-link" href="https://ripio.com/">Ripio</a>
+          <br>
+          <a class="marketplace-link" href="https://www.cryptomkt.com/">Cryptomkt</a>
         </p>
       </div>
     </div>
@@ -486,6 +490,8 @@ id: exchanges
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
+          <a class="marketplace-link" href="https://www.cryptomkt.com/">Cryptomkt</a>
         </p>
       </div>
     </div>
@@ -498,6 +504,8 @@ id: exchanges
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
+          <a class="marketplace-link" href="https://www.cryptomkt.com/">Cryptomkt</a>
         </p>
       </div>
     </div>
@@ -510,6 +518,8 @@ id: exchanges
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
+          <br>
+          <a class="marketplace-link" href="https://www.cryptomkt.com/">Cryptomkt</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
cryptomkt (https://www.cryptomkt.com) company added as a exchange in south america (Argentina, Brazil, Colombia, Chile, Peru)