### PR TITLE
Remove Volabit from exchanges (ceased operations June 2023)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -392,8 +392,6 @@ id: exchanges
           <a class="marketplace-link" href="https://bitso.com/">Bitso</a>
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
-          <br>
-          <a class="marketplace-link" href="https://www.volabit.com/">Volabit</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Removes Volabit from the exchanges listing. Per #4715 (case 6).

## Evidence

Volabit, the first cryptocurrency exchange in Mexico, announced its closure in May 2023 after nine years of operation, citing the Mexican Fintech Law and the regulatory environment. The platform remained available for withdrawals only until 9 June 2023.

## Sources

- [Volabit official statement — "Toda historia llega a su fin"](https://blog.volabit.com/cese-operaciones/)
- [BeInCrypto (ES) — coverage of the shutdown](https://es.beincrypto.com/volabit-primera-casa-cambio-mexico-cierra-sus-puertas/)

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The exchange has ceased operations.