### PR TITLE
Add Lightning Pay to Exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -561,6 +561,8 @@ id: exchanges
     <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
+    <br>
+    <a class="marketplace-link" href="https://lightningpay.nz/">Lightning Pay</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
   </p>
 </div>
 


### PR DESCRIPTION
Adding Lightning Pay, a New Zealand, Bitcoin Only exchange to the list of exchanges.