### PR TITLE
Fix Argentina flag alt text typo and Peru flag format

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -382,7 +382,7 @@ id: exchanges
   <div class="marketplace-row">
 
     <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag">
+      <img class="marketplace-flag" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinian flag">
       <div>
         <h3 id="argentina" class="no_toc">Argentina</h3>
         <p>
@@ -442,7 +442,7 @@ id: exchanges
     </div>
 
     <div class="row marketplace">
-      <img class="marketplace-flag" src="/img/flags/PE.png?{{site.time | date: '%s'}}" alt="Peruvian flag">
+      <img class="marketplace-flag" src="/img/flags/PE.svg?{{site.time | date: '%s'}}" alt="Peruvian flag">
       <div>
         <h3 id="peru" class="no_toc">Peru</h3>
         <p>


### PR DESCRIPTION
Fixes #4774.

Two objective fixes in `_templates/exchanges.html`, surfaced during a structural audit following PR #4771:

1. **Line 385** — Argentina flag alt text: `Argentinan` → `Argentinian`. The original is a misspelling; the correction matches the demonym style used by every other entry in the South America section.

2. **Line 445** — Peru flag: `PE.png` → `PE.svg`. Every other `marketplace-flag` in the template uses `.svg`; Peru was the sole `.png` reference. `PE.svg` already exists in `img/flags/` and renders correctly.

No other changes. 