### PR TITLE
Add Submit Your Business page

### DIFF
--- a/_templates/getting-started.html
+++ b/_templates/getting-started.html
@@ -127,7 +127,11 @@ id: getting-started
             {% translate visibility %}</h2>
           <p>{% translate visibilitytxt %}</p>
           <div>
+            {% if page.lang == 'en' %}
+            <a class="btn-bright" href="/en/{% translate submit-your-business url %}">{% translate visibilitybut %}</a>
+            {% else %}
             <a class="btn-bright" href="/{{ page.lang }}/{% translate spend-bitcoin url %}">{% translate visibilitybut %}</a>
+            {% endif %}
           </div>
         </div>
       </div>

--- a/_templates/submit-your-business.html
+++ b/_templates/submit-your-business.html
@@ -1,0 +1,67 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+layout: base
+id: submit-your-business
+---
+<div class="hero">
+  <div class="container hero-container">
+    <h1>{% translate pagetitle %}</h1>
+    <p class="summary">{% translate pagedesc %}</p>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row card-row">
+    <div class="card spend-card">
+      <img src="/img/icons/local.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="btc-map">{% translate btc-map %}</h2>
+      <p>{% translate btc-map-text %}</p>
+      <div>
+        <a class="btn-bright" href="https://btcmap.org/add-location">{% translate btc-map-button %}</a>
+      </div>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/product.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="spendabit">{% translate spendabit %}</h2>
+      <p>{% translate spendabit-text %}</p>
+      <div>
+        <a class="btn-bright" href="https://spendabit.co/onboard/">{% translate spendabit-button %}</a>
+      </div>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/directory.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="coinmap">{% translate coinmap %}</h2>
+      <p>{% translate coinmap-text %}</p>
+      <div>
+        <a class="btn-bright" href="https://coinmap.org/add">{% translate coinmap-button %}</a>
+      </div>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/search.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="bitcoinwide">{% translate bitcoinwide %}</h2>
+      <p>{% translate bitcoinwide-text %}</p>
+      <div>
+        <a class="btn-bright" href="https://bitcoinwide.com/business/add">{% translate bitcoinwide-button %}</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="row card-row">
+    <div class="card spend-card">
+      <img src="/img/icons/check.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="before-submit">{% translate before-submit %}</h2>
+      <p>{% translate before-submit-text %}</p>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/ico_business.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="keep-updated">{% translate keep-updated %}</h2>
+      <p>{% translate keep-updated-text %}</p>
+    </div>
+  </div>
+</div>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -62,7 +62,7 @@ en:
     pci: "No PCI compliance required"
     pcitext: "Accepting credit cards online typically requires extensive security checks in order to comply with the PCI standard. Bitcoin still requires you to <a href=\"#secure-your-wallet#\">secure your wallet</a> and your payment requests, however, you do not carry the costs and responsibilities that come with processing sensitive information from your customers like with credit card numbers."
     visibility: "Get some free visibility"
-    visibilitytext: "Bitcoin is an emerging market of new customers who are searching for ways to spend their bitcoins. Accepting them is a good way to get new customers and give your business some new visibility. Accepting a new payment method has often shown to be a clever practice for online businesses."
+    visibilitytext: "Bitcoin is an emerging market of new customers who are searching for ways to spend their bitcoins. Accepting them is a good way to get new customers and give your business some new visibility. You can <a href=\"/en/submit-your-business\">submit your business</a> to directories that help Bitcoin users find places to spend."
     multisig: "Multi-signature"
     multisigtext: "Bitcoin also includes a multi-signature feature which allows bitcoins to be spent only if a subset of a group of people authorize the transaction. This can be used by a board of directors, for example, to prevent members from making expenditures without enough consent from other members, as well as to track which members permitted particular transactions."
     transparency: "Accounting transparency"
@@ -1054,6 +1054,26 @@ en:
     business-map-text: "There are also many local businesses, like cafes and restaurants, that accept Bitcoin. You can use <a href=\"https://btcmap.org/\">btcmap.org</a> to browse thousands of businesses across the globe."
     business-search: "Global local and online business search"
     business-search-text: "<a href=\"https://bitcoinwide.com/\">BitcoinWide.com</a> is a global, open and free platform to search businesses, organizations or individuals who accept Bitcoin and other Cryptocurrency."
+  submit-your-business:
+    title: "Submit Your Business - Bitcoin"
+    pagetitle: "Submit Your Business"
+    pagedesc: "Help Bitcoin users find your shop, service, or online store."
+    btc-map: "Add a local place to BTC Map"
+    btc-map-text: "BTC Map is a free and open-source map of Bitcoin-accepting merchants. It is best for shops, restaurants, services, and other physical locations that accept Bitcoin."
+    btc-map-button: "Add to BTC Map"
+    spendabit: "List products on Spendabit"
+    spendabit-text: "Spendabit helps Bitcoin users search for products they can buy online. It is useful for ecommerce stores and merchants with online product catalogs."
+    spendabit-button: "Start Spendabit onboarding"
+    coinmap: "Add a location to Coinmap"
+    coinmap-text: "Coinmap is a long-running map for businesses that accept Bitcoin. Add your location so nearby Bitcoin users and travelers can find it."
+    coinmap-button: "Add to Coinmap"
+    bitcoinwide: "Submit to BitcoinWide"
+    bitcoinwide-text: "BitcoinWide lists local and online businesses that accept Bitcoin and other digital payments. It can be used for physical locations, organizations, and online services."
+    bitcoinwide-button: "Add to BitcoinWide"
+    before-submit: "Before you submit"
+    before-submit-text: "Prepare your business name, website, contact details, address if you have a physical location, and the Bitcoin payment methods you accept, such as on-chain or Lightning payments."
+    keep-updated: "Keep listings accurate"
+    keep-updated-text: "Directories are most useful when listings stay current. Update your listing if your hours, address, website, or payment options change, and remove it if you stop accepting Bitcoin."
   support-bitcoin:
     title: "Support Bitcoin - Bitcoin"
     pagetitle: "Support Bitcoin"
@@ -1234,6 +1254,7 @@ en:
     bitcoin-paper: bitcoin-paper
     whitepaper-mirrors: whitepaper-mirrors
     spend-bitcoin: spend-bitcoin
+    submit-your-business: submit-your-business
   anchor:
     community:
       non-profit: non-profit


### PR DESCRIPTION
## Summary

Adds an English Submit Your Business page for merchants that accept Bitcoin, addressing bounty #1583.

Changes:

- adds a new `submit-your-business` template with current directory/onboarding links
- points the English Getting Started merchant visibility button to the new page
- keeps non-English Getting Started pages on the existing Spend Bitcoin target to avoid missing translation keys
- links the Bitcoin for Businesses visibility text to the new page

The page includes BTC Map, Spendabit, Coinmap, and BitcoinWide. I checked the linked submission/onboarding URLs before opening the PR.

## Bounty

Fixes bitcoin-dot-org/Bitcoin.org#1583.

BTC bounty payment address: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`

## Testing

- `git diff --check -- _templates/submit-your-business.html _templates/getting-started.html _translations/en.yml`
- `ruby -e "require 'yaml'; YAML.load_file('_translations/en.yml'); puts 'en.yml ok'"`
- `ruby -e "require 'yaml'; loc=YAML.load_file('_translations/en.yml')['en']; abort('missing url') unless loc['url']['submit-your-business']=='submit-your-business'; abort('missing page') unless loc['submit-your-business']['title']; puts 'submit-your-business translations ok'"`

Full local Jekyll build was not run because this workspace has Ruby 2.6.10 while the repository pins Ruby 2.5.8 in the Gemfile.