### PR TITLE
Remove NovaDAX from exchanges (ceasing Brazil operations, June 2026)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -410,8 +410,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://mercadobitcoin.com.br/">Mercado Bitcoin</a>
           <br>
-          <a class="marketplace-link" href="https://novadax.com.br/">NovaDAX</a>
-          <br>
           <a class="marketplace-link" href="https://ripio.com/">Ripio</a>
         </p>
       </div>


### PR DESCRIPTION
Fixes #4784.

NovaDAX announced on 8 June 2026 that it is winding down its Brazil operations. New user registration and buy orders were disabled immediately, with a phased shutdown running through September 2026. Since new-user signup is already closed, a visitor arriving from bitcoin.org can no longer register.

**Sources:**
- InfoMoney (8 Jun 2026): https://www.infomoney.com.br/onde-investir/exchange-de-criptomoedas-novadax-encerra-operacoes-no-brasil-e-da-prazo-para-saques/
- Exame (8 Jun 2026): https://exame.com/future-of-money/corretora-de-criptoativos-novadax-anuncia-fim-das-atividades-no-brasil/

Removes the NovaDAX listing from the Brazil section (2-line deletion). The section retains seven other exchanges.