### PR TITLE
docs: update outdated references in contributor and translation docs

### DIFF
--- a/docs/assisting-with-translations.md
+++ b/docs/assisting-with-translations.md
@@ -13,23 +13,23 @@ ___
 
 ## Getting Started with the Translation Team
 
-While the website itself is managed on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), the translations are handled through [Transifex](https://www.transifex.com/bitcoinorg/bitcoinorg/).
+While the website itself is managed on [GitHub](https://github.com/bitcoin-dot-org/bitcoin.org/), the translations are handled through [Transifex](https://app.transifex.com/bitcoinorg/bitcoinorg/).
 This section shall explain the first steps on Transifex for new volunteers who want to help with translating bitcoin.org.
 
-General guidelines provided by Transifex itself can be found [here](https://docs.transifex.com/getting-started/translators).
+General guidelines provided by Transifex itself can be found [here](https://help.transifex.com/en/collections/3441044-starting-with-the-basics).
 
 ### 1. Create a Transifex Account
-* Follow this [link](https://www.transifex.com/signup/) and create an account. Creating a Transifex account is free and not much information is needed.
+* Follow this [link](https://app.transifex.com/signup/) and create an account. Creating a Transifex account is free and not much information is needed.
 
 ### 2. Login and join the Bitcoin.org Translation Team
-* Follow this [link](https://www.transifex.com/bitcoinorg/bitcoinorg/) and click on “Join team”.
+* Follow this [link](https://app.transifex.com/bitcoinorg/bitcoinorg/) and click on “Join team”.
 * Select the language you want to translate into.
 * Your request to join a team will be accepted instantly, and you will be a translator for the language you selected.
 * If your language is not available yet, close the pop-up, scroll down, and click on “Request language” on the right side. Please consider first if it is necessary that bitcoin.org is available in your language. There is a lot of content to be translated and especially for languages with a low number of native speakers, there won’t be many people available that are willing to assist you.
 
 ### 3. Get to know the Interface
 * Play around with the interface. Transifex's interface can be a bit confusing and it cannot hurt to take a look around.
-* An introduction, provided by Transifex, can be found [here](https://docs.transifex.com/translation/translating-with-the-web-editor/?utm_source=welcome&utm_medium=email&utm_content=translator).
+* An introduction, provided by Transifex, can be found [here](https://help.transifex.com/en/articles/6318216-translating-with-the-web-editor).
 * As Translator, you cannot cause any harm as you can only edit unreviewed strings. A complete history is saved for every string, making it impossible to destroy previous work.
 * In the beginning, stay away from the Glossary as this can be edited by new translators but no history is saved.
 
@@ -116,7 +116,7 @@ No, even though the website is managed on GitHub, it is only necessary to unders
 
 ### 4. How do I use Transifex? 
 
-It is probably best if you take a look at the info provided by Transifex [here](https://docs.transifex.com/getting-started-1/translators) and [here](https://docs.transifex.com/translation/translating-with-the-web-editor/?utm_source=welcome&utm_medium=email&utm_content=translator). Everything beyond the basics is probably best learned by clicking through the menus of Transifex. 
+It is probably best if you take a look at the info provided by Transifex [here](https://help.transifex.com/en/collections/3441044-starting-with-the-basics) and [here](https://help.transifex.com/en/articles/6318216-translating-with-the-web-editor). Everything beyond the basics is probably best learned by clicking through the menus of Transifex. 
 
 ### 5. What are resources? 
 
@@ -242,7 +242,7 @@ ___
 
 ## Handling Translations on GitHub
 
-This section outlines how to handle translations on GitHub. In order to handle translations on GitHub, it's important that you have a fundamental understanding of [Ruby](https://ruby.github.io/TryRuby/), [HTML](https://www.w3schools.com/html/default.asp)/[CSS](https://www.w3schools.com/css/default.asp), [JavaScript](https://www.javascript.com/try), [Jekyll](https://jekyllrb.com/), [Git](https://guides.github.com/) and [Travis CI](https://travis-ci.org/bitcoin-dot-org/bitcoin.org). You should also be able to [set up your environment](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/setting-up-your-environment.md).
+This section outlines how to handle translations on GitHub. In order to handle translations on GitHub, it's important that you have a fundamental understanding of [Ruby](https://try.ruby-lang.org/), [HTML](https://www.w3schools.com/html/default.asp)/[CSS](https://www.w3schools.com/css/default.asp), [JavaScript](https://www.javascript.com/try), [Jekyll](https://jekyllrb.com/), [Git](https://docs.github.com/en/get-started) and [Travis CI](https://app.travis-ci.com/bitcoin-dot-org/bitcoin.org). You should also be able to [set up your environment](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/setting-up-your-environment.md).
 
 **If you only want to help by translating content, simply navigate to [Getting Started with the Translation Team](#getting-started-with-the-translation-team) section.**
 
@@ -274,29 +274,4 @@ code for other languages until they are updated.
 **When translation is needed**: If you want all changes you've made to be
 re-translated, you can simply update the resource file (en.yml) on Transifex.
 
-**When translation is not needed**: If you are only pushing typo fixes and that
-you don't want translators to redo all their work again, you can use the
-Transifex client to pull translations, update en.yml and push back all
-translations at once:
-
-
-    # Init Transifex project
-    tx init
-    
-    # Setup Transifex local client to use a project created on Transifex
-    tx set --auto-remote https://www.transifex.com/bitcoinorg/bitcoinorg/
-    
-    # Download all translations
-    tx pull -a -s --skip
-    
-    # Set the translations/bitcoinorg.bitcoinorg/en.yml file
-    # as a source that will be pushed back to the server after
-    # updating the translation
-    tx set --source -r bitcoinorg.bitcoinorg -l en translations/bitcoinorg.bitcoinorg/en.yml
-    
-    # (update en.yml)
-    
-    # Push changes back to Transifex
-    tx push -s -t -f --skip --no-interactive
-    
 

--- a/docs/become-a-contributor.md
+++ b/docs/become-a-contributor.md
@@ -6,10 +6,8 @@ Here are some ways you can help:
   repository to be notified of issues and Pull Requests (PRs) that could use
   your attention.
 
-    Alternatively, email volunteer coordinator Will Binns
-    ([will@bitcoin.org](mailto:will@bitcoin.org))
-    with a short list of your interests and skills, and they will email you when
-    there's an issue or PR that could use your attention.
+    Alternatively, [open an issue](https://github.com/bitcoin-dot-org/Bitcoin.org/issues/new)
+    on GitHub with a short list of your interests and skills.
 
 * Help [write new documentation](https://github.com/bitcoin-dot-org/developer.bitcoin.org/)
   for the [developer documentation pages](https://developer.bitcoin.org/)
@@ -25,11 +23,11 @@ Here are some ways you can help:
   help us [review wallet submissions](https://github.com/bitcoin-dot-org/bitcoin.org/pulls?q=is%3Aopen+label%3Awallet+is%3Apr).
 
 * [Translate Bitcoin.org into another language](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md)
-  using [Transifex](https://www.transifex.com/projects/p/bitcoinorg/) or help
+  using [Transifex](https://app.transifex.com/bitcoinorg/bitcoinorg/) or help
   review new and updated translations.
 
 * Add Bitcoin events to the [events page](https://bitcoin.org/en/events)
   either by editing `_events.yml` according to the [event instructions](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
   or by filling in a [pre-made events issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?title=New%20event&body=%20%20%20%20-%20date%3A%20YYYY-MM-DD%0A%20%20%20%20%20%20title%3A%20%22%22%0A%20%20%20%20%20%20venue%3A%20%22%22%0A%20%20%20%20%20%20address%3A%20%22%22%0A%20%20%20%20%20%20city%3A%20%22%22%0A%20%20%20%20%20%20country%3A%20%22%22%0A%20%20%20%20%20%20link%3A%20%22%22).
 
-* Help improve Bitcoin.org another way. Email volunteer coordinator Will Binns ([will@bitcoin.org](mailto:will@bitcoin.org)) to let us know how what you're interested in and how you'd like to get involved.
+* Help improve Bitcoin.org another way. [Open an issue](https://github.com/bitcoin-dot-org/Bitcoin.org/issues/new) on GitHub to let us know what you're interested in and how you'd like to get involved.


### PR DESCRIPTION
Resolves #4680.

Per @Cobra-Bitcoin's guidance in the issue thread, this PR applies the following changes:

### `docs/become-a-contributor.md`
- Replaced both references to volunteer coordinator Will Binns (`will@bitcoin.org`) with a link to open an issue on GitHub, following the maintainer's direction:
  > "Regarding Q1 I think the best approach is to direct people to open an issue."
- Updated the Transifex link from the legacy `www.transifex.com/projects/p/bitcoinorg/` URL (HTTP 404) to the current canonical `https://app.transifex.com/bitcoinorg/bitcoinorg/`.

### `docs/assisting-with-translations.md`
- Migrated all `www.transifex.com/...` URLs to `app.transifex.com/...` per the [Transifex domain migration of April 3, 2023](https://community.transifex.com/t/announcement-of-transifex-domain-change/3350). The `bitcoinorg/bitcoinorg` project slug is retained as confirmed by the maintainer:
  > "`bitcoinorg/bitcoinorg` is still the active Transifex location."
- Removed the legacy Transifex CLI instructions (`tx init`, `tx set`, `tx pull`, `tx push`) entirely, per:
  > "I would remove the CLI instructions entirely as I don't think anybody even does the translations that way."

  The Python `transifex-client` was deprecated in January 2022 and sunset on November 30, 2022, along with Transifex API v2/v2.5.
- Updated additional outdated reference URLs to their current canonical locations (same category of redirecting/legacy references as the Transifex URLs above):
  - `travis-ci.org/bitcoin-dot-org/bitcoin.org` → `app.travis-ci.com/bitcoin-dot-org/bitcoin.org` (the `travis-ci.org` domain was shut down on May 31, 2021)
  - `guides.github.com/` → `docs.github.com/en/get-started` (GitHub Guides was consolidated into the GitHub Docs "Get started" collection, which is the closest equivalent in spirit and intent)
  - `ruby.github.io/TryRuby/` → `try.ruby-lang.org/` (project moved to its canonical home)
  - `docs.transifex.com/getting-started[-1]/translators` → `help.transifex.com/en/collections/3441044-starting-with-the-basics` (the "Starting with the Basics" collection is the current equivalent)
  - `docs.transifex.com/translation/translating-with-the-web-editor/` → `help.transifex.com/en/articles/6318216-translating-with-the-web-editor` (direct article equivalent)

### Out of scope (intentionally left for follow-up)
- References to "Komodorpudel" as Team Leader (13 occurrences across the file) require a separate discussion about current translation team contacts — better handled as a dedicated issue.

### Verification
Each URL change was verified with `curl -sI -L` (HTTP status + final canonical URL) before applying. 