### PR TITLE
Add Earn Bitcoin page

### DIFF
--- a/_includes/layout/base/footer-menu.html
+++ b/_includes/layout/base/footer-menu.html
@@ -109,6 +109,9 @@ http://opensource.org/licenses/MIT.
           <a href="/en/{% translate sell url %}">{% translate menu-sell layout %}</a>
         </li>
         {% if page.lang == 'en' %}
+        <li{% if page.id == 'earn-bitcoin' %} class="active"{% endif %}>
+          <a href="/en/{% translate earn-bitcoin url %}">{% translate menu-earn-bitcoin layout %}</a>
+        </li>
         <li{% if page.id == 'full-node' %} class="active"{% endif %}>
           <a href="/en/full-node">{% translate menu-full-node layout %}</a>
         </li>

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -61,6 +61,7 @@ http://opensource.org/licenses/MIT.
       <li{% if page.id == 'support-bitcoin' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate support-bitcoin url %}">{% translate menu-support-bitcoin layout %}</a>
       <li id="buybitcoinmenulink" {% if page.id == 'buy' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate buy url %}">{% translate menu-buy layout %}</a></li>
       <li id="sellbitcoinmenulink" {% if page.id == 'sell' %} class="active"{% endif %}><a href="/en/{% translate sell url %}">{% translate menu-sell layout %}</a></li>
+      {% if page.lang == 'en' %}<li{% if page.id == 'earn-bitcoin' %} class="active"{% endif %}><a href="/en/{% translate earn-bitcoin url %}">{% translate menu-earn-bitcoin layout %}</a></li>{% endif %}
       {% if page.lang == 'en' %}<li{% if page.id == 'full-node' %} class="active"{% endif %}><a href="/en/full-node">Running a full node</a></li>{% endif %}
       <li{% if page.id == 'development' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate development url %}">{% translate menu-development layout %}</a></li>
     </ul>

--- a/_templates/earn-bitcoin.html
+++ b/_templates/earn-bitcoin.html
@@ -1,0 +1,53 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+layout: base
+id: earn-bitcoin
+---
+<div class="hero">
+  <div class="container hero-container">
+    <h1>{% translate pagetitle %}</h1>
+    <p class="summarytxt">{% translate summary %}</p>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row card-row">
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_conf.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="contribute">{% translate contribute %}</h2>
+      <p>{% translate contributetxt %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_business.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="jobs">{% translate jobs %}</h2>
+      <p>{% translate jobstxt %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_payment.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="sell">{% translate sell-products %}</h2>
+      <p>{% translate sell-products-txt %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_wallet.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="payroll">{% translate payroll %}</h2>
+      <p>{% translate payrolltxt %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_micro.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="small-tasks">{% translate small-tasks %}</h2>
+      <p>{% translate small-tasks-txt %}</p>
+    </div>
+
+    <div class="card support-card">
+      <img class="titleicon" src="/img/icons/ico_warning.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="stay-safe">{% translate stay-safe %}</h2>
+      <p>{% translate stay-safe-txt %}</p>
+    </div>
+  </div>
+</div>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -1099,6 +1099,22 @@ en:
     translatetxt: "You can help spread Bitcoin awareness by translating or improving translations inside important parts of the Bitcoin ecosystem. Just pick a project you would like to help with."
     help: "Meet the communities"
     helptxt: "You can join Bitcoin <a href=\"#community#\">communities</a> and talk with other Bitcoin enthusiasts. You can learn more about Bitcoin every day, give help to new users and get involved in interesting projects."
+  earn-bitcoin:
+    title: "Earn Bitcoin - Bitcoin"
+    pagetitle: "Earn Bitcoin"
+    summary: "You do not need to buy bitcoin from an exchange to get started. Many people earn bitcoin by working, selling goods or services, contributing to open source projects, or receiving part of their regular income in bitcoin."
+    contribute: "Contribute to open source"
+    contributetxt: "Some Bitcoin projects pay bounties for useful contributions. Bitcoin.org maintains a list of <a href=\"https://github.com/bitcoin-dot-org/bitcoin.org/labels/Bounty\">open bounty issues</a>; if your pull request is merged, the bounty is paid to the bitcoin address you provide."
+    jobs: "Find jobs or freelance work"
+    jobstxt: "You can look for full-time roles, contract work, and small services where clients are willing to pay in bitcoin. Bitcoin-focused job boards such as <a href=\"https://bitcoinerjobs.com/\">Bitcoiner Jobs</a> and <a href=\"https://cryptocurrencyjobs.co/bitcoin/\">Cryptocurrency Jobs' Bitcoin listings</a> can be places to start."
+    sell-products: "Sell products or services"
+    sell-products-txt: "Merchants, freelancers, creators, and local businesses can earn bitcoin by accepting it directly from customers. A self-hosted payment processor such as <a href=\"https://btcpayserver.org/\">BTCPay Server</a> can help you receive bitcoin online or in person without relying on a custodial payment account."
+    payroll: "Receive income in bitcoin"
+    payrolltxt: "Some employers and payroll providers can pay wages, contractor invoices, or a percentage of regular income in bitcoin. Services such as <a href=\"https://bitwage.com/en-us\">Bitwage</a> can help workers receive part of their existing income in bitcoin where supported."
+    small-tasks: "Do small tasks"
+    small-tasks-txt: "Task boards, community forums, and tip-based projects can pay small amounts of bitcoin for testing, writing, design, support, translations, or other useful work. These opportunities usually pay less, so compare the time required with the expected payout."
+    stay-safe: "Stay safe"
+    stay-safe-txt: "Avoid any offer that asks for an upfront deposit, your private keys, a seed phrase, or promises guaranteed profit. Check the reputation of the person or service paying you, consider escrow for unfamiliar counterparties, and follow the tax and legal rules that apply where you live."
   vocabulary:
     title: "Vocabulary - Bitcoin"
     pagetitle: "Some Bitcoin words you might hear"
@@ -1203,6 +1219,7 @@ en:
     menu-support-bitcoin: "Support Bitcoin"
     menu-buy: "Buy Bitcoin"
     menu-sell: "Sell Bitcoin"
+    menu-earn-bitcoin: "Earn Bitcoin"
     menu-full-node: "Running a full node"
     menu-other: "Other"
     menu-vocabulary: Vocabulary
@@ -1268,6 +1285,7 @@ en:
     scams: scams
     secure-your-wallet: secure-your-wallet
     support-bitcoin: support-bitcoin
+    earn-bitcoin: earn-bitcoin
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     bitcoin-paper: bitcoin-paper


### PR DESCRIPTION
Closes #2524.

This adds an English-only Earn Bitcoin page and links it from the Participate menu in both the header and footer. It intentionally does not add a homepage button, matching maintainer feedback in the issue.

The page covers several practical ways to earn bitcoin:

- contributing to open source bounty issues
- finding Bitcoin-related jobs or freelance work
- selling products or services for bitcoin
- receiving regular income in bitcoin where supported
- evaluating smaller task-based opportunities
- avoiding common scams and unsafe offers

Bounty payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

Validation run locally:

- `git diff --check`
- YAML parse and referenced key checks for `_translations/en.yml`
- generated URL key check for `earn-bitcoin`
- HTTP 200 checks for newly added external links using `curl --http1.1 -L`

I could not run the full `make valid` locally because this checkout requires Ruby 2.5.8 while the available system Ruby is 2.6.10.