### PR TITLE
Wallets: Drop orphan mixing_shuffling feature from Ginger

### DIFF
--- a/_wallets/ginger.md
+++ b/_wallets/ginger.md
@@ -15,7 +15,7 @@ platform:
       link: "https://gingerwallet.io/"
       source: "https://github.com/GingerPrivacy/GingerWallet"
       screenshot: "ginger.png"
-      features: "2fa bech32 hardware_wallet mixing_shuffling segwit"
+      features: "2fa bech32 hardware_wallet segwit"
       check:
         control: "checkgoodcontrolfull"
         validation: "checkfailvalidationcentralized"


### PR DESCRIPTION
The `mixing_shuffling` feature was fully removed from the site in #3280 (Feb 2020), including the `wizard-feature-mixing` and `wizard-feature-mixing-description` translation keys.

The Ginger wallet file still carries the tag in its `features:` list. With no translation string to render, this produces an empty checkmark with a blank tooltip on the wallet page, between Hardware Wallet and SegWit.

This removes the orphan tag so the feature list renders cleanly:

`features: "2fa bech32 hardware_wallet mixing_shuffling segwit"` → `features: "2fa bech32 hardware_wallet segwit"`