### PR TITLE
Remove Koinim from exchanges (ceased trading operations 2024)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -192,15 +192,6 @@ id: exchanges
       </div>
     </div>
 
-    <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/TR.svg?{{site.time | date: '%s'}}" alt="Turkish flag">
-      <div>
-        <h3 id="turkey" class="no_toc">Turkey</h3>
-        <p>
-          <a class="marketplace-link" href="https://www.koinim.com/">Koinim</a>
-        </p>
-      </div>
-    </div>
 
     <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/UAE.svg?{{site.time | date: '%s'}}" alt="United Arab Emirates flag">


### PR DESCRIPTION
Removes Koinim from the exchanges listing. Per #4715 (case 1).

## Evidence

Koinim, a Turkish exchange, halted its trading operations in 2024 — stopping new user registrations and crypto buy/sell — following Turkish Law 7518, which regulated crypto asset service providers (effective 2 July 2024). Koinim was among the firms that filed for liquidation as Turkey's regulatory framework took effect. Existing users were directed to withdraw their balances.

Koinim was the only exchange listed under Turkey, so the Turkey section is removed in full.

## Sources

- [BitcoinSistemi — industry coverage of Turkish exchange liquidations](https://en.bitcoinsistemi.com/is-the-giant-cryptocurrency-exchange-leaving-the-turkish-market-application-withdrawn-here-are-the-details/)
- [CoinCodex — Koinim (marked no longer operational)](https://coincodex.com/exchange/koinim)

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The exchange has ceased operations.