### PR TITLE
Remove itBit listing — retail services deprecated; SSL certificate expired

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -421,8 +421,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://gemini.com/">Gemini</a>
           <br>
-          <a class="marketplace-link" href="https://www.itbit.com/">itBit</a>
-          <br>
           <a class="marketplace-link" href="https://river.com/">River Financial</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
           <br>
           <a class="marketplace-link" href="https://www.swanbitcoin.com/">Swan Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">


### PR DESCRIPTION
Removes the itBit listing under United States.

Companion to #4684

## Evidence

The listed URL `https://www.itbit.com/` currently fails on two independent grounds:

### 1. SSL certificate expired (Jun 2024)

The listed domain has not maintained a valid SSL certificate since June 2024:

```
$ echo | openssl s_client -servername www.itbit.com -connect www.itbit.com:443 2>/dev/null \
    | openssl x509 -noout -dates

notBefore=Jun  9 00:00:00 2023 GMT
notAfter=Jun 11 23:59:59 2024 GMT
```

That is approximately 22 months expired at the time of this PR. Browsers display a security warning; `curl` aborts the connection with `SSL certificate problem: certificate has expired`.

### 2. Retail services being deprecated by the operator (Aug 2023 onwards)

Paxos, the operator of itBit, [publicly announced on August 30, 2023](https://www.paxos.com/newsroom/focusing-on-our-enterprise-platform-and-retiring-legacy-itbit-services) the deprecation of retail services on itBit Exchange:

> "Paxos is further streamlining the platform to focus service on our core enterprise clients. Starting August 30, 2023, we will deprecate retail services for users on the itBit Exchange whose accounts are inactive or have little to no balance."

A retail-targeted FAQ documenting the retirement is available at: https://help.paxos.com/hc/en-us/articles/17667873012244-FAQ-Retiring-itBit-Retail-Users

The surviving Paxos itBit platform is now [explicitly positioned as enterprise-only](https://www.paxos.com/itbit), targeting trades over $100K USD with FIX 4.2 API access for institutional high-frequency trading — a different audience from the bitcoin.org consumer exchange listing.

## Criterion

Per `docs/adding-exchanges.md`, "Site functionality" is the first review criterion. The expired TLS certificate alone (point 1, ~22 months) is sufficient to fail that criterion. The operator's stated direction toward enterprise-only service (point 2) provides additional context for why the situation is unlikely to be temporary.

## Reproduction

Anyone can verify in under 5 seconds:

```
curl -I https://www.itbit.com/
echo | openssl s_client -servername www.itbit.com -connect www.itbit.com:443 2>/dev/null \
    | openssl x509 -noout -dates
```
