### PR TITLE
Remove OKCoin from exchanges (brand discontinued, migrated to OKX)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -27,8 +27,6 @@ id: exchanges
     <br>
     <a class="marketplace-link" href="https://nexo.com/">Nexo</a>
     <br>
-    <a class="marketplace-link" href="https://www.okcoin.com/">OKCoin</a>
-    <br>
     <a class="marketplace-link" href="https://uphold.com?ref=bitcoin.org">Uphold</a>
   </p>
 </div>


### PR DESCRIPTION
Removes OKCoin from the exchanges listing. Per #4715 (case 2).

## Evidence

The OKCoin brand has been discontinued. OK Group has consolidated its brands under OKX: Okcoin Europe migrated to OKX in January 2024, and Okcoin USA migrated in May 2025. The listed URL (okcoin.com) now displays a notice stating the brand is rebranding to OKX. The brand no longer operates under the OKCoin name.

(Note: this concerns the okcoin.com listing only. The separate Japan operation, formerly "OKCoin Japan," continues to operate under the name "OKJ" and is not affected.)

## Sources

- [Okcoin support — Europe migration to OKX](https://support.okcoin.com/hc/en-us/articles/21702481409933)
- [Okcoin support — USA migration to OKX](https://support.okcoin.com/hc/en-us/articles/34726173120525)

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The listed exchange brand has been discontinued.