### PR TITLE
Remove Canadian Bitcoins from exchanges (wind-down announced 19 March 2026)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -373,8 +373,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
           <br>
-          <a class="marketplace-link" href="https://www.canadianbitcoins.com/">Canadian Bitcoins</a>
-          <br>
           <a class="marketplace-link" href="https://coinberry.com/">Coinberry</a>
           <br>
           <a class="marketplace-link" href="https://ndax.io/">NDAX</a>


### PR DESCRIPTION
Removes Canadian Bitcoins from the exchanges listing. Per #4715 (case 9).

## Evidence

The official Canadian Bitcoins website displays the following wind-down notice on its homepage:

> "March 19, 2026 — FOR IMMEDIATE RELEASE
>
> It's with a heavy heart to announce that after careful consideration I have made the difficult decision to wind down Canadian Bitcoins."

Last day of operation: **31 March 2026**.

## Sources

- [canadianbitcoins.com](https://www.canadianbitcoins.com/) — official wind-down announcement posted on homepage

## Reproduction

```bash
curl -sL https://www.canadianbitcoins.com/ | grep -i "wind down"
```

The notice text appears in the rendered HTML.

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The exchange has officially wound down operations.