### PR TITLE
Resources: fix outdated links and remove orphaned translation string

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -32,13 +32,13 @@ id: resources
         </p>
         <p>{% translate linkwiki %}</p>
         <p>
-          <a href="https://bitcoiner.guide">Bitcoiner.Guide</a>
+          <a href="https://bitcoiner.guide/resources">Bitcoiner.Guide</a>
         </p>
         <p>
           <a href="https://nakamotoinstitute.org/">Satoshi Nakamoto Institute</a>
         </p>
         <p>
-          <a href="http://www.bitcoinprojects.net/">BitcoinProjects.net</a>
+          <a href="https://bitcoinprojects.net/">BitcoinProjects.net</a>
         </p>
       </div>
 

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -963,7 +963,6 @@ en:
     pagedesc: "Useful websites and resources about Bitcoin."
     linkwiki: "<a href=\"https://en.bitcoin.it/\">Bitcoin Wiki</a>"
     charts: "Charts & Tools"
-    news: "News"
     documentaries: "Documentaries"
     learn: "Learning Resources"
     podcasts: "Podcasts"


### PR DESCRIPTION
This PR makes three small, factual fixes to the Resources page.

### 1. Update Bitcoiner.Guide link

The link pointed to the root domain `bitcoiner.guide`, which currently serves a paid mentorship landing page. The educational material is at the `/resources` subpath. Updated the URL accordingly.

### 2. Fix BitcoinProjects.net to HTTPS

`http://www.bitcoinprojects.net/` was the only non-HTTPS link on the page and redirects to `https://bitcoinprojects.net/`. Updated to point directly to the HTTPS URL.

### 3. Remove orphaned `news` translation string

`_translations/en.yml` defined `news: "News"` under the `resources:` block, but no `{% translate news %}` exists in `_templates/resources.html`. This is leftover from the News section removed years ago. Removed the unused string.

Davi de Jesus