### PR TITLE
fix broken mobile layout for all blog pages

### DIFF
--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -1445,6 +1445,8 @@ h1 span.fa, h2 span.fa, h3 span.fa, h4 span.fa, h5 span.fa, h6 span.fa {
         -ms-flex-pack: center;
             justify-content: center;
     padding: 95px 0 50px;
+    margin-left: 1rem;
+    margin-right: 1rem;
 }
 .toc {
     min-width: 370px;
@@ -1538,7 +1540,7 @@ h1 span.fa, h2 span.fa, h3 span.fa, h4 span.fa, h5 span.fa, h6 span.fa {
     width: 100%;
     min-width: 290px;
     word-wrap: break-word;
-    padding: 18px;
+    padding: 18px 0;
 }
 .toccontent-block {
     border-top: 1px solid #dfdfdf;


### PR DESCRIPTION
## Description

All of the blog pages in the mobile breakpoint have a broken layout where the content overflows past the right margin and expands the page width and creates a blank white gutter. This breaks the header and footer structure. In the current setup, the left and right padding from `toccontent` is causing the issue.

This fix:
- Removes the left and right padding from `toccontent`.
- Adds left and right margin spacing to its parent `toc-row` to create a similar spacing layout without the overflow issue.
- Modifies  `screen.scss` only

**Before - scrolled to the right**
![blog-before](https://github.com/user-attachments/assets/9b6ed2a0-1ee6-457d-b50d-9dc8e1003727)
**After**
![blog-after](https://github.com/user-attachments/assets/cf4cb120-47d6-4edc-9bfb-36d185684693)
