### PR TITLE
Add Nexo to exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -24,6 +24,8 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://www.kraken.com/">Kraken</a>
     <br>
+    <a class="marketplace-link" href="https://nexo.com/">Nexo</a>
+    <br>
     <a class="marketplace-link" href="https://www.okcoin.com/">OKCoin</a>
   </p>
 </div>


### PR DESCRIPTION
Hello! I want to add [the Nexo Exchange](https://nexo.com/exchange) to the [international exchanges list](https://bitcoin.org/en/exchanges).

Nexo is a well-established platform [founded all the way back in 2018](https://nexo.com/about) (which is centuries in crypto years) and has survived through all the challenging market cycles that were the end for many other platforms in the space.

As Nexo operates globally, I think it's great fit for the "International" list in the exchanges page.

**Full disclosure:** I work for Nexo.