### PR TITLE
Add blockdyor to resources

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -144,6 +144,9 @@ id: resources
         <p>
           <a href="http://node.guide">Node.Guide</a>
         </p>
+         <p>
+          <a href="https://blockdyor.com">blockdyor</a>
+        </p>
       </div>
 
   </div>


### PR DESCRIPTION
I believe [blockdyor](https://blockdyor.com/) would be a valuable addition to the Bitcoin.org resources page, as it offers in-depth reviews of Bitcoin products and comprehensive Bitcoin guides. After more than three years online, we have worked with most major Bitcoin companies, always aiming to provide high-quality, informative content.