### PR TITLE
Update WasabiWallet repository url

### DIFF
--- a/_wallets/wasabi.md
+++ b/_wallets/wasabi.md
@@ -14,7 +14,7 @@ platform:
     default: &DEFAULT
       text: "walletwasabi"
       link: "https://wasabiwallet.io/"
-      source: "https://github.com/zkSNACKs/WalletWasabi/"
+      source: "https://github.com/WalletWasabi/WalletWasabi/"
       screenshot: "wasabi.png"
       features: "bech32 hardware_wallet segwit"
       check:


### PR DESCRIPTION
Updates the listed URL for Wasabi Wallet from `https://github.com/zkSNACKs/WalletWasabi/` to `https://github.com/WalletWasabi/WalletWasabi/`.  

This changed two years ago after the company behind Wasabi Wallet closed its doors and let the project in the hands of the community and transferred the original repository.

More details in: https://github.com/bitcoin-dot-org/Bitcoin.org/issues/4674
Note: The description in `_translations/en.yml`  looks okay to me.
