### PR TITLE
Add Romania (RO) exchange: Abarai 

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -286,6 +286,17 @@ id: exchanges
           </p>
         </div>
       </div>
+      
+      <div class="row marketplace">
+        <img class="marketplace-flag" src="/img/flags/RO.svg?{{site.time | date: '%s'}}" alt="Romanian flag">
+        <div>
+          <h3 id="romania" class="no_toc">Romania</h3>
+          <p>
+          <a class="marketplace-link" href="https://abarai.ro">Abarai</a>
+        </p>
+      </div>
+    </div>
+
 
       <div class="row marketplace">
         <img class="marketplace-flag" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag">


### PR DESCRIPTION
This PR adds Romania under the Europe section of exchanges and lists Abarai (https://abarai.ro/), a Romania-based Bitcoin exchange service.

**Service overview**
Abarai is a non-custodial Bitcoin on/off-ramp that enables users to buy BTC with direct delivery to user-controlled wallets, and to sell BTC directly from their personal wallet in exchange for fiat (RON). The platform also provides a crypto-to-crypto swap service.

**Operational details**

* Non-custodial model (no user funds are held by the platform)
* Users send/receive funds directly from/to their own wallets
* Supports RON payments via bank transfer and card
* KYC is required for fiat on/off-ramp services, depending on transaction size and regulatory requirements
* The swap service (crypto-to-crypto) is available without KYC
* Execution is near-instant or depends on payment method

**Fees and pricing**

* Pricing is transparently displayed on the website before confirmation
* No hidden custody or withdrawal fees

**Exchange model**

* Broker-style service (not a traditional order-book exchange)

**Policies**

* Terms: https://www.abarai.ro/en/terms-and-conditions/
* Privacy: https://www.abarai.ro/en/privacy-policy/

**Background**

* Service active since 2023
* Public platform available since 2024
* Founders: Dragos Vintoiu and Alexandru Vintoiu
* The founders previously co-founded in 2017 a Bitcoin ATM network in Romania (https://bitpm.ro/)

**Public presence / community feedback**

* https://agerpres.ro/ots/cum-sa-devii-expert-in-tranzactionari-pe-piata-cripto-abarai-locul-perfect-de-invatare-si-tranzactio--656009
* https://maps.app.goo.gl/iNtWzSVvXCnkCiL58

**Technical notes**

* Maintains alphabetical order (between Poland and Ukraine)
* Uses existing HTML structure and styling

Full disclosure: I work here (I am one of the co-founders)

Please let me know if any additional details or criteria are required.
