### PR TITLE
Add Earn Bitcoin page

### DIFF
--- a/_includes/layout/base/footer-menu.html
+++ b/_includes/layout/base/footer-menu.html
@@ -109,6 +109,9 @@ http://opensource.org/licenses/MIT.
           <a href="/en/{% translate sell url %}">{% translate menu-sell layout %}</a>
         </li>
         {% if page.lang == 'en' %}
+        <li{% if page.id == 'earn' %} class="active"{% endif %}>
+          <a href="/en/{% translate earn url %}">{% translate menu-earn layout %}</a>
+        </li>
         <li{% if page.id == 'full-node' %} class="active"{% endif %}>
           <a href="/en/full-node">{% translate menu-full-node layout %}</a>
         </li>

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -61,6 +61,7 @@ http://opensource.org/licenses/MIT.
       <li{% if page.id == 'support-bitcoin' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate support-bitcoin url %}">{% translate menu-support-bitcoin layout %}</a>
       <li id="buybitcoinmenulink" {% if page.id == 'buy' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate buy url %}">{% translate menu-buy layout %}</a></li>
       <li id="sellbitcoinmenulink" {% if page.id == 'sell' %} class="active"{% endif %}><a href="/en/{% translate sell url %}">{% translate menu-sell layout %}</a></li>
+      {% if page.lang == 'en' %}<li{% if page.id == 'earn' %} class="active"{% endif %}><a href="/en/{% translate earn url %}">{% translate menu-earn layout %}</a></li>{% endif %}
       {% if page.lang == 'en' %}<li{% if page.id == 'full-node' %} class="active"{% endif %}><a href="/en/full-node">Running a full node</a></li>{% endif %}
       <li{% if page.id == 'development' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate development url %}">{% translate menu-development layout %}</a></li>
     </ul>

--- a/_templates/earn.html
+++ b/_templates/earn.html
@@ -1,0 +1,53 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+layout: base
+id: earn
+---
+<div class="hero">
+  <div class="container hero-container">
+    <h1>{% translate pagetitle %}</h1>
+    <p class="summary">{% translate pagedesc %}</p>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row card-row">
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_business.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="work">{% translate work %}</h2>
+      <p>{% translate worktext %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_developers.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="freelance">{% translate freelance %}</h2>
+      <p>{% translate freelancetext %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/product.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="sell">{% translate sellproducts %}</h2>
+      <p>{% translate sellproductstext %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_conversation.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="create">{% translate create %}</h2>
+      <p>{% translate createtext %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_code.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="contribute">{% translate contribute %}</h2>
+      <p>{% translate contributetext %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_better_security.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="safety">{% translate safety %}</h2>
+      <p>{% translate safetytext %}</p>
+    </div>
+  </div>
+</div>

--- a/_templates/earn.html
+++ b/_templates/earn.html
@@ -8,46 +8,48 @@ id: earn
 <div class="hero">
   <div class="container hero-container">
     <h1>{% translate pagetitle %}</h1>
-    <p class="summary">{% translate pagedesc %}</p>
+    <p class="summarytxt">{% translate summary %}</p>
   </div>
 </div>
 
 <div class="container">
+
   <div class="row card-row">
     <div class="card support-card">
-      <img class="titleicon" src="/img/icons/ico_business.svg?{{site.time | date: '%s'}}" alt="icon">
+      <img class="titleicon" src="/img/icons/ico_business.svg?{{site.time | date: '%s'}}" alt="Icon" />
       <h2 id="work">{% translate work %}</h2>
-      <p>{% translate worktext %}</p>
+      <p>{% translate worktxt %}</p>
     </div>
 
     <div class="card support-card">
-      <img class="titleicon" src="/img/icons/ico_developers.svg?{{site.time | date: '%s'}}" alt="icon">
-      <h2 id="freelance">{% translate freelance %}</h2>
-      <p>{% translate freelancetext %}</p>
+      <img class="titleicon" src="/img/icons/ico_wallet.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="sell">{% translate sell %}</h2>
+      <p>{% translate selltxt %}</p>
     </div>
 
     <div class="card support-card">
-      <img class="titleicon" src="/img/icons/product.svg?{{site.time | date: '%s'}}" alt="icon">
-      <h2 id="sell">{% translate sellproducts %}</h2>
-      <p>{% translate sellproductstext %}</p>
-    </div>
-
-    <div class="card support-card">
-      <img class="titleicon" src="/img/icons/ico_conversation.svg?{{site.time | date: '%s'}}" alt="icon">
-      <h2 id="create">{% translate create %}</h2>
-      <p>{% translate createtext %}</p>
-    </div>
-
-    <div class="card support-card">
-      <img class="titleicon" src="/img/icons/ico_code.svg?{{site.time | date: '%s'}}" alt="icon">
+      <img class="titleicon" src="/img/icons/ico_code.svg?{{site.time | date: '%s'}}" alt="Icon" />
       <h2 id="contribute">{% translate contribute %}</h2>
-      <p>{% translate contributetext %}</p>
+      <p>{% translate contributetxt %}</p>
     </div>
 
     <div class="card support-card">
-      <img class="titleicon" src="/img/icons/ico_better_security.svg?{{site.time | date: '%s'}}" alt="icon">
+      <img class="titleicon" src="/img/icons/ico_spread.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="create">{% translate create %}</h2>
+      <p>{% translate createtxt %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_mining.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="mining">{% translate mining %}</h2>
+      <p>{% translate miningtxt %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_security.svg?{{site.time | date: '%s'}}" alt="Icon" />
       <h2 id="safety">{% translate safety %}</h2>
-      <p>{% translate safetytext %}</p>
+      <p>{% translate safetytxt %}</p>
     </div>
   </div>
+
 </div>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -1054,6 +1054,22 @@ en:
     business-map-text: "There are also many local businesses, like cafes and restaurants, that accept Bitcoin. You can use <a href=\"https://btcmap.org/\">btcmap.org</a> to browse thousands of businesses across the globe."
     business-search: "Global local and online business search"
     business-search-text: "<a href=\"https://bitcoinwide.com/\">BitcoinWide.com</a> is a global, open and free platform to search businesses, organizations or individuals who accept Bitcoin and other Cryptocurrency."
+  earn:
+    title: "Earn Bitcoin - Bitcoin"
+    pagetitle: "Earn Bitcoin"
+    pagedesc: "You do not have to buy Bitcoin to get started. You can earn it by working, selling, contributing, and creating useful things."
+    work: "Find Bitcoin work"
+    worktext: "Bitcoin-focused job boards such as <a href=\"https://bitcoinerjobs.com/\">Bitcoiner Jobs</a> and communities such as <a href=\"https://www.reddit.com/r/Jobs4Bitcoins/\">Jobs4Bitcoins</a> can help you find people hiring for work paid in bitcoin."
+    freelance: "Complete freelance tasks"
+    freelancetext: "Task and bounty sites such as <a href=\"https://microlancer.io/\">Microlancer</a> and <a href=\"https://www.lightningbounties.com/\">Lightning Bounties</a> let people post small jobs that can be paid with Bitcoin or Lightning."
+    sellproducts: "Sell goods or services"
+    sellproductstext: "If you already sell products or services, you can accept Bitcoin directly. Tools such as <a href=\"https://btcpayserver.org/\">BTCPay Server</a> can help you receive payments without relying on a custodial payment processor."
+    create: "Create and share"
+    createtext: "Communities such as <a href=\"https://stacker.news/\">Stacker News</a> and apps built on <a href=\"https://nostr.com/\">Nostr</a> let people reward useful posts, writing, podcasts, and other work with small Bitcoin payments."
+    contribute: "Contribute to open source"
+    contributetext: "Some open source projects pay bounties for useful fixes and documentation. Bitcoin.org also has <a href=\"https://github.com/bitcoin-dot-org/bitcoin.org#earn-bitcoin-for-contributing\">bounties for selected contributions</a>."
+    safety: "Avoid scams"
+    safetytext: "Be skeptical of anyone promising easy returns, asking you to deposit money first, or requiring control of your wallet. Real earning opportunities pay for useful work, products, or services."
   support-bitcoin:
     title: "Support Bitcoin - Bitcoin"
     pagetitle: "Support Bitcoin"
@@ -1164,6 +1180,7 @@ en:
     menu-support-bitcoin: "Support Bitcoin"
     menu-buy: "Buy Bitcoin"
     menu-sell: "Sell Bitcoin"
+    menu-earn: "Earn Bitcoin"
     menu-full-node: "Running a full node"
     menu-other: "Other"
     menu-vocabulary: Vocabulary
@@ -1214,6 +1231,7 @@ en:
     transactions-guide: transactions-guide
     wallets-guide: wallets-guide
     development: development
+    earn: earn
     download: download
     exchanges: exchanges
     events: events

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -1054,22 +1054,6 @@ en:
     business-map-text: "There are also many local businesses, like cafes and restaurants, that accept Bitcoin. You can use <a href=\"https://btcmap.org/\">btcmap.org</a> to browse thousands of businesses across the globe."
     business-search: "Global local and online business search"
     business-search-text: "<a href=\"https://bitcoinwide.com/\">BitcoinWide.com</a> is a global, open and free platform to search businesses, organizations or individuals who accept Bitcoin and other Cryptocurrency."
-  earn:
-    title: "Earn Bitcoin - Bitcoin"
-    pagetitle: "Earn Bitcoin"
-    pagedesc: "You do not have to buy Bitcoin to get started. You can earn it by working, selling, contributing, and creating useful things."
-    work: "Find Bitcoin work"
-    worktext: "Bitcoin-focused job boards such as <a href=\"https://bitcoinerjobs.com/\">Bitcoiner Jobs</a> and communities such as <a href=\"https://www.reddit.com/r/Jobs4Bitcoins/\">Jobs4Bitcoins</a> can help you find people hiring for work paid in bitcoin."
-    freelance: "Complete freelance tasks"
-    freelancetext: "Task and bounty sites such as <a href=\"https://microlancer.io/\">Microlancer</a> and <a href=\"https://www.lightningbounties.com/\">Lightning Bounties</a> let people post small jobs that can be paid with Bitcoin or Lightning."
-    sellproducts: "Sell goods or services"
-    sellproductstext: "If you already sell products or services, you can accept Bitcoin directly. Tools such as <a href=\"https://btcpayserver.org/\">BTCPay Server</a> can help you receive payments without relying on a custodial payment processor."
-    create: "Create and share"
-    createtext: "Communities such as <a href=\"https://stacker.news/\">Stacker News</a> and apps built on <a href=\"https://nostr.com/\">Nostr</a> let people reward useful posts, writing, podcasts, and other work with small Bitcoin payments."
-    contribute: "Contribute to open source"
-    contributetext: "Some open source projects pay bounties for useful fixes and documentation. Bitcoin.org also has <a href=\"https://github.com/bitcoin-dot-org/bitcoin.org#earn-bitcoin-for-contributing\">bounties for selected contributions</a>."
-    safety: "Avoid scams"
-    safetytext: "Be skeptical of anyone promising easy returns, asking you to deposit money first, or requiring control of your wallet. Real earning opportunities pay for useful work, products, or services."
   support-bitcoin:
     title: "Support Bitcoin - Bitcoin"
     pagetitle: "Support Bitcoin"
@@ -1094,6 +1078,22 @@ en:
     translatetxt: "You can help spread Bitcoin awareness by translating or improving translations inside important parts of the Bitcoin ecosystem. Just pick a project you would like to help with."
     help: "Meet the communities"
     helptxt: "You can join Bitcoin <a href=\"#community#\">communities</a> and talk with other Bitcoin enthusiasts. You can learn more about Bitcoin every day, give help to new users and get involved in interesting projects."
+  earn:
+    title: "Earn Bitcoin - Bitcoin"
+    pagetitle: "Earn Bitcoin"
+    summary: "There are many ways to earn bitcoin through work, business, creativity, and contributions to the Bitcoin ecosystem."
+    work: "Work for bitcoin"
+    worktxt: "Freelancers and remote workers can look for bitcoin-paying clients and employers on communities and job boards like <a href=\"https://www.reddit.com/r/Jobs4Bitcoins/\">Jobs4Bitcoins</a> and <a href=\"https://bitcoinerjobs.com/\">Bitcoiner Jobs</a>. People with existing employers or clients can also use services such as <a href=\"https://bitwage.com/\">Bitwage</a> to receive some or all of their pay in bitcoin."
+    sell: "Sell goods and services"
+    selltxt: "Merchants, creators, and small businesses can accept bitcoin directly. A self-hosted payment processor such as <a href=\"https://btcpayserver.org/\">BTCPay Server</a> can help you receive payments without relying on a custodial processor."
+    contribute: "Contribute to open source"
+    contributetxt: "Developers, writers, translators, designers, and testers can earn bitcoin by completing public bounties or applying for grants. Start with <a href=\"https://github.com/bitcoin-dot-org/bitcoin.org#earn-bitcoin-for-contributing\">Bitcoin.org bounties</a>, <a href=\"https://www.lightningbounties.com/\">Lightning Bounties</a>, or grant programs such as <a href=\"https://opensats.org/\">OpenSats</a>."
+    create: "Publish and create"
+    createtxt: "Writers, podcasters, video makers, musicians, and educators can use Bitcoin and Lightning payment tools to receive direct support from their audiences. Communities like <a href=\"https://stacker.news/\">Stacker News</a> and value-for-value apps such as <a href=\"https://fountain.fm/\">Fountain</a> are examples of this model."
+    mining: "Mine bitcoin"
+    miningtxt: "Bitcoin mining rewards miners for helping secure the network. Mining requires specialized hardware, reliable electricity, and careful cost planning, so it is not the easiest way for most newcomers to earn bitcoin."
+    safety: "Stay safe"
+    safetytxt: "Avoid any offer that asks you to pay money up front to earn bitcoin, promises guaranteed returns, or pressures you to share private keys or seed words. Research each service, understand its fees and privacy tradeoffs, and make sure the opportunity is legal where you live."
   vocabulary:
     title: "Vocabulary - Bitcoin"
     pagetitle: "Some Bitcoin words you might hear"
@@ -1231,8 +1231,8 @@ en:
     transactions-guide: transactions-guide
     wallets-guide: wallets-guide
     development: development
-    earn: earn
     download: download
+    earn: earn
     exchanges: exchanges
     events: events
     faq: faq


### PR DESCRIPTION
## Summary

Adds an English Earn Bitcoin page for bounty #2524.

Changes:

- adds a new `earn` page with practical ways to earn bitcoin through work, selling, creating, mining, and open source contributions
- adds an English-only Participate menu/footer link so untranslated pages do not get links to pages that are not generated
- omits the homepage button, matching the maintainer feedback in the issue discussion
- includes a safety section warning against upfront-deposit, private-key, and easy-return scams

I checked the external links before opening the PR and avoided links that failed or redirected to unrelated pages.

## Bounty

Addresses bitcoin-dot-org/Bitcoin.org#2524.

BTC bounty payment address: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`

## Testing

- `git diff --check -- _templates/earn.html _includes/layout/base/head-menu.html _includes/layout/base/footer-menu.html _translations/en.yml`
- `ruby -e "require 'yaml'; YAML.load_file('_translations/en.yml'); puts 'en.yml ok'"`
- checked the `earn` translation keys, `earn` URL key, and `menu-earn` layout key are present
- checked every icon referenced by `_templates/earn.html` has both `.svg` and `.png` assets
- checked the external links used on the page returned final HTTP 200 responses

Full local Jekyll build was not run because this workspace has Ruby 2.6.10 while the repository pins Ruby 2.5.8 in the Gemfile; a verification-only bundle attempt was also blocked by native `ffi` build failure on this macOS arm64 environment.
