### PR TITLE
Update outdated _config.yml variables to reflect April 2026 state

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -609,22 +609,22 @@ kramdown:
     css_class:
 
 text:
-  ## Values last updated 2018-10-16
+  ## Values last updated 2026-04-17
   ## All variable names must indicate unit type for easy translation of adjacent text,
   ##   such as: subsidy_in_decimal_bitcoins or
   ##   bitcoin_org_docs_maintainer_email_link
   ## For increasing variables, like chain size, choose a somewhat higher
   ##   value so we don't need to update too often
-  subsidy_in_decimal_bitcoins: 6.25
+  subsidy_in_decimal_bitcoins: 3.125
   ## cd ~ ; du -sh .bitcoin/ --exclude=testnet3 --exclude=regtest
-  bitcoin_datadir_gb: 350
+  bitcoin_datadir_gb: 750
   ## Slightly smaller than the total datadir size
-  chain_gb: 340
+  chain_gb: 740
   ## The main difference between the datadir size and the chain size, if
   ## you don't have any extra indices
   bitcoin_datadir_gb_pruned: 7
   ## the tx= field in: grep UpdateTip .bitcoin/debug.log | tail -n1
-  total_tx_count_in_millions: 230
+  total_tx_count_in_millions: 1300
   typical_ibd_time_in_hours: 4
   typical_144_block_catchup_time_in_minutes: 5
   bitcoin_org_docs_maintainer_email_link: '<a href="mailto:will@bitcoin.org">Will Binns</a>'


### PR DESCRIPTION
Related: #4662

## Summary

The `_config.yml` file contains a comment indicating "Values last updated 2018-10-16" for several variables used across multiple pages of the site (full-node descriptions, block chain size references, mining reward mentions). This PR updates the outdated values to reflect the current state of the Bitcoin network as of April 2026.

## Changes

| Variable | Before | After | Source |
|---|---|---|---|
| `subsidy_in_decimal_bitcoins` | 6.25 | 3.125 | [Fourth halving, April 20, 2024 (block 840,000)](https://www.theblock.co/post/289875/bitcoin-ushers-in-fourth-halving-as-miners-block-subsidy-reward-drops-to-3-125-btc) |
| `bitcoin_datadir_gb` | 350 | 750 | Actual size: 733.24 GB on April 13, 2026 ([YCharts](https://ycharts.com/indicators/bitcoin_blockchain_size)). Value set slightly higher per the file's own guidance: *"For increasing variables, like chain size, choose a somewhat higher value so we don't need to update too often."* |
| `chain_gb` | 340 | 740 | Adjusted proportionally to `bitcoin_datadir_gb`, maintaining the original ~10 GB gap for chainstate and block indices. |
| `total_tx_count_in_millions` | 230 | 1300 | Bitcoin network surpassed 1 billion transactions on May 5, 2024. YCharts reports 1.292B as of January 1, 2026. Value set with margin for growth. |
| Comment | "Values last updated 2018-10-16" | "Values last updated 2026-04-17" | — |

## Notes

- The `bitcoin_datadir_gb_pruned: 7` variable was intentionally left unchanged, as 7 GB remains the documented minimum for running a pruned node (per [bitcoin.org/en/full-node](https://bitcoin.org/en/full-node)).
- The updated values affect descriptions across multiple pages of the site via the `site.text.*` variables, including the full-node page, wallet validation descriptions, and initial sync notes.