### PR TITLE
Remove Will Binns as contact in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,4 @@ The following quick guides will help you get started:
 Participation in this project is subject to a [Code of Conduct](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/CODE_OF_CONDUCT.md).
 
 ### Questions?
-Please contact Will Binns ([will@bitcoin.org](mailto:will@bitcoin.org)) if you need help.
+If you need help, please [open an issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues).


### PR DESCRIPTION
Will Binns was removed from the project in 2020 (#3397) but is still listed as the contact in CONTRIBUTING.md under "Questions?":

> Please contact Will Binns (will@bitcoin.org) if you need help.

The will@bitcoin.org address points to a former maintainer who has not been involved since 2020. This PR replaces it with a pointer to open an issue.

The same stale contact also appears in CODE_OF_CONDUCT.md; that one will be handled in a separate PR.