### PR TITLE
Update Bitybank URL to bity.com.br — same company rebranded

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -456,7 +456,7 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitypreco.com/">Bitypreço</a>
           <br>
-          <a class="marketplace-link" href="https://bitybank.com.br/">Bitybank</a>
+          <a class="marketplace-link" href="https://bity.com.br/">Bitybank</a>
           <br>
           <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>


### PR DESCRIPTION
Updates the listed URL for Bitybank from `https://bitybank.com.br/` to `https://bity.com.br/`.

Companion to #4684

## Why update rather than remove

Unlike the other 7 cases in #4684, **Bitybank is not a closed or acquired exchange** — it's the same legal entity rebranded. Bitybank, Bitypreço and Biscoint were consolidated under the **Bity** group, and the platform continues to operate.

The legacy domain `bitybank.com.br` redirects (HTTP 302 → 308) to `bity.com.br`, where the exchange is fully operational.

Source (company's own blog explaining the rebrand): https://www.bity.com.br/blog/bitypreco-o-que-aconteceu-com-exchange/

## Choice of URL format

The new URL is `https://bity.com.br/` (without `www.`) to stay consistent with the formatting of all other Brazil-section listings (Bitypreço, Brasil Bitcoin, Coinext, Foxbit, etc.), all of which use the bare domain. The browser is redirected to `www.bity.com.br` automatically.

The display text "Bitybank" is preserved — that is still the product name on the new domain.

## Reproduction

```
curl -sIL https://bitybank.com.br/ | head -10
```

Shows `HTTP/2 302` with `location: https://bity.com.br/`, confirming the legacy domain redirects to the new one.

---

**Note:** This is the final PR in the QA initiative documented in #4684 (7 removals + 1 URL update across 8 PRs).