### PR TITLE
Add BankToBTC to resources page.html

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -66,6 +66,8 @@ id: resources
         <p>
           <a href="https://www.bitrawr.com/">{% translate linkexchanges %}</a> - bitrawr.com</p>
         <p>
+          <a href="https://banktobtc.com/">{% translate linkexchanges %}</a> - banktobtc.com</p>
+        <p>
           <a href="https://en.bitcoin.it/wiki/Category:Shopping_Cart_Interfaces">{% translate linkmerchantstools %}</a> - en.bitcoin.it</p>
         <p>
           <a href="http://www.bitcoinprojects.net/">{% translate linkprojects %}</a> - BitcoinProjects.net</p>


### PR DESCRIPTION
Adds BankToBTC.com to the Directories section.

BankToBTC scores banks on Bitcoin compatibility based on the bank's policies, transfer limits and user reports - whether they allow exchange purchases, permit withdrawals, or freeze/close accounts for Bitcoin activity.

Helps Bitcoiners avoid banking issues before they happen.

Recently mentioned by Jimmy Song as a project/public good to look out for on his Substack: https://x.com/jimmysong/status/2015811160759517381

![2026-01-28 11 30 18](https://github.com/user-attachments/assets/ca2c9812-0a40-4d14-9fd5-69538f678e76)
