### PR TITLE
Add RoboSats p2p exchange to exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -41,6 +41,8 @@ id: exchanges
     <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
     <br>
     <a class="marketplace-link" href="https://noones.com/">Noones Buy Bitcoin</a>
+    <br>
+    <a class="marketplace-link" href="https://learn.robosats.com/">RoboSats</a>
   </p>
 </div>
 


### PR DESCRIPTION
Robosats is a open source p2p fiat <-> bitcoin exchange (bitcoin only!). It is available as website on Tor and as Android app , using the lightning network with hold invoices to allow for secure trades. Comparable to Bisq, but with a different architecture and trade-offs. 
This PR adds a link to "https://learn.robosats.com" which is the official Robosats clearnet website (operated by the main Robosats dev).