### PR TITLE
Update exchanges.html

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -387,6 +387,8 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://ndax.io/">NDAX</a>
           <br>
+          <a class="marketplace-link" href="https://www.netcoins.com/">Netcoins</a>
+          <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>
         </p>
       </div>


### PR DESCRIPTION
Added Netcoins exchange to Canadian Bitcoin exchanges list. Netcoins is based in Vancouver, British Columbia and has been operating in Canada for 10+ years. It's part of a publicly traded company (BIGG on the TSXV).

Netcoins is registered with FINTRAC as a Money Service Business. FINTRAC# : M15560893