### PR TITLE
Update events.html

### DIFF
--- a/_templates/events.html
+++ b/_templates/events.html
@@ -38,7 +38,6 @@ id: events
     </div>
     <div class="additional-links events-links row">
       <div>
-        <p>{% translate meetupgroup %}</p>
         <p>{% translate meetupbitcointalk %}</p>
         <p>{% translate meetupwiki %}</p>
       </div>


### PR DESCRIPTION
The link to the "Bitcoin meetup groups" resource has been removed because the page is no longer available. Keeping dead or outdated links can negatively affect user experience and reduce the credibility of the content. This change ensures that all external references remain relevant and functional.