### PR TITLE
Remove unavailable 'Evolution of Bitcoin' link from resources

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -112,9 +112,6 @@ id: resources
         <p>
           <a href="https://www.youtube.com/watch?v=PVo5wCSnmSs">Magic Money: The Bitcoin Revolution</a>
         </p>
-        <p>
-          <a href="https://www.youtube.com/watch?v=HUpGHOLkoXs">Evolution of Bitcoin</a>
-        </p>
       </div>
 
       <div class="card resources-card">


### PR DESCRIPTION
This PR removes the link to the "Evolution of Bitcoin" documentary from the _templates/resources.html file.

**Reason for removal:**
The content is no longer available on YouTube.

**Changes:**
Removed the block containing the link:
<a href="https://www.youtube.com/watch?v=HUpGHOLkoXs">Evolution of Bitcoin</a>