### PR TITLE
Add Paribu to Turkey exchange listings

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -196,6 +196,8 @@ id: exchanges
         <h3 id="turkey" class="no_toc">Turkey</h3>
         <p>
           <a class="marketplace-link" href="https://www.koinim.com/">Koinim</a>
+          <br>
+          <a class="marketplace-link" href="https://www.paribu.com/">Paribu</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
This PR adds Paribu to the Turkey exchange listings in `_templates/exchanges.html`.

Exchange: Paribu
Country: Turkey
URL: https://www.paribu.com/