### PR TITLE
Remove ArgenBTC from exchanges (ceased operations 24 March 2025)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -430,8 +430,6 @@ id: exchanges
       <div>
         <h3 id="argentina" class="no_toc">Argentina</h3>
         <p>
-          <a class="marketplace-link" href="https://argenbtc.com/">ArgenBTC</a>
-          <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>


### PR DESCRIPTION
Removes ArgenBTC from the exchanges listing. Per #4715 (case 7).

## Evidence

ArgenBTC, a pioneer Bitcoin exchange in Argentina, announced its shutdown in October 2024 due to CNV (Comisión Nacional de Valores) regulations. Final closure was on 24 March 2025.

## Sources

- [La Nación — coverage of the shutdown announcement](https://www.lanacion.com.ar/economia/IA/el-sitio-de-compraventa-de-cripto-argenbtc-dejara-de-operar-en-el-pais-nid12112024/)
- [argenbtc.com/status](https://argenbtc.com/status) — closure status page

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The exchange has ceased operations.