### PR TITLE
More info on setting up env instructions

### DIFF
--- a/docs/setting-up-your-environment.md
+++ b/docs/setting-up-your-environment.md
@@ -200,18 +200,18 @@ please read /home/myusername/.rvm/log/1739938091_ruby-2.5.8/make.log
 There has been an error while running make. Halting the installation.
 ```
 
-And if the the `make.log` file has this lines at the end:
+And if the the `make.log` file has these lines at the end:
 ```
 make: *** [uncommon.mk:240: build-ext] Error 2
 ++ return 2
 ```
 
-Probably you need to run the following command to install a specific openssl dependency needed to compile ruby-2.5.8:
+Probably you need to run the following command to install a specific openssl dependency needed by ruby-2.5.8 compilation:
 ```
 rvm pkg install openssl
 ```
 
-And then install/compile ruby with the following command:
+Then install/compile ruby with the following command:
 ```
 rvm install ruby-2.5.8 --with-openssl-dir=$HOME/.rvm/usr
 ```

--- a/docs/setting-up-your-environment.md
+++ b/docs/setting-up-your-environment.md
@@ -50,7 +50,8 @@ To install Ruby 2.5.8, simply run this command:
 
 Sometimes this will find a pre-compiled Ruby package for your Linux
 distribution, but sometimes it will need to compile Ruby from scratch
-(which takes about 15 minutes).
+(which takes about 15 minutes, if you got an error see [error while
+compiling](#error-while-compiling)).
 
 After Ruby 2.5.8 is installed, make it your default Ruby:
 
@@ -188,3 +189,29 @@ before building you preview:
 You can also add this line to your `~/.bashrc` file if you frequently
 build site previews so that you don't have to remember to run it for
 each shell.
+
+#### Error While Compiling
+
+If you got an error while compiling that looks like this:
+```
+Error running '__rvm_make -j8',
+please read /home/myusername/.rvm/log/1739938091_ruby-2.5.8/make.log
+
+There has been an error while running make. Halting the installation.
+```
+
+And if the the `make.log` file has this lines at the end:
+```
+make: *** [uncommon.mk:240: build-ext] Error 2
+++ return 2
+```
+
+Probably you need to run the following command to install a specific openssl dependency needed to compile ruby-2.5.8:
+```
+rvm pkg install openssl
+```
+
+And then install/compile ruby with the following command:
+```
+rvm install ruby-2.5.8 --with-openssl-dir=$HOME/.rvm/usr
+```


### PR DESCRIPTION
Added extra info regarding compilation error for ruby 2.5.8 when setting up your environment. The error occurred with the latest version of Linux Mint (22.1), but I found others complaining about this issue on Ubuntu too.