### PR TITLE
Removing BitQuick from exchanges pages

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -36,8 +36,6 @@ id: exchanges
   <p>
     <a class="marketplace-link" href="https://bisq.network/">Bisq</a>
     <br>
-    <a class="marketplace-link" href="https://bitquick.co/">BitQuick</a>
-    <br>
     <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
     <br>
     <a class="marketplace-link" href="https://noones.com/">Noones Buy Bitcoin</a>


### PR DESCRIPTION
https://bitquick.co/ is no longer active, I am removing the link from the exchanges page.