### PR TITLE
Remove Kiwi-coin from exchanges (ceased operations 1 January 2026)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -501,8 +501,6 @@ id: exchanges
     <a class="marketplace-link" href="https://www.bitaroo.nz/">Bitaroo</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
-    <br>
-    <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
   </p>
 </div>
 


### PR DESCRIPTION
Removes Kiwi-coin from the exchanges listing. Per #4715 (case 10).

## Evidence

Kiwi-coin announced its closure on 17 October 2025 and ceased operations on 1 January 2026, citing banking de-risking in New Zealand. It was one of New Zealand's longest-running exchanges.

## Sources

- [Cryptocurrency NZ — Kiwi-coin closes down amid banking crisis](https://cryptocurrency.org.nz/news/kiwi-coin-closes-down-amid-banking-crisis)
- [MEXC blog — coverage of the shutdown](https://blog.mexc.com/news/goodbye-kiwi-coin-what-the-shutdown-of-nzs-longest-running-exchange-means-for-local-liquidity-in-2026/)

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The exchange has ceased operations.