### PR TITLE
Add CoinSwitch (India) to Asia exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -58,6 +58,22 @@ id: exchanges
       </div>
     </div>
 
+    <!--
+      CoinSwitch — Bitcoin exchange serving India (BTC/INR)
+      Bitcoin trade:    https://coinswitch.co/pro/btc-inr/csx
+      AML policy:       https://coinswitch.co/aml-policy
+      Supported region: India | Fiat pair: INR
+    -->
+    <div class="row marketplace">
+      <img class="marketplace-flag" src="/img/flags/IN.svg?{{site.time | date: '%s'}}" alt="Indian flag">
+      <div>
+        <h3 id="india" class="no_toc">India</h3>
+        <p>
+          <a class="marketplace-link" href="https://coinswitch.co/">CoinSwitch</a>
+        </p>
+      </div>
+    </div>
+
     <div class="row marketplace">
       <img class="marketplace-flag" src="/img/flags/ID.svg?{{site.time | date: '%s'}}" alt="Indonesian flag">
       <div>


### PR DESCRIPTION
CoinSwitch is a Bitcoin exchange serving India (BTC/INR).
  Bitcoin trade: https://coinswitch.co/pro/btc-inr/csx
  AML policy:    https://coinswitch.co/aml-policy