### PR TITLE
docs: fix broken table cell in setting-up-your-environment.md

### DIFF
--- a/docs/setting-up-your-environment.md
+++ b/docs/setting-up-your-environment.md
@@ -157,8 +157,7 @@ Plugins include:
 | events       | 5       | Google Maps    | Events page
 | glossary     | 30      | --             | Developer glossary
 | redirects    | 20      | --             | Redirects from old URLs
-| releases     | 10      | --             | Bitcoin Core release notes; Download
-page
+| releases     | 10      | --             | Bitcoin Core release notes; Download page
 | sitemap      | 10      | --             | /sitemap.xml
 
 Notes: some plugins interact with each other or with translations; for example


### PR DESCRIPTION
The plugin table in docs/setting-up-your-environment.md has a broken cell. The releases row's last column reads "Bitcoin Core release notes; Download page", but "Download" and "page" are split across two physical lines, which breaks the Markdown table — "page" renders as orphan text between the table and the note that follows.

Formatting-only change. No content modified.