### PR TITLE
fix invisible text in language selector

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -3555,6 +3555,11 @@ html[data-theme="dark"] .dark-theme-toggle::before {
     .develdocdisclaimerclose:active {
         right: 30px;
     }
+    // language selector BG on small viewport sizes when it is NOT a mobile device using the browser's native UI selector
+    #select-input {
+  background-color: black;
+  padding-left: 10px;
+}
 }
 
 @media handheld, only screen and ( max-width: 67.5em ), only screen and ( max-device-width: 67.5em ){


### PR DESCRIPTION
## Description

On small-screen **desktop viewports**, the language selector renders with a **white background and white text**, making the options **completely invisible**. This effectively blocks users from being able to select or change their language in those conditions (unless hovering over each option to reveal the text with the blue highlighter). On mobile devices, the native browser UI handles the selector's styling automatically, so the issue only appears in non-mobile small screens.

This update fixes the issue by explicitly styling the language selector with a black background, in keeping with the style of the mobile menu, so that the text remains visible and accessible across all devices.

**Before**
![lang-before](https://github.com/user-attachments/assets/8f136928-a705-42d1-a8aa-eaae416d9671)

**After**
![lang-after](https://github.com/user-attachments/assets/2c957150-2665-42c1-9cd1-3b5a9f7ce3b7)
