### PR TITLE
docs: modernize adding-exchanges.md

### DIFF
--- a/docs/adding-exchanges.md
+++ b/docs/adding-exchanges.md
@@ -1,23 +1,44 @@
 ## Adding Exchanges
 
 Exchanges seeking to be added to Bitcoin.org should add themselves to the
-respective area(s) they serve in `exchanges.html` in the `_templates` directory,
-via [pull request](https://github.com/bitcoin-dot-org/bitcoin.org/pull/new/master).
+appropriate section(s) of `_templates/exchanges.html` and open a
+[pull request](https://github.com/bitcoin-dot-org/bitcoin.org/pull/new/master).
 
-Shortly after the pull request is made, a Travis CI job will be added to [our
-queue](https://travis-ci.org/bitcoin-dot-org/bitcoin.org). This will build the
-site and run some basic checks. If the job fails, you will be emailed a link to
-the build log and the pull request will indicate a failed job. Please read the
-build report and try to correct the problem.
+If you are not comfortable opening a pull request, you can instead open a
+[new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new)
+requesting to be added.
 
-If you're not comfortable with GitHub pull requests, please open a
-[new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new) requesting
-to be added.
+### How the Listings Are Organized
+
+`_templates/exchanges.html` is organized into nine top-level sections:
+
++ **International** and **Peer-to-Peer (P2P)** — non-geographic category
+  sections. Exchanges are listed directly under the section heading, with
+  no country subdivision.
++ **Asia**, **Europe**, **Africa**, **North America**, and **South America** —
+  continental sections subdivided by country. Each country has its own `<h3>`
+  heading and flag SVG, with exchanges listed underneath.
++ **Australia** and **New Zealand** — country-level sections (no continental
+  grouping). Exchanges are listed directly under the section heading, same
+  flat structure as International and P2P.
+
+For sections with country subdivision, adding a new country requires placing
+the country's flag SVG at `/img/flags/XX.svg` (where `XX` is the ISO 3166-1
+alpha-2 code) and referencing it from the country block. Use an existing
+country block as a guide.
+
+### Build Checks
+
+Once a pull request is opened, a [Travis CI](https://app.travis-ci.com/bitcoin-dot-org/bitcoin.org)
+check runs against it. The status (passing or failing) is shown directly
+on the pull request page; clicking through the check provides the full
+build log. If the build fails, please read the log and address the issue
+before requesting review.
 
 ### Review Criteria
 
-Exchanges are reviewed before potentially being added to the site, focusing on
-the following areas:
+Exchanges are reviewed before potentially being added to the site, focusing
+on the following areas:
 
 + Site functionality
 + Operational processes


### PR DESCRIPTION
This PR modernizes `docs/adding-exchanges.md` to reflect the current state of the repository and CI tooling. Four changes:

1. Fix the dead Travis CI link. The `travis-ci.org` domain was decommissioned in 2021; the Travis instance for this repo lives at `app.travis-ci.com/bitcoin-dot-org/bitcoin.org`, matching the URL already used in `docs/assisting-with-translations.md`.

2. Modernize the Travis CI workflow description. The current prose describes an older email-and-link workflow ("you will be emailed a link to the build log") that no longer matches what a contributor sees — Travis status now shows inline on the pull request, with the build log accessible by clicking the check. The paragraph is also promoted to its own `### Build Checks` section.

3. Add a `### How the Listings Are Organized` section documenting the structure of `_templates/exchanges.html`: which sections are flat (International, P2P, Australia, New Zealand) versus subdivided by country with `<h3>` headings (Asia, Europe, Africa, North America, South America), plus the `/img/flags/XX.svg` requirement for country-subdivided sections. None of this is currently documented.

4. Reorder the "If you're not comfortable" paragraph to immediately follow the submission instructions (was previously after the Travis paragraph, separating the primary submission path from its fallback). Two small wording updates in the opening: "appropriate section(s) of" replaces "respective area(s) they serve in" (better fits the International and P2P sections, which aren't regional), and "comfortable opening a pull request" replaces "comfortable with GitHub pull requests" (clarifies what the fallback is opting out of).

Review Criteria and the final paragraph on periodic re-review are intentionally untouched. Operationalizing those bullets, or adding a formal Removal Criteria section, would be editorial policy and belongs in a separate proposal.

This follows the same pattern as PR #4764, which modernized `docs/become-a-contributor.md` and `docs/assisting-with-translations.md`.