### PR TITLE
Remove Kuna from exchanges (ceased operations 31 March 2025)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -286,16 +286,6 @@ id: exchanges
       </div>
 
       <div class="row marketplace">
-        <img class="marketplace-flag" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag">
-        <div>
-          <h3 id="ukraine" class="no_toc">Ukraine</h3>
-          <p>
-            <a class="marketplace-link" href="https://kuna.io/">Kuna</a>
-          </p>
-        </div>
-      </div>
-
-      <div class="row marketplace">
         <img class="marketplace-flag" src="/img/flags/UK.svg?{{site.time | date: '%s'}}" alt="United Kingdom flag">
         <div>
           <h3 id="united-kingdom" class="no_toc">United Kingdom</h3>


### PR DESCRIPTION
Removes Kuna from the exchanges listing. Per #4715 (case 8).

## Evidence

The official Kuna website displays the following notice on its homepage:

> "On March 31, 2025, the Kuna platform officially ceased operations."

Kuna was blocked by Ukrainian authorities in January 2025 and announced final wind-down shortly after.

## Sources

- [kuna.io](https://kuna.io/) — notice posted on homepage
- [Kyiv Post coverage](https://www.kyivpost.com/post/46355)

## Reproduction

```bash
curl -sL https://kuna.io/ | grep -i "ceased"
```

The notice text appears in the rendered HTML.

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The listed URL no longer resolves to a functioning instance of the listed exchange.

## Note

Kuna was the only exchange listed for Ukraine, so the entire region block was removed (10 lines). The diff shows only deletions, no additions.