### PR TITLE
Remove CoinSmart listing — acquired by WonderFi; platform wind-down announced

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -385,8 +385,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://coinberry.com/">Coinberry</a>
           <br>
-          <a class="marketplace-link" href="https://www.coinsmart.com/">Coinsmart</a>
-          <br>
           <a class="marketplace-link" href="https://ndax.io/">NDAX</a>
           <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>


### PR DESCRIPTION
Companion to #4684

## Evidence

The listed URL `https://www.coinsmart.com/` currently redirects (HTTP 301 → 302) to `https://bitbuy.ca/en-ca`.

### Acquisition by WonderFi and platform wind-down (Jul 2023)

WonderFi acquired CoinSmart in **July 2023** as part of the WonderFi-Coinsquare-CoinSmart business combination, and subsequently announced the wind-down of the CoinSmart platform itself.

- WonderFi press release (closing of business combination): https://www.wonder.fi/press-release/wonderfi-coinsquare-and-coinsmart-announce-closing-of-business-combination
- Globe and Mail coverage (CoinSmart wind-down announcement): https://www.theglobeandmail.com/business/article-wonderfi-to-wind-down-coinsmart-as-deal-to-form-canadas-largest-crypto/

Bitbuy (the destination of the redirect, also a WonderFi property) is itself already listed under Canada on bitcoin.org/en/exchanges, so no replacement is needed.

## Criterion

Per `docs/adding-exchanges.md`, "Site functionality" is the first review criterion. A listed URL that redirects to a different exchange — following a publicly announced platform wind-down — fails that criterion.

## Reproduction

```
curl -sIL https://www.coinsmart.com/ | head -20
```

The first response shows `HTTP/2 301` with `location: https://bitbuy.ca/`, followed by `HTTP/2 302` and finally `HTTP/2 200` on the Bitbuy `/en-ca` page.