### PR TITLE
Remove AnyCoin Direct listing — acquired by Finst; platform wind-down announced

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -229,8 +229,6 @@ id: exchanges
 
     <div class="general-marketplace">
       <p>
-        <a class="marketplace-link" href="https://anycoindirect.eu">AnyCoin Direct</a>
-        <br>
         <a class="marketplace-link" href="https://www.binance.com">Binance</a>
         <br>
         <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>


### PR DESCRIPTION
Companion to #4684

## Evidence

The listed URL `https://anycoindirect.eu` currently redirects (HTTP 301) to `https://finst.com/`.

### Acquisition by Finst (Nov 2024) and announced platform wind-down

Finst acquired AnyCoin Direct on **November 12, 2024**. The acquiring company has publicly stated that the AnyCoin Direct platform will shut down, with users transitioning to Finst.

- Finst press release: https://finst.com/en/blog/finst-news/finst-and-anycoin-direct-join-forces
- AnyCoin Direct's own FAQ confirming the upcoming shutdown: https://anycoindirect.eu/en/support/anycoin-direct/finst

Finst is not currently listed on bitcoin.org/en/exchanges. If maintainers consider the destination platform a suitable replacement for European users, that would be a separate listing decision; this PR addresses only the removal of the URL that no longer resolves to a functioning AnyCoin Direct platform.

## Criterion

Per `docs/adding-exchanges.md`, "Site functionality" is the first review criterion. A listed URL that redirects to a different exchange — following a publicly announced platform wind-down — fails that criterion.

## Reproduction

```
curl -sIL https://anycoindirect.eu | head -10
```

The first response shows `HTTP/2 301` with `location: https://finst.com`, followed by `HTTP/2 200` on the Finst homepage.