### PR TITLE
Add an Earn Bitcoin page and site navigation entry

### DIFF
--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -60,6 +60,7 @@ http://opensource.org/licenses/MIT.
     <ul>
       <li{% if page.id == 'support-bitcoin' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate support-bitcoin url %}">{% translate menu-support-bitcoin layout %}</a>
       <li id="buybitcoinmenulink" {% if page.id == 'buy' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate buy url %}">{% translate menu-buy layout %}</a></li>
+      {% if page.lang == 'en' %}<li{% if page.id == 'earn-bitcoin' %} class="active"{% endif %}><a href="/en/earn-bitcoin">Earn Bitcoin</a></li>{% endif %}
       <li id="sellbitcoinmenulink" {% if page.id == 'sell' %} class="active"{% endif %}><a href="/en/{% translate sell url %}">{% translate menu-sell layout %}</a></li>
       {% if page.lang == 'en' %}<li{% if page.id == 'full-node' %} class="active"{% endif %}><a href="/en/full-node">Running a full node</a></li>{% endif %}
       <li{% if page.id == 'development' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate development url %}">{% translate menu-development layout %}</a></li>

--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -8,6 +8,7 @@
       <a class="btn btn-bright btn-home" href="/{{ page.lang }}/{% translate getting-started url %}">{% translate getstarted layout %}</a>
       <a class="btn btn-light btn-home" href="/{{ page.lang }}/{% translate choose-your-wallet url %}">{% translate choosebut getting-started %}</a>
       <a id="buybitcoinbutton" class="btn btn-light btn-home" href="/{{ page.lang }}/{% translate buy url %}">{% translate menu-buy layout %}</a>
+      {% if page.lang == 'en' %}<a class="btn btn-light btn-home" href="/en/earn-bitcoin">Earn Bitcoin</a>{% endif %}
     </div>
 
     <div class="mainvideo">

--- a/_templates/earn-bitcoin.html
+++ b/_templates/earn-bitcoin.html
@@ -1,0 +1,40 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+layout: base
+id: earn-bitcoin
+---
+<div class="hero">
+  <div class="container hero-container">
+    <h1>Earn Bitcoin</h1>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row card-row">
+    <div class="card spend-card">
+      <img src="/img/icons/product.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="sell-goods-services">Sell goods and services</h2>
+      <p>Accept Bitcoin payments for products, freelance work, or consulting services.</p>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/directory.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="contribute-open-source">Contribute to open source</h2>
+      <p>Some open-source projects and communities offer bounties for code, documentation, and security improvements.</p>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/search.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="find-remote-work">Find remote work</h2>
+      <p>Look for global opportunities where clients can pay in Bitcoin for design, development, writing, or operations.</p>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/local.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="learn-safety">Use trusted platforms and stay safe</h2>
+      <p>Use reputable marketplaces, verify counterparties, and avoid offers that promise guaranteed profits or require upfront deposits.</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add a new Earn Bitcoin page with practical earning paths
- add an Earn Bitcoin item under the Participate menu (English)
- add an Earn Bitcoin button on the home page (English)

## Why
This addresses the open bounty request in #2524 by adding a dedicated page and direct navigation paths.

## Testing
- content and link updates only

Closes #2524