### PR TITLE
Remove Will Binns as contact in CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,10 +55,9 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting Will Binns at <will@bitcoin.org>. All complaints will be
-reviewed and investigated and will result in a response that is deemed necessary
-and appropriate to the circumstances. The project team is obligated to maintain
-confidentiality with regard to the reporter of an incident.
+reported by opening an issue. All complaints will be reviewed and investigated
+and will result in a response that is deemed necessary and appropriate to the
+circumstances.
 
 Further details of specific enforcement policies may be posted separately.
 


### PR DESCRIPTION
Will Binns was removed from the project in 2020 (#3397) but is still listed as the contact for Code of Conduct reports in CODE_OF_CONDUCT.md (Enforcement):

> ...may be reported by contacting Will Binns at will@bitcoin.org.

Since this is the channel for reporting abuse or harassment, directing it to a former maintainer who has not been involved since 2020 is a problem. This PR removes the personal contact and routes reports to opening an issue.

Companion to #4776, which removes the same stale contact from CONTRIBUTING.md.