### PR TITLE
Remove Coinberry listing — acquired by Bitbuy/WonderFi; accounts migrated

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -383,8 +383,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a>
           <br>
-          <a class="marketplace-link" href="https://coinberry.com/">Coinberry</a>
-          <br>
           <a class="marketplace-link" href="https://www.coinsmart.com/">Coinsmart</a>
           <br>
           <a class="marketplace-link" href="https://ndax.io/">NDAX</a>

--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -337,8 +337,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
           <br>
-          <a class="marketplace-link" href="https://coinberry.com/">Coinberry</a>
-          <br>
           <a class="marketplace-link" href="https://ndax.io/">NDAX</a>
           <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>


### PR DESCRIPTION
Companion to #4684

## Evidence

The listed URL `https://coinberry.com/` currently redirects (HTTP 301 → 302) to `https://bitbuy.ca/en-ca`.

### Acquisition by Bitbuy/WonderFi (Jul 2023)

WonderFi/Bitbuy acquired Coinberry's client accounts in **July 2023**. Coinberry users were migrated to Bitbuy and the Coinberry brand was retired.

- WonderFi press release: https://www.wonder.fi/press-release/wonderfi-announces-proposed-transaction-for-bitbuy-to-acquire-coinberry-client-accounts
- SEC filing: https://www.sec.gov/Archives/edgar/data/0001882839/000110465922092982/tm2220521d1_ex99-121.htm

Bitbuy is itself already listed under Canada on bitcoin.org/en/exchanges, so no replacement is needed.

## Criterion

Per `docs/adding-exchanges.md`, "Site functionality" is the first review criterion. A listed URL that redirects to a different exchange (acquirer) — nearly three years after the acquisition completed — fails that criterion.

## Reproduction

```
curl -sIL https://coinberry.com/ | head -20
```

The first response shows `HTTP/2 301` with `location: https://bitbuy.ca/`, followed by `HTTP/2 302` and finally `HTTP/2 200` on the Bitbuy `/en-ca` page.