### PR TITLE
Remove PagCripto from exchanges (rebranded to Virtuati; trading disabled)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -458,8 +458,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://novadax.com.br/">NovaDAX</a>
           <br>
-          <a class="marketplace-link" href="https://pagcripto.com.br/">PagCripto</a>
-          <br>
           <a class="marketplace-link" href="https://ripio.com/">Ripio</a>
         </p>
       </div>


### PR DESCRIPTION
Removes PagCripto from the exchanges listing. Per #4715 (case 11).

## Evidence

PagCripto rebranded to Virtuati. Both pagcripto.com.br and virtuati.com.br currently display a restructuring notice stating that only withdrawals are permitted — deposits and buy/sell trading are disabled.

## Sources

- [pagcripto.com.br](https://www.pagcripto.com.br/)
- [virtuati.com.br](https://www.virtuati.com.br/)

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The listed URL no longer resolves to a functioning instance of the listed exchange.