### PR TITLE
Remove Mine Digital from exchanges (collapsed September 2022)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -144,8 +144,6 @@ id: exchanges
         <h3 id="singapore" class="no_toc">Singapore</h3>
         <p>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
-          <br>
-          <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
         </p>
       </div>
     </div>
@@ -533,8 +531,6 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
     <br>
-    <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
-    <br>
     <a class="marketplace-link" href="https://paybtc.com.au/">paybtc</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
     <br>
     <a class="marketplace-link" href="https://swyftx.com.au/">Swyftx</a>
@@ -549,8 +545,6 @@ id: exchanges
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
     <br>
     <a class="marketplace-link" href="https://kiwi-coin.com/">Kiwi-coin</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
-    <br>
-    <a class="marketplace-link" href="https://www.minedigital.exchange/">Mine Digital</a>
   </p>
 </div>
 


### PR DESCRIPTION
Removes Mine Digital from the exchanges listing. Per #4715 (case 4).

## Evidence

Mine Digital (operated by ACCE Australia Pty Ltd) collapsed in September 2022 and entered administration on 23 September 2022. In October 2024, the company's former CEO was charged with fraud following an ASIC investigation.

The listing appeared in three sections (Singapore, Australia, New Zealand); all three entries are removed.

## Sources

- [ASIC media release 24-231MR — ex-CEO of Mine Digital charged with fraud](https://asic.gov.au/about-asic/news-centre/find-a-media-release/2024-releases/24-231mr-ex-ceo-of-crypto-exchange-mine-digital-charged-with-fraud/)
- [Reuters via US News — ex-CEO charged with fraud](https://www.usnews.com/news/technology/articles/2024-10-21/australias-corporate-watchdog-charges-mine-digitals-ex-ceo-with-fraud)

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The exchange has ceased operations.