### PR TITLE
Add 'Earn Bitcoin' section

### DIFF
--- a/_includes/layout/base/footer-menu.html
+++ b/_includes/layout/base/footer-menu.html
@@ -108,6 +108,9 @@ http://opensource.org/licenses/MIT.
         <li id="sellbitcoinfootermenulink" {% if page.id == 'sell' %} class="active"{% endif %}>
           <a href="/en/{% translate sell url %}">{% translate menu-sell layout %}</a>
         </li>
+        <li{% if page.id == 'earn' %} class="active"{% endif %}>
+          <a href="/{{ page.lang }}/{% translate earn url %}">{% translate menu-earn layout %}</a>
+        </li>
         {% if page.lang == 'en' %}
         <li{% if page.id == 'full-node' %} class="active"{% endif %}>
           <a href="/en/full-node">{% translate menu-full-node layout %}</a>

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -61,6 +61,7 @@ http://opensource.org/licenses/MIT.
       <li{% if page.id == 'support-bitcoin' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate support-bitcoin url %}">{% translate menu-support-bitcoin layout %}</a>
       <li id="buybitcoinmenulink" {% if page.id == 'buy' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate buy url %}">{% translate menu-buy layout %}</a></li>
       <li id="sellbitcoinmenulink" {% if page.id == 'sell' %} class="active"{% endif %}><a href="/en/{% translate sell url %}">{% translate menu-sell layout %}</a></li>
+      <li{% if page.id == 'earn' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate earn url %}">{% translate menu-earn layout %}</a></li>
       {% if page.lang == 'en' %}<li{% if page.id == 'full-node' %} class="active"{% endif %}><a href="/en/full-node">Running a full node</a></li>{% endif %}
       <li{% if page.id == 'development' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate development url %}">{% translate menu-development layout %}</a></li>
     </ul>

--- a/_templates/earn.html
+++ b/_templates/earn.html
@@ -14,66 +14,55 @@ id: earn
 </div>
 
 <div class="container">
-
   <div class="row card-row">
-    <div class="card earn-card">
+    <div class="card support-card">
       <h2 id="freelancing">{% translate freelancing %}</h2>
       <p>{% translate freelancingtext %}</p>
       <ul>
-        <li><a href="https://microlancer.io/" target="_blank" rel="noopener">Microlancer</a> - {% translate microlancerdesc %}</li>
-        <li><a href="https://stacker.news/" target="_blank" rel="noopener">Stacker News</a> - {% translate stackernewsdesc %}</li>
-        <li><a href="https://www.reddit.com/r/Jobs4Bitcoins/" target="_blank" rel="noopener">Jobs4Bitcoins</a> - {% translate jobs4bitcoinsdesc %}</li>
+        <li><a href="https://microlancer.io/">Microlancer</a> - {% translate microlancerdesc %}</li>
+        <li><a href="https://stacker.news/">Stacker News</a> - {% translate stackernewsdesc %}</li>
+        <li><a href="https://www.reddit.com/r/Jobs4Bitcoins/">Jobs4Bitcoins</a> - {% translate jobs4bitcoinsdesc %}</li>
       </ul>
     </div>
-  </div>
 
-  <div class="row card-row">
-    <div class="card earn-card">
+    <div class="card support-card">
       <h2 id="content">{% translate content %}</h2>
       <p>{% translate contenttext %}</p>
       <ul>
-        <li><a href="https://fountain.fm/" target="_blank" rel="noopener">Fountain</a> - {% translate fountaindesc %}</li>
-        <li><a href="https://www.publish0x.com/" target="_blank" rel="noopener">Publish0x</a> - {% translate publish0xdesc %}</li>
+        <li><a href="https://fountain.fm/">Fountain</a> - {% translate fountaindesc %}</li>
+        <li><a href="https://www.publish0x.com/">Publish0x</a> - {% translate publish0xdesc %}</li>
       </ul>
     </div>
-  </div>
 
-  <div class="row card-row">
-    <div class="card earn-card">
+    <div class="card support-card">
       <h2 id="bounties">{% translate bounties %}</h2>
       <p>{% translate bountiestext %}</p>
       <ul>
-        <li><a href="https://www.lightningbounties.com/" target="_blank" rel="noopener">Lightning Bounties</a> - {% translate lightningbountiesdesc %}</li>
-        <li><a href="https://bitcoinbounties.org/" target="_blank" rel="noopener">Bitcoin Bounties</a> - {% translate bitcoinbountiesdesc %}</li>
-        <li><a href="https://github.com/bitcoin-dot-org/bitcoin.org#earn-bitcoin-for-contributing" target="_blank" rel="noopener">Bitcoin.org</a> - {% translate bitcoinorgdesc %}</li>
+        <li><a href="https://www.lightningbounties.com/">Lightning Bounties</a> - {% translate lightningbountiesdesc %}</li>
+        <li><a href="https://bitcoinbounties.org/">Bitcoin Bounties</a> - {% translate bitcoinbountiesdesc %}</li>
+        <li><a href="https://github.com/bitcoin-dot-org/bitcoin.org#earn-bitcoin-for-contributing">Bitcoin.org</a> - {% translate bitcoinorgdesc %}</li>
       </ul>
     </div>
-  </div>
 
-  <div class="row card-row">
-    <div class="card earn-card">
+    <div class="card support-card">
       <h2 id="mining">{% translate mining %}</h2>
       <p>{% translate miningtext %}</p>
       <ul>
-        <li><a href="https://ocean.xyz/" target="_blank" rel="noopener">OCEAN</a> - {% translate oceandesc %}</li>
-        <li><a href="https://www.nicehash.com/" target="_blank" rel="noopener">NiceHash</a> - {% translate nicehashdesc %}</li>
+        <li><a href="https://ocean.xyz/">OCEAN</a> - {% translate oceandesc %}</li>
+        <li><a href="https://www.nicehash.com/">NiceHash</a> - {% translate nicehashdesc %}</li>
       </ul>
     </div>
-  </div>
 
-  <div class="row card-row">
-    <div class="card earn-card">
+    <div class="card support-card">
       <h2 id="rewards">{% translate rewards %}</h2>
       <p>{% translate rewardstext %}</p>
       <ul>
-        <li><a href="https://foldapp.com/" target="_blank" rel="noopener">Fold</a> - {% translate folddesc %}</li>
-        <li><a href="https://www.lolli.com/" target="_blank" rel="noopener">Lolli</a> - {% translate lollidesc %}</li>
+        <li><a href="https://foldapp.com/">Fold</a> - {% translate folddesc %}</li>
+        <li><a href="https://www.lolli.com/">Lolli</a> - {% translate lollidesc %}</li>
       </ul>
     </div>
-  </div>
 
-  <div class="row card-row">
-    <div class="card earn-card">
+    <div class="card support-card">
       <h2 id="important">{% translate important %}</h2>
       <p>{% translate importanttext %}</p>
       <ul>
@@ -83,5 +72,4 @@ id: earn
       </ul>
     </div>
   </div>
-
 </div>

--- a/_templates/earn.html
+++ b/_templates/earn.html
@@ -1,0 +1,87 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+layout: base
+id: earn
+---
+
+<div class="hero">
+  <div class="container hero-container">
+    <h1>{% translate pagetitle %}</h1>
+    <p class="summary">{% translate pagedesc %}</p>
+  </div>
+</div>
+
+<div class="container">
+
+  <div class="row card-row">
+    <div class="card earn-card">
+      <h2 id="freelancing">{% translate freelancing %}</h2>
+      <p>{% translate freelancingtext %}</p>
+      <ul>
+        <li><a href="https://microlancer.io/" target="_blank" rel="noopener">Microlancer</a> - {% translate microlancerdesc %}</li>
+        <li><a href="https://stacker.news/" target="_blank" rel="noopener">Stacker News</a> - {% translate stackernewsdesc %}</li>
+        <li><a href="https://www.reddit.com/r/Jobs4Bitcoins/" target="_blank" rel="noopener">Jobs4Bitcoins</a> - {% translate jobs4bitcoinsdesc %}</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row card-row">
+    <div class="card earn-card">
+      <h2 id="content">{% translate content %}</h2>
+      <p>{% translate contenttext %}</p>
+      <ul>
+        <li><a href="https://fountain.fm/" target="_blank" rel="noopener">Fountain</a> - {% translate fountaindesc %}</li>
+        <li><a href="https://www.publish0x.com/" target="_blank" rel="noopener">Publish0x</a> - {% translate publish0xdesc %}</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row card-row">
+    <div class="card earn-card">
+      <h2 id="bounties">{% translate bounties %}</h2>
+      <p>{% translate bountiestext %}</p>
+      <ul>
+        <li><a href="https://www.lightningbounties.com/" target="_blank" rel="noopener">Lightning Bounties</a> - {% translate lightningbountiesdesc %}</li>
+        <li><a href="https://bitcoinbounties.org/" target="_blank" rel="noopener">Bitcoin Bounties</a> - {% translate bitcoinbountiesdesc %}</li>
+        <li><a href="https://github.com/bitcoin-dot-org/bitcoin.org#earn-bitcoin-for-contributing" target="_blank" rel="noopener">Bitcoin.org</a> - {% translate bitcoinorgdesc %}</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row card-row">
+    <div class="card earn-card">
+      <h2 id="mining">{% translate mining %}</h2>
+      <p>{% translate miningtext %}</p>
+      <ul>
+        <li><a href="https://ocean.xyz/" target="_blank" rel="noopener">OCEAN</a> - {% translate oceandesc %}</li>
+        <li><a href="https://www.nicehash.com/" target="_blank" rel="noopener">NiceHash</a> - {% translate nicehashdesc %}</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row card-row">
+    <div class="card earn-card">
+      <h2 id="rewards">{% translate rewards %}</h2>
+      <p>{% translate rewardstext %}</p>
+      <ul>
+        <li><a href="https://foldapp.com/" target="_blank" rel="noopener">Fold</a> - {% translate folddesc %}</li>
+        <li><a href="https://www.lolli.com/" target="_blank" rel="noopener">Lolli</a> - {% translate lollidesc %}</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row card-row">
+    <div class="card earn-card">
+      <h2 id="important">{% translate important %}</h2>
+      <p>{% translate importanttext %}</p>
+      <ul>
+        <li>{% translate warning1 %}</li>
+        <li>{% translate warning2 %}</li>
+        <li>{% translate warning3 %}</li>
+      </ul>
+    </div>
+  </div>
+
+</div>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -570,7 +570,7 @@ en:
     content: "Content Creation"
     contenttext: "Create content and get paid in Bitcoin for your work."
     fountaindesc: "Earn Bitcoin for listening to podcasts and creating clips"
-    publish0xdesc: "Earn cryptocurrency for writing and reading articles"
+    publish0xdesc: "Earn Bitcoin for writing and reading articles"
     bounties: "Bug Bounties & Open Source"
     bountiestext: "Contribute to open source projects and earn Bitcoin for fixing bugs or adding features."
     lightningbountiesdesc: "Earn sats for fixing GitHub issues via Lightning Network"
@@ -1200,6 +1200,7 @@ en:
     menu-support-bitcoin: "Support Bitcoin"
     menu-buy: "Buy Bitcoin"
     menu-sell: "Sell Bitcoin"
+    menu-earn: "Earn Bitcoin"
     menu-full-node: "Running a full node"
     menu-other: "Other"
     menu-vocabulary: Vocabulary

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -558,6 +558,37 @@ en:
     ircjoin: "<a href=\"https://webchat.freenode.net/?channels=bitcoin-core-dev\">IRC Channel #bitcoin-core-dev</a> on freenode."
     stackexchange: "<a href=\"https://bitcoin.stackexchange.com/\">Bitcoin StackExchange</a>"
     bitcointalkdev: "<a href=\"https://bitcointalk.org/index.php?board=6.0\">BitcoinTalk Development &amp; Technical Discussion Forum</a>"
+  earn:
+    title: "Earn Bitcoin - Bitcoin"
+    pagetitle: "Earn Bitcoin"
+    pagedesc: "Not everyone can buy Bitcoin. Discover ways to earn it through work, content creation, and contributions."
+    freelancing: "Freelancing & Microtasks"
+    freelancingtext: "Complete tasks and freelance work paid in Bitcoin via the Lightning Network."
+    microlancerdesc: "Complete small tasks for instant Bitcoin payments via Lightning"
+    stackernewsdesc: "Earn sats by posting valuable content and comments"
+    jobs4bitcoinsdesc: "Reddit community for finding freelance work paid in Bitcoin"
+    content: "Content Creation"
+    contenttext: "Create content and get paid in Bitcoin for your work."
+    fountaindesc: "Earn Bitcoin for listening to podcasts and creating clips"
+    publish0xdesc: "Earn cryptocurrency for writing and reading articles"
+    bounties: "Bug Bounties & Open Source"
+    bountiestext: "Contribute to open source projects and earn Bitcoin for fixing bugs or adding features."
+    lightningbountiesdesc: "Earn sats for fixing GitHub issues via Lightning Network"
+    bitcoinbountiesdesc: "Directory of active Bitcoin bounties across projects"
+    bitcoinorgdesc: "Earn Bitcoin for contributing to this website"
+    mining: "Mining"
+    miningtext: "Earn Bitcoin by providing computational power to secure the network."
+    oceandesc: "Decentralized Bitcoin mining pool"
+    nicehashdesc: "Marketplace for buying and selling hashpower"
+    rewards: "Shopping Rewards"
+    rewardstext: "Earn Bitcoin back when you shop at participating retailers."
+    folddesc: "Earn Bitcoin rewards when shopping with the Fold card"
+    lollidesc: "Browser extension that gives Bitcoin back on online purchases"
+    important: "Important Warnings"
+    importanttext: "Be cautious when earning Bitcoin online:"
+    warning1: "Never pay money upfront to earn Bitcoin - legitimate opportunities don't require deposits"
+    warning2: "Research any platform thoroughly before providing personal information"
+    warning3: "Be skeptical of promises of high returns with little effort"
   download:
     title: "Download - Bitcoin"
     pagetitle: "Download Bitcoin Core"
@@ -1219,6 +1250,7 @@ en:
     transactions-guide: transactions-guide
     wallets-guide: wallets-guide
     development: development
+    earn: earn
     download: download
     exchanges: exchanges
     events: events


### PR DESCRIPTION
## Summary

This PR adds a new "Earn Bitcoin" page to help users discover ways to earn Bitcoin without purchasing it directly, addressing issue #2524.

### Changes include:

- New page template `_templates/earn.html` with categories: Freelancing, Content Creation, Bug Bounties, Mining, Shopping Rewards, and Warnings
- All English translations added to `_translations/en.yml`
- URL mapping for `/earn`
- Navigation menu integration (header and footer)
- Uses existing `support-card` CSS class for consistent styling

## Addresses

This PR addresses bounty #2524: "Add 'Earn Bitcoin' section"
https://github.com/bitcoin-dot-org/bitcoin.org/issues/2524

## Payment Address

Bitcoin address for bounty payment: `bc1qax8d6etvphms3tqqc7hy52vas4af7ezv4msvqd`

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)