### PR TITLE
Remove Egera listing — domain DNS A record removed; site unreachable

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -283,8 +283,6 @@ id: exchanges
           <h3 id="poland" class="no_toc">Poland</h3>
           <p>
             <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
-            <br>
-            <a class="marketplace-link" href="https://egera.com/">Egera</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
Companion to #4684

## Evidence

The listed URL `https://egera.com/` is currently unreachable: the domain has no DNS A record, so no IP address resolves and HTTPS connections cannot be established.

```
$ dig +short egera.com
(no output — no A record)

$ host egera.com
egera.com mail is handled by 5 alt1.aspmx.l.google.com.
egera.com mail is handled by 1 aspmx.l.google.com.
... (only MX records returned)

$ python3 -c "import socket; print(socket.gethostbyname('egera.com'))"
socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```

The domain registration itself is still active (registered via GoDaddy until 2027, with Cloudflare nameservers), and email infrastructure remains configured (Google Workspace MX records). However, **the web platform is not deployed** — no A record means no website can load at this domain.

## Criterion

Per `docs/adding-exchanges.md`, "Site functionality" is the first review criterion. A listed URL whose domain returns no IP address fails that criterion at the most fundamental level: the listed exchange website cannot be reached at all.

This appears to be a multi-month state, not a transient outage; the registration and nameserver records have been stable while the A record remains absent.

## Reproduction

Anyone can verify in under 1 second:

```
dig +short egera.com
host egera.com
```