### PR TITLE
Remove BitBay from exchanges (rebranded to Zonda; now in liquidation)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -275,15 +275,6 @@ id: exchanges
         </div>
       </div>
 
-      <div class="row marketplace">
-        <img class="marketplace-flag" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="Polish flag">
-        <div>
-          <h3 id="poland" class="no_toc">Poland</h3>
-          <p>
-            <a class="marketplace-link" href="https://www.bitbay.net/">BitBay</a>
-          </p>
-        </div>
-      </div>
 
       <div class="row marketplace">
         <img class="marketplace-flag" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag">


### PR DESCRIPTION
Removes BitBay from the exchanges listing. Per #4715 (case 3).

## Evidence

BitBay rebranded to Zonda in November 2021. As of April 2026, Zonda is in liquidation following a collapse in reserves and the loss of its operating licence. The BitBay brand no longer operates.

BitBay was the only exchange listed under Poland, so the Poland section is removed in full.

## Sources

- [CoinDesk — BitBay rebrand to Zonda](https://www.coindesk.com/business/2021/11/08/polands-largest-crypto-exchange-revamps-to-go-license-shopping)
- [Notes from Poland — Zonda liquidation coverage](https://notesfrompoland.com/2026/04/21/polish-prosecutors-identify-hundreds-of-possible-victims-of-troubled-crypto-platform/)

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The listed exchange brand has been discontinued.