### PR TITLE
Remove BtcBox from exchanges (all services suspended)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -95,8 +95,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://bitflyer.com/ja-jp/">bitFlyer</a>
           <br>
-          <a class="marketplace-link" href="https://www.btcbox.co.jp/">BtcBox</a>
-          <br>
           <a class="marketplace-link" href="https://coincheck.com/">Coincheck</a>
         </p>
       </div>


### PR DESCRIPTION
Removes BtcBox from the exchanges listing. Per #4715 (case 12).

## Evidence

BtcBox (Japan) reported a data breach on 15 January 2026 and suspended all services in response. On 5 February 2026, it received a Reporting Order from the Kanto Local Finance Bureau under the Payment Services Act, Article 63-15(1). The company has issued no further communication since 5 February 2026, and no service resumption date has been
announced. The site has displayed a "Temporary Suspension of All Services" notice for several months.

## Sources

- [BTCBOX official statement (Japanese)](https://blog.btcbox.jp/archives/18696)
- [btcbox.co.jp](https://www.btcbox.co.jp/)

## Note

The official statement is in Japanese. Key points: (1) data breach affecting 39 customers reported 15 Jan 2026; (2) all services suspended; (3) regulatory Reporting Order issued 5 Feb 2026; (4) no resumption date announced.

## Criterion

Per `docs/adding-exchanges.md`, listings may be removed when severe and/or unresolved site functionality issues are encountered. The listed URL does not resolve to a functioning instance of the exchange.
