### PR TITLE
Remove Coinfloor listing — acquired by CoinCorner; ceased operations

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -308,8 +308,6 @@ id: exchanges
             <br>
             <a class="marketplace-link" href="https://www.coincorner.com/">CoinCorner</a>
             <br>
-            <a class="marketplace-link" href="https://www.coinfloor.co.uk/">Coinfloor</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
-            <br>
             <a class="marketplace-link" href="https://www.coinjar.com/uk/">CoinJar</a>
             <br>
             <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>


### PR DESCRIPTION
Companion to #4684

## Evidence

The listed URL `https://www.coinfloor.co.uk/` currently redirects (HTTP 301) to `https://www.coincorner.com/`.

### Acquisition by CoinCorner (Oct 2021)

CoinCorner acquired Coinfloor on **October 4, 2021**, with Coinfloor ceasing operations and customer accounts migrating to CoinCorner. Coinfloor (founded 2013) had been the longest-running cryptocurrency exchange in the UK at the time.

- CoinCorner blog (official announcement): https://blog.coincorner.com/coinfloor-to-migrate-customers-to-coincorner-to-further-british-bitcoin-adoption-31f5cbb22380
- Bitcoin Magazine coverage: https://bitcoinmagazine.com/business/bitcoin-exchange-coincorner-acquires-coinfloor-customer-base-domain

The migration process was completed and the Coinfloor brand was retired. CoinCorner is itself already listed under United Kingdom on bitcoin.org/en/exchanges, so no replacement is needed.

## Criterion

Per `docs/adding-exchanges.md`, "Site functionality" is the first review criterion. A listed URL that redirects to a different exchange (acquirer) — over four years after the acquisition completed — fails that criterion.

## Reproduction

```
curl -sIL https://www.coinfloor.co.uk/ | head -20
```

The first response shows `HTTP/2 301` with `location: https://www.coincorner.com/`, followed by `HTTP/2 200` on the CoinCorner homepage.