### PR TITLE
fix(homepage): add spacing between buttons on tablet screens

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -943,6 +943,12 @@ h1 span.fa, h2 span.fa, h3 span.fa, h4 span.fa, h5 span.fa, h6 span.fa {
     width: 290px;
     height: 55px;
 }
+// Give space when this button is stacked underneath the two other btn-home's in tablet screen width
+@media screen and (min-width: 769px) and (max-width: 1029px) {
+  #buybitcoinbutton {
+    margin-top: 10px;
+  }
+}
 .btn:not(:first-child) {
     margin-left: 6px;
 }


### PR DESCRIPTION
### Description

On the homepage, every breakpoint provides consistent space between each of the button-like elements in the hero area, except in the tablet viewport size (769-1029px). Here the bottom-most button is directly touching the two buttons above it, breaking the layout.

This update fixes the layout at that breakpoint by adding margin space (equivalent to the value used on mobile) to that particular element via ID selector. It's added in `screens.scss` and placed next to the `btn-home` class selector that all the elements share.

**Before**
![homepage-before](https://github.com/user-attachments/assets/cc96ad6c-ec3c-4e08-a41d-9930d688c9d6)

**After**
![homepage-after](https://github.com/user-attachments/assets/7e01dde7-0f23-4161-a009-eaf99282508c)
