### PR TITLE
Remove inactive BitQuick from exchanges listing

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -38,8 +38,6 @@ id: exchanges
   <p>
     <a class="marketplace-link" href="https://bisq.network/">Bisq</a>
     <br>
-    <a class="marketplace-link" href="https://bitquick.co/">BitQuick</a>
-    <br>
     <a class="marketplace-link" href="https://hodlhodl.com/">Hodl Hodl</a>
     <br>
     <a class="marketplace-link" href="https://noones.com/">Noones Buy Bitcoin</a>


### PR DESCRIPTION
Removes BitQuick from the exchanges listing. Per #4715 (case 5).

## Evidence

BitQuick, a peer-to-peer Bitcoin marketplace, ceased operations in 2022. The exchange tracker Cryptowisser has flagged it as inactive and moved it to its "Exchange Graveyard".

Additionally, the listed URL (`bitquick.co`) does not resolve to a functioning site — it returns an SSL protocol error (`ERR_SSL_PROTOCOL_ERROR`), and no usable page loads.

## Sources

- Cryptowisser — BitQuick  
- Live check of `https://bitquick.co/` — `ERR_SSL_PROTOCOL_ERROR`

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. In this case, the exchange has ceased operations, and the listed URL does not resolve to a functioning instance of the service.