### PR TITLE
Remove Bitaroo from New Zealand section (bitaroo.nz no longer resolves)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -494,8 +494,6 @@ id: exchanges
 <div class="toccontent-block boxexpand expanded">
   <h2 id="new-zealand" class="exchanges-tab-title exchanges-newzealand-title">New Zealand</h2>
   <p>
-    <a class="marketplace-link" href="https://www.bitaroo.nz/">Bitaroo</a><img src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
-    <br>
     <a class="marketplace-link" href="https://www.independentreserve.com/">Independent Reserve</a>
   </p>
 </div>


### PR DESCRIPTION
Fixes #4785.

The New Zealand section links to `https://www.bitaroo.nz/`, but that domain no longer resolves in DNS:

    $ nslookup bitaroo.nz
    ** server can't find bitaroo.nz: NXDOMAIN

    $ nslookup www.bitaroo.nz
    ** server can't find www.bitaroo.nz: NXDOMAIN

The link is dead — a visitor clicking it from bitcoin.org reaches nothing.

**Context:** New Zealand's domestic exchange sector has been hollowed out by banking "de-risking" in recent years. Kiwi-Coin, the country's longest-running exchange, ceased trading on 1 January 2026 for this reason ([Cryptocurrency NZ News, Oct 2025](https://cryptocurrency.org.nz/news/kiwi-coin-closes-down-amid-banking-crisis)), joining Cryptopia, Dasset, BitNZ, NZBCX, Vimba, and BitPrime. The dead domain combined with this sector-wide collapse makes a temporary outage unlikely.

**Scope:** this affects **only** the New Zealand listing. Bitaroo's Australian operation at `bitaroo.com.au` (Australia section) is fully active and stays. 2-line deletion; Independent Reserve remains in the New Zealand section.