### PR TITLE
Add missing Bitcoin Core release notes (28.2 through 31.0)

### DIFF
--- a/_releases/v28.2.md
+++ b/_releases/v28.2.md
@@ -1,0 +1,125 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 28.2
+title: Bitcoin Core 28.2
+id: en-release-28.2
+name: release-28.2
+permalink: /en/releases/28.2/
+excerpt: Bitcoin Core version 28.2 is now available
+date: 2025-06-26
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [28, 2]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+28.2 Release Notes
+==================
+
+Bitcoin Core version 28.2 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-28.2/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and extensively tested on operating systems
+using the Linux Kernel 3.17+, macOS 11.0+, and Windows 7 and newer. Bitcoin
+Core should also work on most other UNIX-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### Build
+
+- #31407 guix: Notarize MacOS app bundle and codesign all MacOS and Windows binaries
+- #31500 depends: Fix compiling libevent package on NetBSD
+- #31627 depends: Fix spacing issue
+- #32070 build: use make < 3.82 syntax for define directive
+- #32439 guix: accomodate migration to codeberg
+- #32568 depends: use "mkdir -p" when installing xproto
+- #32693 depends: fix cmake compatibility error for freetype
+
+### Test
+
+- #32286 test: Handle empty string returned by CLI as None in RPC tests
+- #32336 test: Suppress upstream -Wduplicate-decl-specifier in bpfcc
+
+### Tracing
+
+- #31623 tracing: Rename the MIN macro to TRACEPOINT_TEST_MIN in log_raw_p2p_msgs
+
+### Doc
+
+- #32003 doc: remove note about macOS self-signing
+
+### Misc
+
+- #31611 doc: upgrade license to 2025
+- #32187 refactor: Remove spurious virtual from final ~CZMQNotificationInterface
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- 0xB10C
+- achow101
+- Brandon Odiwuor
+- fanquake
+- Hennadii Stepanov
+- josibake
+- kehiy
+- MarcoFalke
+- Sjors Provoost
+
+As well as to everyone that helped with translations on
+[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v28.3.md
+++ b/_releases/v28.3.md
@@ -1,0 +1,154 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 28.3
+title: Bitcoin Core 28.3
+id: en-release-28.3
+name: release-28.3
+permalink: /en/releases/28.3/
+excerpt: Bitcoin Core version 28.3 is now available
+date: 2025-10-17
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [28, 3]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+28.3 Release Notes
+==================
+
+Bitcoin Core version 28.3 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-28.3/>
+
+This release includes various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and extensively tested on operating systems
+using the Linux Kernel 3.17+, macOS 11.0+, and Windows 7 and newer. Bitcoin
+Core should also work on most other UNIX-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### Mempool & Policy
+
+ The minimum block feerate (`-blockmintxfee`) has been changed to 1 satoshi per kvB. It can still be changed using the
+configuration option.
+
+- The default minimum relay feerate (`-minrelaytxfee`) and incremental relay feerate (`-incrementalrelayfee`) have been
+changed to 100 satoshis per kvB. They can still be changed using their respective configuration options, but it is
+recommended to change both together if you decide to do so.
+
+  - Other minimum feerates (e.g. the dust feerate, the minimum returned by the fee estimator, and all feerates used by
+  the wallet) remain unchanged. The mempool minimum feerate still changes in response to high volume.
+
+  - Note that unless these lower defaults are widely adopted across the network, transactions created with lower fee
+  rates are not guaranteed to propagate or confirm. The wallet feerates remain unchanged; `-mintxfee` must be changed
+  before attempting to create transactions with lower feerates using the wallet.
+
+- #33106 policy: lower the default blockmintxfee, incrementalrelayfee, minrelaytxfee
+- #33504 mempool: Do not enforce TRUC checks on reorg
+
+### P2P
+
+- #33395 net: do not apply whitelist permissions to onion inbounds
+
+### Test
+
+- #32765 test: Fix list index out of range error in feature_bip68_sequence.py
+- #33001 test: Do not pass tests on unhandled exceptions
+- #30125 test: improve BDB parser (handle internal/overflow pages, support all page sizes)
+- #30948 test: Add missing sync_mempools() to fill_mempool()
+- #30784 test: add BulkTransaction helper to unit test transaction utils
+
+### Build
+
+- #32678 guix: warn and abort when SOURCE_DATE_EPOCH is set
+- #32943 depends: Force CMAKE_EXPORT_NO_PACKAGE_REGISTRY=TRUE
+- #33073 guix: warn SOURCE_DATE_EPOCH set in guix-codesign
+- #33563 build: fix depends Qt download link
+
+### Doc
+
+- #32776 doc: taproot became always active in v24.0
+- #32777 doc: fix Transifex 404s
+- #33070 doc/zmq: fix unix socket path example
+- #33133 rpc: fix getpeerinfo ping duration unit docs
+- #33236 doc: Remove wrong and redundant doxygen tag
+
+### Misc
+
+- #33340 Fix benchmark CSV output
+- #33482 contrib: fix macOS deployment with no translations
+- #33581 ci: Properly include $FILE_ENV in DEPENDS_HASH
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- 0xB10C
+- amisha
+- Ava Chow
+- fanquake
+- glozow
+- Hennadii Stepanov
+- MarcoFalke
+- Martin Zumsande
+- romanz
+- Sjors Provoost
+- theStack
+- Vasil Dimov
+- willcl-ark
+- zaidmstrr
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v28.4.md
+++ b/_releases/v28.4.md
@@ -1,0 +1,122 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 28.4
+title: Bitcoin Core 28.4
+id: en-release-28.4
+name: release-28.4
+permalink: /en/releases/28.4/
+excerpt: Bitcoin Core version 28.4 is now available
+date: 2026-03-18
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [28, 4]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+28.4 Release Notes
+==================
+
+Bitcoin Core version 28.4 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-28.4/>
+
+This release includes various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and extensively tested on operating systems
+using the Linux Kernel 3.17+, macOS 11.0+, and Windows 7 and newer. Bitcoin
+Core should also work on most other UNIX-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### Wallet
+
+- #34156 wallet: fix unnamed legacy wallet migration failure
+- #34215 wallettool: fix unnamed createfromdump failure walletsdir deletion
+- #34226 wallet: test: Relative wallet failed migration cleanup
+- #34370 Fix #34222 backport bugs
+
+### P2P
+
+- #33723 chainparams: remove dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us
+
+### Build
+
+- #34227 guix: Fix `osslsigncode` tests
+
+### CI
+
+- #32513 ci: remove 3rd party js from windows dll gha job
+- #34344 ci: update GitHub Actions versions
+- #34463 ci: use macos-14 image
+
+### Misc
+
+- #34174 doc: update copyright year to 2026
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- achow101
+- davidgumberg
+- fanquake
+- furszy
+- Hennadii Stepanov
+- Luke Dashjr
+- m3dwards
+- Padraic Slattery
+- SatsAndSports
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v29.0.md
+++ b/_releases/v29.0.md
@@ -1,0 +1,302 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 29.0
+title: Bitcoin Core 29.0
+id: en-release-29.0
+name: release-29.0
+permalink: /en/releases/29.0/
+excerpt: Bitcoin Core version 29.0 is now available
+date: 2025-04-14
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [29, 0]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+29.0 Release Notes
+==================
+
+Bitcoin Core version 29.0 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-29.0/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### P2P and Network Changes
+
+- Support for UPnP was dropped. If you want to open a port automatically, consider using the `-natpmp`
+option instead, which uses PCP or NAT-PMP depending on router support. (#31130)
+
+- libnatpmp was replaced with a built-in implementation of PCP and NAT-PMP (still enabled using the `-natpmp` option). This supports automatic IPv4 port forwarding as well as IPv6 pinholing. (#30043)
+
+- When the `-port` configuration option is used, the default onion listening port will now
+be derived to be that port + 1 instead of being set to a fixed value (8334 on mainnet).
+This re-allows setups with multiple local nodes using different `-port` and not using `-bind`,
+which would lead to a startup failure in v28.0 due to a port collision.
+Note that a `HiddenServicePort` manually configured in `torrc` may need adjustment if used in
+connection with the `-port` option.
+For example, if you are using `-port=5555` with a non-standard value and not using `-bind=...=onion`,
+previously Bitcoin Core would listen for incoming Tor connections on `127.0.0.1:8334`.
+Now it would listen on `127.0.0.1:5556` (`-port` plus one). If you configured the hidden service manually
+in torrc now you have to change it from `HiddenServicePort 8333 127.0.0.1:8334` to `HiddenServicePort 8333
+127.0.0.1:5556`, or configure bitcoind with `-bind=127.0.0.1:8334=onion` to get the previous behavior.
+(#31223)
+
+- Upon receiving an orphan transaction (an unconfirmed transaction that spends unknown inputs), the node will attempt to download missing parents from all peers who announced the orphan. This change may increase bandwidth usage but make orphan-handling more reliable. (#31397)
+
+### Mempool Policy and Mining Changes
+
+- Ephemeral dust is a new concept that allows a single
+dust output in a transaction, provided the transaction
+is zero fee. In order to spend any unconfirmed outputs
+from this transaction, the spender must also spend
+this dust in addition to any other desired outputs.
+In other words, this type of transaction
+should be created in a transaction package where
+the dust is both created and spent simultaneously. (#30239)
+
+- Due to a bug, the default block reserved weight (`4,000 WU`) for fixed-size block header, transactions count, and coinbase transaction was reserved twice and could not be lowered. As a result the total reserved weight was always `8,000 WU`, meaning that even when specifying a `-blockmaxweight` higher than the default (even to the max of `4,000,000 WU`), the actual block size will never exceed `3,992,000 WU`.
+The fix consolidates the reservation into a single place and introduces a new startup option, `-blockreservedweight` which specifies the reserved weight directly. The default value of `-blockreservedweight` is set to `8,000 WU` to ensure backward compatibility for users who relied on the previous behavior of `-blockmaxweight`.
+The minimum value of `-blockreservedweight` is set to `2,000 WU`. Users setting `-blockreservedweight` below the default should ensure that the total weight of their block header, transaction count, and coinbase transaction does not exceed the reduced value or they may risk mining an invalid block. (#31384)
+
+### Updated RPCs
+
+- The RPC `testmempoolaccept` response now includes a `reject-details` field in some cases,
+similar to the complete error messages returned by `sendrawtransaction` (#28121)
+
+- Duplicate blocks submitted with `submitblock` will now persist their block data
+even if it was previously pruned. If pruning is activated, the data will be
+pruned again eventually once the block file it is persisted in is selected for
+pruning. This is consistent with the behaviour of `getblockfrompeer` where the
+block is persisted as well even when pruning. (#31175)
+
+- `getmininginfo` now returns `nBits` and the current target in the `target` field. It also returns a `next` object which specifies the `height`, `nBits`, `difficulty`, and `target` for the next block. (#31583)
+
+- `getblock` and `getblockheader` now return the current target in the `target` field (#31583)
+
+- `getblockchaininfo` and `getchainstates` now return `nBits` and the current target in the `target` field (#31583)
+
+- the `getblocktemplate` RPC `curtime` (BIP22) and `mintime` (BIP23) fields now
+  account for the timewarp fix proposed in BIP94 on all networks. This ensures
+  that, in the event a timewarp fix softfork activates on mainnet, un-upgraded
+  miners will not accidentally violate the timewarp rule. (#31376, #31600)
+As a reminder, it's important that any software which uses the `getblocktemplate`
+RPC takes these values into account (either `curtime` or `mintime` is fine).
+Relying only on a clock can lead to invalid blocks under some circumstances,
+especially once a timewarp fix is deployed. (#31600)
+
+### New RPCs
+
+- `getdescriptoractivity` can be used to find all spend/receive activity relevant to
+  a given set of descriptors within a set of specified blocks. This call can be used with
+  `scanblocks` to lessen the need for additional indexing programs. (#30708)
+
+### Updated REST APIs
+
+- `GET /rest/block/<BLOCK-HASH>.json` and `GET /rest/headers/<BLOCK-HASH>.json` now return the current target in the `target` field
+
+### Updated Settings
+
+- The maximum allowed value for the `-dbcache` configuration option has been
+  dropped due to recent UTXO set growth. Note that before this change, large `-dbcache`
+  values were automatically reduced to 16 GiB (1 GiB on 32 bit systems). (#28358)
+
+- Handling of negated `-noseednode`, `-nobind`, `-nowhitebind`, `-norpcbind`, `-norpcallowip`, `-norpcwhitelist`, `-notest`, `-noasmap`, `-norpcwallet`, `-noonlynet`, and `-noexternalip` options has changed. Previously negating these options had various confusing and undocumented side effects. Now negating them just resets the settings and restores default behaviors, as if the options were not specified.
+
+- Starting with v28.0, the `-mempoolfullrbf` startup option was set to
+default to `1`. With widespread adoption of this policy, users no longer
+benefit from disabling it, so the option has been removed, making full
+replace-by-fee the standard behavior. (#30592)
+
+- Setting `-upnp` will now log a warning and be interpreted as `-natpmp`. Consider using `-natpmp` directly instead. (#31130, #31916)
+
+- As a safety check, Bitcoin core will **fail to start** when `-blockreservedweight` init parameter value is lower than `2000` weight units. Bitcoin Core will also **fail to start** if the `-blockmaxweight` or `-blockreservedweight` init parameter exceeds consensus limit of `4,000,000 WU`.
+
+- Passing `-debug=0` or `-debug=none` now behaves like `-nodebug`: previously set debug categories will be cleared, but subsequent `-debug` options will still be applied.
+
+- The default for `-rpcthreads` has been changed from 4 to 16, and the default for `-rpcworkqueue` has been changed from 16 to 64. (#31215).
+
+### Build System
+
+The build system has been migrated from Autotools to CMake:
+
+1. The minimum required CMake version is 3.22.
+2. In-source builds are not allowed. When using a subdirectory within the root source tree as a build directory, it is recommended that its name includes the substring "build".
+3. CMake variables may be used to configure the build system. **Some defaults have changed.** For example, you will now need to add `-DWITH_ZMQ=ON` to build with zmq and `-DBUILD_GUI=ON` to build `bitcoin-qt`. See [Autotools to CMake Options Mapping](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Autotools-to-CMake-Options-Mapping) for details.
+4. For single-configuration generators, the default build configuration (`CMAKE_BUILD_TYPE`) is "RelWithDebInfo". However, for the "Release" configuration, CMake defaults to the compiler optimization flag `-O3`, which has not been extensively tested with Bitcoin Core. Therefore, the build system replaces it with `-O2`.
+5. By default, the built executables and libraries are located in the `bin/` and `lib/` subdirectories of the build directory.
+6. The build system supports component‐based installation. The names of the installable components coincide with the build target names. For example:
+```
+cmake -B build
+cmake --build build --target bitcoind
+cmake --install build --component bitcoind
+```
+
+7. If any of the `CPPFLAGS`, `CFLAGS`, `CXXFLAGS` or `LDFLAGS` environment variables were used in your Autotools-based build process, you should instead use the corresponding CMake variables (`APPEND_CPPFLAGS`, `APPEND_CFLAGS`, `APPEND_CXXFLAGS` and `APPEND_LDFLAGS`). Alternatively, if you opt to use the dedicated `CMAKE_<...>_FLAGS` variables, you must ensure that the resulting compiler or linker invocations are as expected.
+
+For more detailed guidance on configuring and using CMake, please refer to the official [CMake documentation](https://cmake.org/cmake/help/latest/) and [CMake’s User Interaction Guide](https://cmake.org/cmake/help/latest/guide/user-interaction/index.html). Additionally, consult platform-specific `doc/build-*.md` build guides for instructions tailored to your operating system.
+
+## Low-Level Changes
+
+### Tools and Utilities
+
+- A new tool [`utxo_to_sqlite.py`](https://github.com/bitcoin/bitcoin/blob/v29.0/contrib/utxo-tools/utxo_to_sqlite.py)
+  converts a compact-serialized UTXO snapshot (as created with the
+  `dumptxoutset` RPC) to a SQLite3 database. Refer to the script's `--help`
+  output for more details. (#27432)
+
+### Tests
+
+- The BIP94 timewarp attack mitigation (designed for testnet4) is no longer active on the regtest network. (#31156)
+
+### Dependencies
+
+- MiniUPnPc and libnatpmp have been removed as dependencies (#31130, #30043).
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- 0xb10c
+- Adlai Chandrasekhar
+- Afanti
+- Alfonso Roman Zubeldia
+- am-sq
+- Andre
+- Andre Alves
+- Anthony Towns
+- Antoine Poinsot
+- Ash Manning
+- Ava Chow
+- Boris Nagaev
+- Brandon Odiwuor
+- brunoerg
+- Chris Stewart
+- Cory Fields
+- costcould
+- Daniel Pfeifer
+- Daniela Brozzoni
+- David Gumberg
+- dergoegge
+- epysqyli
+- espi3
+- Eval EXEC
+- Fabian Jahr
+- fanquake
+- furszy
+- Gabriele Bocchi
+- glozow
+- Greg Sanders
+- Gutflo
+- Hennadii Stepanov
+- Hodlinator
+- i-am-yuvi
+- ion-
+- ismaelsadeeq
+- Jadi
+- James O'Beirne
+- Jeremy Rand
+- Jon Atack
+- jurraca
+- Kay
+- kevkevinpal
+- l0rinc
+- laanwj
+- Larry Ruane
+- Lőrinc
+- Maciej S. Szmigiero
+- Mackain
+- MarcoFalke
+- marcofleon
+- Marnix
+- Martin Leitner-Ankerl
+- Martin Saposnic
+- Martin Zumsande
+- Matthew Zipkin
+- Max Edwards
+- Michael Dietz
+- naiyoma
+- Nicola Leonardo Susca
+- omahs
+- pablomartin4btc
+- Pieter Wuille
+- Randall Naar
+- RiceChuan
+- rkrux
+- Roman Zeyde
+- Ryan Ofsky
+- Sebastian Falbesoner
+- secp512k2
+- Sergi Delgado Segura
+- Simon
+- Sjors Provoost
+- stickies-v
+- Suhas Daftuar
+- tdb3
+- TheCharlatan
+- tianzedavid
+- Torkel Rogstad
+- Vasil Dimov
+- wgyt
+- willcl-ark
+- yancy
+
+As well as to everyone that helped with translations on
+[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v29.1.md
+++ b/_releases/v29.1.md
@@ -1,0 +1,271 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 29.1
+title: Bitcoin Core 29.1
+id: en-release-29.1
+name: release-29.1
+permalink: /en/releases/29.1/
+excerpt: Bitcoin Core version 29.1 is now available
+date: 2025-09-04
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [29, 1]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+29.1 Release Notes
+==================
+
+Bitcoin Core version 29.1 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-29.1/>
+
+This release includes various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### Mempool Policy
+
+- The maximum number of potentially executed legacy signature operations in a
+  single standard transaction is now limited to 2500. Signature operations in all
+  previous output scripts, in all input scripts, as well as all P2SH redeem
+  scripts (if there are any) are counted toward the limit. The new limit is
+  assumed to not affect any known typically formed standard transactions. The
+  change was done to prepare for a possible BIP54 deployment in the future.
+
+- #32521 policy: make pathological transactions packed with legacy sigops non-standard
+
+- The minimum block feerate (`-blockmintxfee`) has been changed to 1 satoshi per kvB. It can still be changed using the
+configuration option.
+
+- The default minimum relay feerate (`-minrelaytxfee`) and incremental relay feerate (`-incrementalrelayfee`) have been
+changed to 100 satoshis per kvB. They can still be changed using their respective configuration options, but it is
+recommended to change both together if you decide to do so.
+
+  - Other minimum feerates (e.g. the dust feerate, the minimum returned by the fee estimator, and all feerates used by
+  the wallet) remain unchanged. The mempool minimum feerate still changes in response to high volume.
+
+  - Note that unless these lower defaults are widely adopted across the network, transactions created with lower fee
+  rates are not guaranteed to propagate or confirm. The wallet feerates remain unchanged; `-mintxfee` must be changed
+  before attempting to create transactions with lower feerates using the wallet.
+
+- #33106 policy: lower the default blockmintxfee, incrementalrelayfee, minrelaytxfee
+
+### Logging
+
+Unconditional logging to disk is now rate limited by giving each source location
+a quota of 1MiB per hour. Unconditional logging is any logging with a log level
+higher than debug, that is `info`, `warning`, and `error`. All logs will be
+prefixed with `[*]` if there is at least one source location that is currently
+being suppressed. (#32604)
+
+When `-logsourcelocations` is enabled, the log output now contains the entire
+function signature instead of just the function name. (#32604)
+
+### RPC
+
+- The `dumptxoutset` RPC now requires a `type` parameter to be specified. To maintain pre
+  v29.0 behavior, use the `latest` parameter. Documenting this change was missed in the v29.0
+  release notes. (#30808)
+
+### Updated Settings
+
+- The `-maxmempool` and `-dbcache` startup parameters are now capped on
+  32-bit systems to 500MB and 1GiB respectively.
+
+- #32530 node: cap -maxmempool and -dbcache values for 32-bit
+
+### Wallet
+
+- #31757 wallet: fix crash on double block disconnection
+- #32553 wallet: Fix logging of wallet version
+
+### P2P
+
+- #32826 p2p: add more bad ports
+
+### Test
+
+- #32069 test: fix intermittent failure in wallet_reorgsrestore.py
+- #32286 test: Handle empty string returned by CLI as None in RPC tests
+- #32312 test: Fix feature_pruning test after nTime typo fix
+- #32336 test: Suppress upstream -Wduplicate-decl-specifier in bpfcc
+- #32463 test: fix an incorrect feature_fee_estimation.py subtest
+- #32483 test: fix two intermittent failures in wallet_basic.py
+- #32630 test: fix sync function in rpc_psbt.py
+- #32765 test: Fix list index out of range error in feature_bip68_sequence.py
+- #32742 test: fix catchup loop in outbound eviction functional test
+- #32823 test: Fix wait_for_getheaders() call in test_outbound_eviction_blocks_relay_only()
+- #32833 test: Add msgtype to msg_generic slots
+- #32841 feature_taproot: sample tx version border values more
+- #32850 test: check P2SH sigop count for coinbase tx
+- #32859 test: correctly detect nonstd TRUC tx vsize in feature_taproot
+- #33001 test: Do not pass tests on unhandled exceptions
+
+### Indexes
+
+- #33212 index: Don't commit state in BaseIndex::Rewind
+
+### Util
+
+- #32248 Remove support for RNDR/RNDRRS for aarch64
+
+### Build
+
+- #32356 cmake: Respect user-provided configuration-specific flags
+- #32437 crypto: disable ASan for sha256_sse4 with Clang
+- #32469 cmake: Allow WITH_DBUS on all Unix-like systems
+- #32439 guix: accomodate migration to codeberg
+- #32551 cmake: Add missed SSE41_CXXFLAGS
+- #32568 depends: use "mkdir -p" when installing xproto
+- #32678 guix: warn and abort when SOURCE_DATE_EPOCH is set
+- #32690 depends: fix SHA256SUM command on OpenBSD (use GNU mode output)
+- #32716 depends: Override host compilers for FreeBSD and OpenBSD
+- #32760 depends: capnp 1.2.0
+- #32798 build: add root dir to CMAKE_PREFIX_PATH in toolchain
+- #32805 cmake: Use HINTS instead of PATHS in find_* commands
+- #32814 cmake: Explicitly specify Boost_ROOT for Homebrew's package
+- #32837 depends: fix libevent _WIN32_WINNT usage
+- #32943 depends: Force CMAKE_EXPORT_NO_PACKAGE_REGISTRY=TRUE
+- #32954 cmake: Drop no longer necessary "cmakeMinimumRequired" object
+- #33073 guix: warn SOURCE_DATE_EPOCH set in guix-codesign
+
+### Gui
+
+- #864 Crash fix, disconnect numBlocksChanged() signal during shutdown
+- #868 Replace stray tfm::format to cerr with qWarning
+
+### Doc
+
+- #32333 doc: Add missing top-level description to pruneblockchain RPC
+- #32353 doc: Fix fuzz test_runner.py path
+- #32389 doc: Fix test_bitcoin path
+- #32607 rpc: Note in fundrawtransaction doc, fee rate is for package
+- #32679 doc: update tor docs to use bitcoind binary from path
+- #32693 depends: fix cmake compatibility error for freetype
+- #32696 doc: make -DWITH_ZMQ=ON explicit on build-unix.md
+- #32708 rpc, doc: update listdescriptors RCP help
+- #32711 doc: add missing packages for BSDs (cmake, gmake, curl) to depends/README.md
+- #32719 doc, windows: CompanyName "Bitcoin" => "Bitcoin Core project"
+- #32776 doc: taproot became always active in v24.0
+- #32777 doc: fix Transifex 404s
+- #32846 doc: clarify that the "-j N" goes after the "--build build" part
+- #32858 doc: Add workaround for vcpkg issue with paths with embedded spaces
+- #33070 doc/zmq: fix unix socket path example
+- #33088 doc: move cmake -B build -LH up in Unix build docs
+- #33133 rpc: fix getpeerinfo ping duration unit docs
+- #33119 rpc: Fix 'getdescriptoractivity' RPCHelpMan, add test to verify fix
+- #33236 doc: Remove wrong and redundant doxygen tag
+
+### CI
+
+- #32184 ci: Add workaround for vcpkg's libevent package
+- #33261 ci: return to using dash in CentOS job
+
+### Misc
+
+- #32187 refactor: Remove spurious virtual from final ~CZMQNotificationInterface
+- #32454 tracing: fix invalid argument in mempool_monitor
+- #32771 contrib: tracing: Fix read of pmsg_type in p2p_monitor.py
+- #33086 contrib: [tracing] fix pointer argument handling in mempool_monitor.py
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- 0xB10C
+- achow101
+- Antoine Poinsot
+- benthecarman
+- bigspider
+- Brandon Odiwuor
+- brunoerg
+- Bufo
+- Christewart
+- Crypt-iQ
+- davidgumberg
+- deadmanoz
+- dergoegge
+- enirox001
+- fanquake
+- furszy
+- glozow
+- instagibbs
+- Hennadii Stepanov
+- hodlinator
+- ismaelsadeeq
+- jb55
+- jlopp
+- josibake
+- laanwj
+- luisschwab
+- MarcoFalke
+- Martin Zumsande
+- monlovesmango
+- nervana21
+- pablomartin4btc
+- rkrux
+- romanz
+- ryanofsky
+- Sjors
+- theStack
+- willcl-ark
+- zaidmstrr
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v29.2.md
+++ b/_releases/v29.2.md
@@ -1,0 +1,132 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 29.2
+title: Bitcoin Core 29.2
+id: en-release-29.2
+name: release-29.2
+permalink: /en/releases/29.2/
+excerpt: Bitcoin Core version 29.2 is now available
+date: 2025-10-14
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [29, 2]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+29.2 Release Notes
+==================
+
+Bitcoin Core version 29.2 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-29.2/>
+
+This release includes various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### P2P
+
+- #32646 p2p: Add witness mutation check inside FillBlock
+- #33296 net: check for empty header before calling FillBlock
+- #33395 net: do not apply whitelist permissions to onion inbounds
+
+### Mempool
+
+- #33504 mempool: Do not enforce TRUC checks on reorg
+
+### RPC
+
+- #33446 rpc: fix getblock(header) returns target for tip
+
+### CI
+
+- #32989 ci: Migrate CI to hosted Cirrus Runners
+- #32999 ci: Use APT_LLVM_V in msan task
+- #33099 ci: allow for any libc++ intrumentation & use it for TSAN
+- #33258 ci: use LLVM 21
+- #33364 ci: always use tag for LLVM checkout
+
+### Doc
+
+- #33484 doc: rpc: fix case typo in `finalizepsbt` help
+
+### Misc
+
+- #33310 trace: Workaround GCC bug compiling with old systemtap
+- #33340 Fix benchmark CSV output
+- #33482 contrib: fix macOS deployment with no translations
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Amisha Chhajed
+- Eugene Siegel
+- fanquake
+- Greg Sanders
+- Hennadii Stepanov
+- Luke Dashjr
+- MarcoFalke
+- Martin Zumsande
+- Sebastian Falbesoner
+- Sjors Provoost
+- Vasil Dimov
+- Will Clark
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v29.3.md
+++ b/_releases/v29.3.md
@@ -1,0 +1,146 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 29.3
+title: Bitcoin Core 29.3
+id: en-release-29.3
+name: release-29.3
+permalink: /en/releases/29.3/
+excerpt: Bitcoin Core version 29.3 is now available
+date: 2026-02-10
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [29, 3]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+29.3 Release Notes
+==================
+
+Bitcoin Core version 29.3 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-29.3/>
+
+This release includes various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### P2P
+
+- #33050 net, validation: don't punish peers for consensus-invalid txs
+- #33723 chainparams: remove dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us
+
+### Validation
+
+- #32473 Introduce per-txin sighash midstate cache for legacy/p2sh/segwitv0 scripts
+- #33105 validation: detect witness stripping without re-running Script checks
+
+### Wallet
+
+- #33268 wallet: Identify transactions spending 0-value outputs, and add tests for anchor outputs in a wallet
+- #34156 wallet: fix unnamed legacy wallet migration failure
+- #34226 wallet: test: Relative wallet failed migration cleanup
+- #34123 wallet: migration, avoid creating spendable wallet from a watch-only legacy wallet
+- #34215 wallettool: fix unnamed createfromdump failure walletsdir deletion
+- #34370 wallet: Additional cleanups for migration, and fixes for createfromdump with BDB
+
+### Mining
+
+- #33475 bugfix: miner: fix `addPackageTxs` unsigned integer overflow
+
+### Build
+
+- #34227 guix: Fix `osslsigncode` tests
+
+### Documentation
+
+- #33623 doc: document capnproto and libmultiprocess deps in 29.x
+
+### Test
+
+- #33612 test: change log rate limit version gate
+
+### Misc
+
+- #32513 ci: remove 3rd party js from windows dll gha job
+- #33508 ci: fix buildx gha cache authentication on forks
+- #33581 ci: Properly include $FILE_ENV in DEPENDS_HASH
+- #34344 ci: update GitHub Actions versions
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Anthony Towns
+- Antoine Poinsot
+- Ava Chow
+- David Gumberg
+- Eugene Siegel
+- fanquake
+- furszy
+- Hennadii Stepanov
+- ismaelsadeeq
+- luke-jr
+- m3dwards
+- Padraic Slattery
+- Pieter Wuille
+- SatsAndSports
+- sedited
+- willcl-ark
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v30.0.md
+++ b/_releases/v30.0.md
@@ -334,7 +334,7 @@ Wallet
   `unconfirmed_balance`. (#32721)
 
 - `getunconfirmedbalance` - Removes this RPC command. You can query the `getbalances`
-  RPC and inspect the `["mine"]["untrusted_pending"]` entry within the JSON
+  RPC and inspect the `["mine"]` → `["untrusted_pending"]` entry within the JSON
   response. (#32721)
 
 - The following RPCs now contain a `version` parameter that allows

--- a/_releases/v30.0.md
+++ b/_releases/v30.0.md
@@ -1,0 +1,481 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 30.0
+title: Bitcoin Core 30.0
+id: en-release-30.0
+name: release-30.0
+permalink: /en/releases/30.0/
+excerpt: Bitcoin Core version 30.0 is now available
+date: 2025-10-10
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [30, 0]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+30.0 Release Notes
+==================
+
+v30.0 Release Notes
+===================
+
+Bitcoin Core version v30.0 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-30.0/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+Policy
+------
+
+- The maximum number of potentially executed legacy signature operations in a
+  single standard transaction is now limited to 2500. Signature operations in all
+  previous output scripts, in all input scripts, as well as all P2SH redeem
+  scripts (if there are any) are counted toward the limit. The new limit is
+  assumed to not affect any known typically formed standard transactions. The
+  change was done to prepare for a possible BIP54 deployment in the future. (#32521)
+
+- `-datacarriersize` is increased to 100,000 by default, which effectively uncaps
+  the limit (as the maximum transaction size limit will be hit first). It can be
+  overridden with `-datacarriersize=83` to revert to the limit enforced in previous
+  versions. (#32406)
+
+- Multiple data carrier (OP_RETURN) outputs in a transaction are now permitted for
+  relay and mining. The `-datacarriersize` limit applies to the aggregate size of
+  the scriptPubKeys across all such outputs in a transaction, not including the
+  scriptPubKey size itself. (#32406)
+
+- The minimum block feerate (`-blockmintxfee`) has been changed to 0.001 satoshi per
+  vB. It can still be changed using the configuration option. This option can be used
+  by miners to set a minimum feerate on packages added to block templates. (#33106)
+
+- The default minimum relay feerate (`-minrelaytxfee`) and incremental relay feerate
+  (`-incrementalrelayfee`) have been changed to 0.1 satoshis per vB. They can still
+  be changed using their respective configuration options, but it is recommended to
+  change both together if you decide to do so. (#33106)
+
+  Other minimum feerates (e.g. the dust feerate, the minimum returned by the fee
+  estimator, and all feerates used by the wallet) remain unchanged. The mempool minimum
+  feerate still changes in response to high volume.
+
+  Note that unless these lower defaults are widely adopted across the network, transactions
+  created with lower fee rates are not guaranteed to propagate or confirm. The wallet
+  feerates remain unchanged; `-mintxfee` must be changed before attempting to create
+  transactions with lower feerates using the wallet. (#33106)
+
+P2P and network changes
+-----------------------
+
+- Opportunistic 1-parent-1-child package relay has been improved to handle
+  situations when the child already has unconfirmed parent(s) in the mempool.
+  This means that 1p1c packages can be accepted and propagate, even if they are
+  connected to broader topologies: multi-parent-1-child (where only 1 parent
+  requires fee-bumping), grandparent-parent-child (where only parent requires
+  fee-bumping) etc. (#31385)
+
+- The transaction orphanage, which holds transactions with missing inputs temporarily
+  while the node attempts to fetch its parents, now has improved Denial of Service protections.
+  Previously, it enforced a maximum number of unique transactions (default 100,
+  configurable using `-maxorphantx`). Now, its limits are as follows: the number of
+  entries (unique by wtxid and peer), plus each unique transaction's input count divided
+  by 10, must not exceed 3,000. The total weight of unique transactions must not exceed
+  `404,000` Wu multiplied by the number of peers. (#31829)
+
+- The `-maxorphantx` option no longer has any effect, since the orphanage no longer
+  limits the number of unique transactions. Users should remove this configuration
+  option if they were using it, as the setting will cause an error in future versions
+  when it is no longer recognized. (#31829)
+
+New `bitcoin` command
+---------------------
+
+- A new `bitcoin` command line tool has been added to make features more discoverable
+  and convenient to use. The `bitcoin` tool just calls other executables and does not
+  implement any functionality on its own. Specifically `bitcoin node` is a synonym for
+  `bitcoind`, `bitcoin gui` is a synonym for `bitcoin-qt`, and `bitcoin rpc` is a synonym
+  for `bitcoin-cli -named`. Other commands and options can be listed with `bitcoin help`.
+  The new `bitcoin` command is an alternative to calling other commands directly, but it
+  doesn't replace them, and there are no plans to deprecate existing commands. (#31375)
+
+External Signing
+----------------
+
+- Support for external signing on Windows has been re-enabled. (#29868)
+
+IPC Mining Interface
+--------------------
+
+- The new `bitcoin` command does support one new feature: an (experimental) IPC Mining
+  Interface that allows the node to work with Stratum v2 or other mining client software,
+  see (#31098). When the node is started with `bitcoin -m node -ipcbind=unix` it will
+  listen on a unix socket for IPC client connections, allowing clients to request block
+  templates and submit mined blocks. The `-m` option launches a new internal binary
+  (`bitcoin-node` instead of `bitcoind`) and is currently required but will become optional
+  in the future (with [#33229](https://github.com/bitcoin/bitcoin/pull/33229)).
+
+- IPC connectivity introduces new dependencies (see [multiprocess.md](https://github.com/bitcoin/bitcoin/blob/master/doc/multiprocess.md)),
+  which can be turned off with the `-DENABLE_IPC=OFF` build option if you do not intend
+  to use IPC. (#31802)
+
+Install changes
+---------------
+
+- The `test_bitcoin` executable is now installed in `libexec/` instead of `bin/`.
+  It can still be executed directly, or accessed through the new `bitcoin` command
+  as `bitcoin test`. The `libexec/` directory also contains new `bitcoin-node` and
+  `bitcoin-gui` binaries which support IPC features and are called through the
+  `bitcoin` tool. In source builds only, `test_bitcoin-qt`, `bench_bitcoin`, and
+  `bitcoin-chainstate` are also now installed to `libexec/` instead of `bin/` and
+  can be accessed through the new `bitcoin` command. See `bitcoin help` output for
+  details. (#31679)
+
+- On Windows, the installer no longer adds a “(64-bit)” suffix to entries in the
+  Start Menu (#32132), and it now automatically removes obsolete artifacts during
+  upgrades (#33422).
+
+Indexes
+-------
+
+- The implementation of coinstatsindex was changed to prevent an overflow bug that
+  could already be observed on the default Signet. The new version of the index will
+  need to be synced from scratch when starting the upgraded node for the first time.
+
+  The new version is stored in `/indexes/coinstatsindex/` in contrast to the old version
+  which was stored at `/indexes/coinstats/`. The old version of the index is not deleted
+  by the upgraded node in case the user chooses to downgrade their node in the future.
+  If the user does not plan to downgrade it is safe for them to remove `/indexes/coinstats/`
+  from their datadir. A future release of Bitcoin Core may remove the old version of the
+  index automatically. (#30469)
+
+Logging
+-------
+
+- Unconditional logging to disk is now rate limited by giving each source location
+  a quota of 1MiB per hour. Unconditional logging is any logging with a log level
+  higher than debug, that is `info`, `warning`, and `error`. All logs will be
+  prefixed with `[*]` if there is at least one source location that is currently
+  being suppressed. (#32604)
+
+- When `-logsourcelocations` is enabled, the log output now contains the entire
+  function signature instead of just the function name. (#32604)
+
+Updated RPCs
+------------
+
+- The `-paytxfee` startup option and the `settxfee` RPC are now deprecated and
+  will be removed in Bitcoin Core 31.0. They allowed the user to set a static fee
+  rate for wallet transactions, which could potentially lead to overpaying or underpaying.
+  Users should instead rely on fee estimation or specify a fee rate per transaction
+  using the `fee_rate` argument in RPCs such as `fundrawtransaction`, `sendtoaddress`,
+  `send`, `sendall`, and `sendmany`. (#31278)
+
+- Any RPC in which one of the parameters is a descriptor will throw an error
+  if the provided descriptor contains a whitespace at the beginning or the end
+  of the public key within a fragment - e.g. `pk( KEY)` or `pk(KEY )`. (#31603)
+
+- The `submitpackage` RPC, which allows submissions of child-with-parents
+  packages, no longer requires that all unconfirmed parents be present. The
+  package may contain other in-mempool ancestors as well. (#31385)
+
+- The `waitfornewblock` RPC now takes an optional `current_tip` argument. It
+  is also no longer hidden. (#30635)
+
+- The `waitforblock` and `waitforblockheight` RPCs are no longer hidden.  (#30635)
+
+- The `psbtbumpfee` and `bumpfee` RPCs allow a replacement under fullrbf and no
+  longer require BIP-125 signalling. (#31953)
+
+- Transaction Script validation errors used to return the reason for the error
+  prefixed by either `mandatory-script-verify-flag-failed` if it was a consensus
+  error, or `non-mandatory-script-verify-flag` (without "-failed") if it was a
+  standardness error. This has been changed to `block-script-verify-flag-failed`
+  and `mempool-script-verify-flag-failed` for all block and mempool errors
+  respectively. (#33183)
+
+- The `getmininginfo` RPC now returns "blockmintxfee" result specifying the value of
+  `-blockmintxfee` configuration. (#33189)
+
+- The `getmempoolinfo` RPC now returns an additional "permitbaremultisig" and
+  "maxdatacarriersize" field, reflecting the `-permitbaremultisig` and `-datacarriersize`
+  config values. (#29954)
+
+Changes to wallet-related RPCs can be found in the Wallet section below.
+
+New RPCs
+--------
+
+- A new REST API endpoint (`/rest/spenttxouts/BLOCKHASH`) has been introduced for
+  efficiently fetching spent transaction outputs using the block's undo data (#32540).
+
+Build System
+------------
+
+Updated settings
+----------------
+
+- The `-maxmempool` and `-dbcache` startup parameters are now capped on 32-bit systems
+  to 500MB and 1GiB respectively. (#32530)
+
+- The `-natpmp` option is now set to `1` by default. This means nodes with `-listen`
+  enabled (the default) but running behind a firewall, such as a local network router,
+  will be reachable if the firewall/router supports any of the `PCP` or `NAT-PMP`
+  protocols. (#33004)
+
+- The `-upnp` setting has now been fully removed. Use `-natpmp` instead. (#32500)
+
+- Previously, `-proxy` specified the proxy for all networks (except I2P which
+  uses `-i2psam`) and only the Tor proxy could have been specified separately
+  via `-onion`. Now, the syntax of `-proxy` has been extended and it is possible
+  to specify separately the proxy for IPv4, IPv6, Tor and CJDNS by appending `=`
+  followed by the network name, for example `-proxy=127.0.0.1:5555=ipv6`
+  configures a proxy only for IPv6. The `-proxy` option can be used multiple
+  times to define different proxies for different networks, such as
+  `-proxy=127.0.0.1:4444=ipv4 -proxy=10.0.0.1:6666=ipv6`. Later settings
+  override earlier ones for the same network; this can be used to remove an
+  earlier all-networks proxy and use direct connections only for a given
+  network, for example `-proxy=127.0.0.1:5555 -proxy=0=cjdns`. (#32425)
+
+- The `-blockmaxweight` startup option has been updated to be debug-only.
+  It is still available to users, but now hidden from the default `-help` text
+  and shown only in `-help-debug` (#32654).
+
+Changes to GUI or wallet related settings can be found in the GUI or Wallet section below.
+
+Wallet
+------
+
+- BDB legacy wallets can no longer be created or loaded. They can be migrated
+  to the new descriptor wallet format. Refer to the `migratewallet` RPC for more
+  details.
+
+- The legacy wallet removal drops redundant options in the bitcoin-wallet tool,
+  such as `-withinternalbdb`, `-legacy`, and `-descriptors`. Moreover, the
+  legacy-only RPCs `addmultisigaddress`, `dumpprivkey`, `dumpwallet`,
+  `importaddress`, `importmulti`, `importprivkey`, `importpubkey`,
+  `importwallet`, `newkeypool`, `sethdseed`, and `upgradewallet`, are removed.
+  (#32944, #28710, #32438, #31250)
+
+- Support has been added for spending TRUC transactions received by the
+  wallet, as well as creating TRUC transactions. The wallet ensures that
+  TRUC policy rules are being met. The wallet will throw an error if the
+  user is trying to spend TRUC utxos with utxos of other versions.
+  Additionally, the wallet will treat unconfirmed TRUC sibling
+  transactions as mempool conflicts. The wallet will also ensure that
+  transactions spending TRUC utxos meet the required size restrictions. (#32896)
+
+- Since descriptor wallets do not allow mixing watchonly and non-watchonly descriptors,
+  the `include_watchonly` option (and its variants in naming) are removed from all RPCs
+  that had it. (#32618)
+
+- The `iswatchonly` field is removed from any RPCs that returned it. (#32618)
+
+- `unloadwallet` - Return RPC_INVALID_PARAMETER when both the RPC wallet endpoint
+  and wallet_name parameters are unspecified. Previously the RPC failed with a JSON
+  parsing error. (#32845)
+
+- `getdescriptoractivity` - Mark blockhashes and scanobjects arguments as required,
+  so the user receives a clear help message when either is missing. As in `unloadwallet`,
+  previously the RPC failed with a JSON parsing error. (#32845)
+
+- `getwalletinfo` - Removes the fields `balance`, `immature_balance` and
+  `unconfirmed_balance`. (#32721)
+
+- `getunconfirmedbalance` - Removes this RPC command. You can query the `getbalances`
+  RPC and inspect the `["mine"]["untrusted_pending"]` entry within the JSON
+  response. (#32721)
+
+- The following RPCs now contain a `version` parameter that allows
+  the user to create transactions of any standard version number (1-3):
+
+  - `createrawtransaction`
+  - `createpsbt`
+  - `send`
+  - `sendall`
+  - `walletcreatefundedpsbt`
+  (#32896)
+
+GUI changes
+-----------
+
+- The GUI has been migrated from Qt 5 to Qt 6. On Windows, dark mode is now supported.
+  On macOS, the Metal backend is now used. (#30997)
+
+- A transaction's fee bump is allowed under fullrbf and no longer requires
+  BIP-125 signalling. (#31953)
+
+- Custom column widths in the Transactions tab are reset as a side-effect of legacy
+  wallet removal. (#32459)
+
+Low-level changes
+=================
+
+- Logs now include which peer sent us a header. Additionally there are fewer
+  redundant header log messages. A side-effect of this change is that for
+  some untypical cases new headers aren't logged anymore, e.g. a direct
+  `BLOCK` message with a previously unknown header and `submitheader` RPC. (#27826)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- 0xb10c
+- amisha
+- Andrew Toth
+- Anthony Towns
+- Antoine Poinsot
+- Ava Chow
+- benthecarman
+- Brandon Odiwuor
+- brunoerg
+- Bue-von-hon
+- Bufo
+- Chandra Pratap
+- Chris Stewart
+- Cory Fields
+- Daniel Pfeifer
+- Daniela Brozzoni
+- David Gumberg
+- deadmanoz
+- dennsikl
+- dergoegge
+- enoch
+- Ethan Heilman
+- Eugene Siegel
+- Eunovo
+- Eval EXEC
+- Fabian Jahr
+- fanquake
+- Florian Schmaus
+- fuder.eth
+- furszy
+- glozow
+- Greg Sanders
+- Hao Xu
+- Haoran Peng
+- Haowen Liu
+- Hennadii Stepanov
+- Hodlinator
+- hoffman
+- ishaanam
+- ismaelsadeeq
+- Jameson Lopp
+- janb84
+- Jiri Jakes
+- John Bampton
+- Jon Atack
+- josibake
+- jurraca
+- kevkevin
+- kevkevinpal
+- kilavvy
+- Kristaps Kaupe
+- l0rinc
+- laanwj
+- leopardracer
+- Lőrinc
+- Luis Schwab
+- Luke Dashjr
+- MarcoFalke
+- marcofleon
+- Martin Zumsande
+- Matt Corallo
+- Matthew Zipkin
+- Max Edwards
+- monlovesmango
+- Murch
+- naiyoma
+- nervana21
+- Nicola Leonardo Susca
+- Novo
+- pablomartin4btc
+- Peter Todd
+- Pieter Wuille
+- Pol Espinasa
+- Prabhat Verma
+- rkrux
+- Roman Zeyde
+- Ryan Ofsky
+- Saikiran
+- Salvatore Ingala
+- Sebastian Falbesoner
+- Sergi Delgado Segura
+- Shunsuke Shimizu
+- Sjors Provoost
+- stickies-v
+- stratospher
+- stringintech
+- strmfos
+- stutxo
+- tdb3
+- TheCharlatan
+- Tomás Andróil
+- UdjinM6
+- Vasil Dimov
+- VolodymyrBg
+- w0xlt
+- will
+- willcl-ark
+- William Casarin
+- woltx
+- yancy
+- zaidmstrr
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v30.1.md
+++ b/_releases/v30.1.md
@@ -1,0 +1,149 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 30.1
+title: Bitcoin Core 30.1
+id: en-release-30.1
+name: release-30.1
+permalink: /en/releases/30.1/
+excerpt: Bitcoin Core version 30.1 is now available
+date: 2026-01-02
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [30, 1]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+30.1 Release Notes
+==================
+
+v30.1 Release Notes
+===================
+
+Bitcoin Core version v30.1 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-30.1/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### Wallet
+
+- #33528 wallet: don't consider unconfirmed TRUC coins with ancestors
+
+### Build
+
+- #33580 depends: Use `$(package)_file_name` when downloading from the fallback
+- #33906 depends: Add patch for Windows11Style plugin
+- #32009 contrib: turn off compression of macOS SDK to fix determinism
+
+### IPC
+
+- #33229 multiprocess: Don't require bitcoin -m argument when IPC options are used
+- #33517 multiprocess: Fix high overhead from message logging
+- #33519 Update libmultiprocess subtree in 30.x branch
+- #33566 miner: fix empty mempool case for waitNext()
+- #33676 interfaces: enable cancelling running waitNext calls
+
+### P2P
+
+- #33723 chainparams: remove dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us
+
+### GUI
+
+- gui#899 qt: Modernize custom filtering
+- gui#901 Add createwallet, createwalletdescriptor, and migratewallet to history filter
+
+### Test
+
+- #33612 test: change log rate limit version gate
+
+### Doc
+
+- #33630 doc: correct topology requirements in submitpackage helptext
+- #33826 scripted-diff: Remove obsolete comment
+- #33827 doc: Correct pkgin command usage on NetBSD
+
+### Misc
+
+- #33508 ci: fix buildx gha cache authentication on forks
+- #33558 ci: Use native platform for win-cross task
+- #33581 ci: Properly include $FILE_ENV in DEPENDS_HASH
+- #33744 ci: Fix lint runner selection (and docker cache)
+- #33996 contrib: fix manpage generation
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Ava Chow
+- Cory Fields
+- Eugene Siegel
+- fanquake
+- glozow
+- Hennadii Stepanov
+- ismaelsadeeq
+- MarcoFalke
+- Ryan Ofsky
+- SatsAndSports
+- Sjors Provoost
+- WakeTrainDev
+- willcl-ark
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v30.2.md
+++ b/_releases/v30.2.md
@@ -1,0 +1,132 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 30.2
+title: Bitcoin Core 30.2
+id: en-release-30.2
+name: release-30.2
+permalink: /en/releases/30.2/
+excerpt: Bitcoin Core version 30.2 is now available
+date: 2026-01-10
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [30, 2]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+30.2 Release Notes
+==================
+
+v30.2 Release Notes
+===================
+
+Bitcoin Core version v30.2 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-30.2/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+### Wallet
+
+- #34156 wallet: fix unnamed legacy wallet migration failure
+- #34215 wallettool: fix unnamed createfromdump failure walletsdir deletion
+- #34221 test: migration, avoid backup name mismatch in default_wallet_failure
+
+### IPC
+
+- #33511 init: Fix Ctrl-C shutdown hangs during wait calls
+
+### Build
+
+- #33950 guix: reduce allowed exported symbols
+- #34107 build: Update minimum required Boost version
+- #34227 guix: Fix osslsigncode tests
+
+### Test
+
+- #34137 test: Avoid hard time.sleep(1) in feature_init.py
+- #34226 wallet: test: Relative wallet failed migration cleanup
+
+### Fuzz
+
+- #34091 fuzz: doc: remove any mention to address_deserialize_v2
+
+### Doc
+
+- #34182 doc: Update OpenBSD Build Guide
+
+### Misc
+
+- #34174 doc: update copyright year to 2026
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Ava Chow
+- brunoerg
+- davidgumberg
+- fanquake
+- furszy
+- Hennadii Stepanov
+- MarcoFalke
+- Ryan Ofsky
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v31.0.md
+++ b/_releases/v31.0.md
@@ -1,0 +1,431 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 31.0
+title: Bitcoin Core 31.0
+id: en-release-31.0
+name: release-31.0
+permalink: /en/releases/31.0/
+excerpt: Bitcoin Core version 31.0 is now available
+date: 2026-04-19
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [31, 0]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+31.0 Release Notes
+==================
+
+v31.0 Release Notes
+===================
+
+Bitcoin Core version 31.0 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-31.0/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+
+With the release of this new major version, versions `28.x` and
+older are at "End of Life" and will no longer receive updates.
+
+In accordance with the security policy, we will in two weeks disclose:
+
+* Medium and high severity vulnerabilities fixed in `29.0`. There is one of these.
+
+* Low severity vulnerabilities fixed in `31.0`. There are none of these.
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the installer
+(on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS) or
+`bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be
+migrated. Old wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on the following operating systems or
+newer: Linux Kernel 3.17, macOS 14, and Windows 10 (version 1903). Bitcoin Core
+should also work on most other Unix-like systems but is not as frequently tested
+on them. It is not recommended to use Bitcoin Core on unsupported systems.
+
+Notable changes
+===============
+
+The default `-dbcache` value has been increased to 1024 MiB from 450 MiB on
+systems where at least 4096 MiB of RAM is detected. This improves performance
+but increases memory usage. On some systems (for example when running in
+containers), the detected RAM may exceed the memory actually available, which
+can lead to out-of-memory conditions. To maintain the previous behavior, set
+`-dbcache=450`. See
+[reduce-memory.md](https://github.com/bitcoin/bitcoin/blob/master/doc/reduce-memory.md)
+for further guidance on low-memory systems. (#34692)
+
+Mempool
+-------
+
+The mempool has been reimplemented with a new design ("cluster mempool"), to
+facilitate better decision-making when constructing block templates, evicting
+transactions, relaying transactions, and validating replacement transactions
+(RBF). Most changes should be transparent to users, but some behavior changes
+are noted:
+
+- The mempool no longer enforces ancestor or descendant size/count limits.
+Instead, two new default policy limits are introduced governing connected
+components, or clusters, in the mempool, limiting clusters to 64 transactions
+and up to 101 kB in virtual size.  Transactions are considered to be in the same
+cluster if they are connected to each other via any combination of parent/child
+relationships in the mempool. These limits can be overridden using command-line
+arguments; see the extended help (`-help-debug`) for more information.
+
+- Within the mempool, transactions are ordered based on the feerate at which
+they are expected to be mined, which takes into account the full set, or
+"chunk", of transactions that would be included together (e.g., a parent and its
+child, or more complicated subsets of transactions). This ordering is utilized
+by the algorithms that implement transaction selection for constructing block
+templates; eviction from the mempool when it is full; and transaction relay
+announcements to peers.
+
+- The replace-by-fee validation logic has been updated so that transaction
+replacements are only accepted if the resulting mempool's feerate diagram is
+strictly better than before the replacement. This eliminates all known cases of
+replacements occurring that make the mempool worse off, which was possible under
+previous RBF rules. For singleton transactions (that are in clusters by
+themselves) it's sufficient for a replacement to have a higher fee and feerate
+than the original. See [delvingbitcoin.org
+post](https://delvingbitcoin.org/t/an-overview-of-the-cluster-mempool-proposal/393#rbf-can-now-be-made-incentive-compatible-for-miners-11)
+for more information.
+
+- Two new RPCs have been added: `getmempoolcluster` will provide the set of
+transactions in the same cluster as the given transaction, along with the
+ordering of those transactions and grouping into chunks; and
+`getmempoolfeeratediagram` will return the feerate diagram of the entire
+mempool.
+
+- Chunk size and chunk fees are now also included in the output of
+`getmempoolentry`.
+
+- The "CPFP Carveout" has been removed from the mempool logic. The CPFP carveout
+allowed one additional child transaction to be added to a package that's already
+at its descendant limit, but only if that child has exactly one ancestor (the
+package's root) and is small (no larger than 10kvB). Nothing is allowed to
+bypass the cluster count limit. It is expected that smart contracting use-cases
+requiring similar functionality employ TRUC transactions and sibling eviction
+instead going forward.
+
+- Some additional discussion can be found at
+[doc/policy/mempool-terminology.md](https://github.com/bitcoin/bitcoin/blob/master/doc/policy/mempool-terminology.md)
+and
+[doc/policy/mempool-replacements.md](https://github.com/bitcoin/bitcoin/blob/master/doc/policy/mempool-replacements.md).
+
+P2P and network changes
+-----------------------
+
+- Normally local transactions are broadcast to all connected peers with which we
+do transaction relay. Now, for the `sendrawtransaction` RPC this behavior can be
+changed to only do the broadcast via the Tor or I2P networks. A new boolean
+option `-privatebroadcast` has been added to enable this behavior. This improves
+the privacy of the transaction originator in two aspects:
+
+  1. Their IP address (and thus geolocation) is never known to the recipients.
+  2. If the originator sends two otherwise unrelated transactions, they will not
+  be linkable. This is because a separate connection is used for broadcasting
+  each transaction. (#29415)
+
+- New RPCs have been added to introspect and control private broadcast:
+`getprivatebroadcastinfo` reports transactions currently being privately
+broadcast, and `abortprivatebroadcast` removes matching transactions from the
+private broadcast queue. (#34329)
+
+- Transactions participating in one-parent-one-child package relay can now have
+the parent with a feerate lower than the `-minrelaytxfee` feerate, even 0 fee.
+This expands the change from 28.0 to also cover packages of non-TRUC
+transactions. Note that in general the package child can have additional
+unconfirmed parents, but they must already be in-mempool for the new package to
+be relayed. (#33892)
+
+- The release has asmap data embedded for the first time, allowing the asmap
+feature to be used without any externally sourced file. The embedded map [was
+created on 2026-03-05](https://github.com/bitcoin/bitcoin/pull/34696). Despite
+the data being available, the option remains off-by-default. Users still need to
+set `-asmap` or `-asmap=1` explicitly to make it possible to use a peer's ASN
+(ISP/hoster identifier) in netgroup bucketing in order to ensure a higher
+diversity in their peer set.
+
+Updated RPCs
+------------
+
+- `gettxspendingprevout` has 2 new optional arguments: `mempool_only` and
+`return_spending_tx`. If `mempool_only` is true it will limit scans to the
+mempool even if `txospenderindex` is available. If `return_spending_tx` is true,
+the full spending tx will be returned. In addition if `txospenderindex` is
+available and a confirmed spending transaction is found, its block hash will be
+returned. (#24539)
+
+- The `getpeerinfo` RPC no longer returns the `startingheight` field unless the
+configuration option `-deprecatedrpc=startingheight` is used. The
+`startingheight` field will be fully removed in the next major release. (#34197)
+
+- The `getblock` RPC now returns a `coinbase_tx` object at verbosity levels 1,
+2, and 3. It contains `version`, `locktime`, `sequence`, `coinbase` and
+`witness`. This allows for efficiently querying coinbase transaction properties
+without fetching the full transaction data at verbosity 2+. (#34512)
+
+REST API
+--------
+
+- A new REST API endpoint
+(`/rest/blockpart/<BLOCK-HASH>.<bin|hex>?offset=<OFFSET>&size=<SIZE>`) has been
+introduced for efficiently fetching a range of bytes from block `<BLOCK-HASH>`.
+(#33657)
+
+Build System
+------------
+
+- The minimum supported Clang compiler version has been raised to 17.0 (#33555).
+- The minimum supported GCC compiler version has been raised to 12.1 (#33842).
+
+Updated settings
+----------------
+
+- The `-paytxfee` startup option and the `settxfee` RPC are now deleted after
+being deprecated in Bitcoin Core 30.0. They used to allow the user to set a
+static fee rate for wallet transactions, which could potentially lead to
+overpaying or underpaying. Users should instead rely on fee estimation or
+specify a fee rate per transaction using the `fee_rate` argument in RPCs such as
+`fundrawtransaction`, `sendtoaddress`, `send`, `sendall`, and `sendmany`.
+(#32138)
+
+- Specifying `-asmap` or `-asmap=1` will load the embedded asmap data instead of
+an external file. In previous releases, if `-asmap` was specified without a
+filename, this would try to load an `ip_asn.map` data file. Now loading an
+external asmap file always requires an explicit filename like
+`-asmap=ip_asn.map`.
+
+- The `-maxorphantx` startup option has been removed. It was previously
+deprecated and has no effect anymore since v30.0. (#33872)
+
+- `tor` has been removed as a network specification. It was deprecated in favour
+of `onion` in v0.17.0. (#34031)
+
+- When `-logsourcelocations` is enabled, the log output now contains just the
+function name instead of the entire function signature. (#34088)
+
+- The default `-dbcache` value has been increased to `1024` MiB from `450` MiB
+on systems where at least `4096` MiB of RAM is detected. This is a performance
+increase, but will use more memory. To maintain the previous behaviour, set
+`-dbcache=450`. (#34692)
+
+- `-privatebroadcast` is added to enable private broadcast behavior for
+`sendrawtransaction`.
+
+New settings
+------------
+
+- `-txospenderindex` enables the creation of a transaction output spender index
+that, if present, will be scanned by `gettxspendingprevout` if a spending
+transaction was not found in the mempool. (#24539)
+
+GUI changes
+-----------
+
+- The GUI has been updated to Qt 6.8. (#34650)
+
+- The `createwallet`, `createwalletdescriptor` and `migratewallet` commands are
+filtered from the console history to improve security and privacy. (gui#901)
+
+- The Restore Wallet dialog shows an error message if the restored wallet name
+is empty. (gui#924)
+
+Fee Estimation
+--------------
+
+The Bitcoin Core fee estimator minimum fee rate bucket was updated from **1
+sat/vB** to **0.1 sat/vB**, which matches the node’s default `minrelaytxfee`. This
+means that for a given confirmation target, if a sub-1 sat/vB fee rate bucket is
+the minimum tracked with sufficient data, its average value will be returned as
+the fee rate estimate.
+
+Restarting a node with this change invalidates previously saved
+estimates in `fee_estimates.dat`, the fee estimator will start tracking fresh
+stats.
+
+IPC Interface
+-------------
+
+- The IPC mining interface now requires mining clients to use the latest
+`mining.capnp` schema. Clients built against older schemas will fail when
+calling `Init.makeMining` and receive an RPC error indicating the old mining
+interface is no longer supported. Mining clients must update to the latest
+schema and regenerate bindings to continue working. (#34568)
+
+- `Mining.createNewBlock` now has a `cooldown` behavior (enabled by default)
+that waits for IBD to finish and for the tip to catch up. This usually prevents
+a flood of templates during startup, but is not guaranteed. (#34184)
+
+- `Mining.interrupt()` can be used to interrupt `Mining.waitTipChanged` and
+`Mining.createNewBlock`. (#34184)
+
+- `Mining.createNewBlock` and `Mining.checkBlock` now require a `context`
+parameter.
+
+- `Mining.waitTipChanged` now has a default `timeout` (effectively infinite /
+`maxDouble`) if the client omits it.
+
+- `BlockTemplate.getCoinbaseTx()` now returns a structured `CoinbaseTx` instead
+of raw bytes.
+
+- Removed `BlockTemplate.getCoinbaseCommitment()` and
+`BlockTemplate.getWitnessCommitmentIndex()`.
+
+- Cap’n Proto default values were updated to match the corresponding C++
+defaults for mining-related option structs (e.g. `BlockCreateOptions`,
+`BlockWaitOptions`, `BlockCheckOptions`).
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- 0xb10c
+- Alexander Wiederin
+- Alfonso Roman Zubeldia
+- amisha
+- ANAVHEOBA
+- Andrew Toth
+- Anthony Towns
+- Antoine Poinsot
+- ANtutov
+- Anurag chavan
+- Ava Chow
+- bensig
+- Ben Westgate
+- billymcbip
+- b-l-u-e
+- Brandon Odiwuor
+- brunoerg
+- Bruno Garcia
+- Calin Culianu
+- Carl Dong
+- Chandra Pratap
+- Chris Stewart
+- Coder
+- Cory Fields
+- da1sychain
+- Daniela Brozzoni
+- Daniel Pfeifer
+- David Gumberg
+- dergoegge
+- Dmitry Goncharov
+- Enoch Azariah
+- Eugene Siegel
+- Fabian Jahr
+- fanquake
+- Fibonacci747
+- flack
+- frankomosh
+- furszy
+- glozow
+- Greg Sanders
+- Hao Xu
+- Hennadii Stepanov
+- Henry Romp
+- Hodlinator
+- ismaelsadeeq
+- janb84
+- jayvaliya
+- joaonevess
+- John Moffett
+- Josh Doman
+- kevkevinpal
+- l0rinc
+- Luke Dashjr
+- Mara van der Laan
+- MarcoFalke
+- marcofleon
+- Martin Zumsande
+- Matthew Zipkin
+- Max Edwards
+- Murch
+- Musa Haruna
+- naiyoma
+- nervana21
+- Novo
+- optout
+- pablomartin4btc
+- Padraic Slattery
+- Pieter Wuille
+- Pol Espinasa
+- pythcoiner
+- rkrux
+- Robin David
+- Roman Zeyde
+- rustaceanrob
+- Ryan Ofsky
+- SatsAndSports
+- scgbckbone
+- Sebastian Falbesoner
+- sedited
+- seduless
+- Sergi Delgado Segura
+- Sjors Provoost
+- SomberNight
+- sstone
+- stickies-v
+- stratospher
+- stringintech
+- Suhas Daftuar
+- tboy1337
+- TheCharlatan
+- Tim Ruffing
+- Vasil Dimov
+- w0xlt
+- WakeTrainDev
+- Weixie Cui
+- willcl-ark
+- Woolfgm
+- yancy
+- Yash Bhutwala
+- yuvicc
+- zaidmstrr
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>


### PR DESCRIPTION
This PR adds the 11 Bitcoin Core release notes that are currently missing from `_releases/`. The most recent release present in the directory is 28.1; this brings the directory up to date through 31.0.

Relates to #4704.

### Releases added

| File | Version | Published |
|------|---------|-----------|
| `_releases/v28.2.md` | 28.2 | 2025-06-26 |
| `_releases/v28.3.md` | 28.3 | 2025-10-17 |
| `_releases/v28.4.md` | 28.4 | 2026-03-18 |
| `_releases/v29.0.md` | 29.0 | 2025-04-14 |
| `_releases/v29.1.md` | 29.1 | 2025-09-04 |
| `_releases/v29.2.md` | 29.2 | 2025-10-14 |
| `_releases/v29.3.md` | 29.3 | 2026-02-10 |
| `_releases/v30.0.md` | 30.0 | 2025-10-10 |
| `_releases/v30.1.md` | 30.1 | 2026-01-02 |
| `_releases/v30.2.md` | 30.2 | 2026-01-10 |
| `_releases/v31.0.md` | 31.0 | 2026-04-19 |

### Method

- Each file follows the existing format of `_releases/v28.1.md` (YAML header, `{% githubify %}` wrapper, `XX Release Notes` heading).
- Release-note text is copied verbatim from the official notes in `bitcoin/bitcoin` (`doc/release-notes/release-notes-XX.md`), with only the Markdown formatting adjustments described in `docs/adding-release-notes-and-alerts.md` (blank line before lists).
- The `date:` field of each file is the official announcement date, taken from the "was published on" line of the corresponding page at `bitcoincore.org/en/releases/XX/`.
- `optional_magnetlink` is left empty in each file, consistent with it being an optional field.

### Two things worth flagging 

1. **30.0 and 30.1 binaries.** The Bitcoin Core project pulled the 30.0 and 30.1 binaries from distribution due to the wallet-migration advisory (https://bitcoincore.org/en/2026/01/05/wallet-migration-bug/). If CI checks the download links in those two release notes, they may fail. I've still included both files for completeness of the historical record.

2. **The download button still shows 28.1.** The "latest version" shown by the download button on `/en/bitcoin-core/` and `/en/download` comes from `site.DOWNLOAD_VERSION`. I could not find this variable defined anywhere in the repository — per `_build/update_site.sh` it appears to be set by the deployment build environment. Updating the displayed latest version to 31.0 therefore looks like a server-side change rather than something this PR can include. Flagging it since it's part of the same staleness covered in #4704.

CI note (v30.0). The check-for-broken-markdown-reference-links target greps the generated HTML for the literal sequence ][. The official 30.0 notes contain the JSON access path ["mine"]["untrusted_pending"] inside an inline code span; the adjacent brackets survive into the HTML as <code> content and trip the grep, even though it is not a reference link. To keep CI green, that one phrase is rendered as two separate code spans (["mine"] → ["untrusted_pending"]). The meaning is unchanged; this is the only deviation from verbatim in the 11 files.


Davi de Jesus