### PR TITLE
Fix Africa section: normalize paragraph structure in Nigeria and South Africa

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -289,8 +289,7 @@ id: exchanges
         <h3 id="nigeria" class="no_toc">Nigeria</h3>
         <p>
           <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
-        </p>
-        <p>
+          <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
@@ -302,8 +301,7 @@ id: exchanges
         <h3 id="south-africa" class="no_toc">South Africa</h3>
         <p>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
-        </p>
-        <p>
+          <br>
           <a class="marketplace-link" href="https://www.luno.com/">Luno</a>
         </p>
       </div>


### PR DESCRIPTION
Closes #4765 

The Nigeria and South Africa sections rendered with extra vertical space between exchanges, inconsistent with other multi-exchange country sections. Per #4765, this was caused by separate `<p>` tags introduced in 2021 instead of the standard `<p>` + `<br>` pattern.

## Fix

Normalize both sections to the standard pattern used elsewhere on the page: a single `<p>` containing the exchanges separated by `<br>`. No content change; same exchanges, same order, same links.

## Verification

Confirmed against the rendered page at https://bitcoin.org/en/exchanges#africa: Nigeria and South Africa show the extra vertical spacing, while other multi-exchange sections (Uganda, Bahrain, Israel, Japan, etc.) render correctly with the standard pattern.