### PR TITLE
bitbox02: update website

### DIFF
--- a/_wallets/bitbox.md
+++ b/_wallets/bitbox.md
@@ -13,7 +13,7 @@ platform:
     os:
       - name: hardware
         text: "walletbitbox"
-        link: "https://shiftcrypto.ch/bitbox02/"
+        link: "https://bitbox.swiss/bitbox02/"
         source: "https://github.com/BitBoxSwiss/bitbox02-firmware"
         screenshot: "bitbox02.png"
         features: "bech32 hardware_wallet legacy_addresses multisig segwit"


### PR DESCRIPTION
https://shiftcrypto.ch/bitbox02/ redirects to
https://bitbox.swiss/bitbox02/ and is the up to date URL

Fixes #4672