### PR TITLE
Remove Bitvo listing — acquired by Bitbuy/WonderFi; site deprovisioned

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -377,8 +377,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://bitcoinwell.com/">Bitcoin Well</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
           <br>
-          <a class="marketplace-link" href="https://bitvo.com/">Bitvo</a>
-          <br>
           <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
           <br>
           <a class="marketplace-link" href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a>


### PR DESCRIPTION
Companion to #4684

## Evidence

The listed URL `https://bitvo.com/` currently fails on two independent grounds:

### 1. Site deprovisioned

A TLS handshake against `bitvo.com` completes against the **Microsoft Azure default certificate** (`CN=*.azurewebsites.net`, issued by `Microsoft Azure RSA TLS Issuing CA 04`), with no Bitvo-specific certificate served. This is the signature of an Azure-hosted application that has been removed while the domain still resolves — the underlying app is no longer deployed.

```
$ echo | openssl s_client -servername bitvo.com -connect bitvo.com:443 2>/dev/null \
    | openssl x509 -noout -subject -issuer

subject=C=US, ST=WA, L=Redmond, O=Microsoft Corporation, CN=*.azurewebsites.net
issuer=C=US, O=Microsoft Corporation, CN=Microsoft Azure RSA TLS Issuing CA 04
```

The browser will load the Azure-signed page, but no Bitvo application is being served.

### 2. Acquisition by Bitbuy/WonderFi (Nov 2023)

Bitbuy (a WonderFi subsidiary) acquired Bitvo's customer base on **November 14, 2023**. Approximately 17,000 client accounts were migrated to Bitbuy, and the Bitvo platform was wound down.

- BetaKit coverage: https://betakit.com/wonderfi-owned-bitbuy-acquires-customers-of-fellow-regulated-canadian-crypto-exchange-bitvo/

Bitbuy is itself already listed under Canada on bitcoin.org/en/exchanges, so no replacement is needed.

## Criterion

Per `docs/adding-exchanges.md`, "Site functionality" is the first review criterion. The expired/deprovisioned application alone (point 1) is sufficient to fail that criterion. The publicly announced customer migration (point 2) provides additional context.

## Reproduction

Anyone can verify in under 5 seconds:

```
echo | openssl s_client -servername bitvo.com -connect bitvo.com:443 2>/dev/null \
    | openssl x509 -noout -subject -issuer
```