### PR TITLE
Add submit business page

### DIFF
--- a/_templates/bitcoin-for-businesses.html
+++ b/_templates/bitcoin-for-businesses.html
@@ -43,6 +43,7 @@ id: bitcoin-for-businesses
       <img class="titleicon" src="/img/icons/ico_visib.svg?{{site.time | date: '%s'}}" alt="Icon" />
       <h2 id="visibility">{% translate visibility %}</h2>
       <p>{% translate visibilitytext %}</p>
+      <p><a href="/{{ page.lang }}/{% translate submit-business url %}">{% translate visibilitylink %}</a></p>
     </div>
 
     <div class="card business-card">

--- a/_templates/getting-started.html
+++ b/_templates/getting-started.html
@@ -127,7 +127,7 @@ id: getting-started
             {% translate visibility %}</h2>
           <p>{% translate visibilitytxt %}</p>
           <div>
-            <a class="btn-bright" href="/{{ page.lang }}/{% translate spend-bitcoin url %}">{% translate visibilitybut %}</a>
+            <a class="btn-bright" href="/{{ page.lang }}/{% translate submit-business url %}">{% translate visibilitybut %}</a>
           </div>
         </div>
       </div>

--- a/_templates/submit-business.html
+++ b/_templates/submit-business.html
@@ -1,0 +1,35 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+layout: base
+id: submit-business
+---
+<div class="hero">
+  <div class="container hero-container">
+    <h1>{% translate pagetitle %}</h1>
+    <p class="summary">{% translate summary %}</p>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row card-row">
+    <div class="card spend-card">
+      <img src="/img/icons/local.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="map">{% translate map %}</h2>
+      <p>{% translate map-text %}</p>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/directory.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="directory">{% translate directory %}</h2>
+      <p>{% translate directory-text %}</p>
+    </div>
+
+    <div class="card spend-card">
+      <img src="/img/icons/badge.svg?{{site.time | date: '%s'}}" alt="icon">
+      <h2 id="keep-current">{% translate keep-current %}</h2>
+      <p>{% translate keep-current-text %}</p>
+    </div>
+  </div>
+</div>

--- a/_translations/ar.yml
+++ b/_translations/ar.yml
@@ -660,6 +660,7 @@ ar:
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/bg.yml
+++ b/_translations/bg.yml
@@ -667,6 +667,7 @@ bg:
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/ca.yml
+++ b/_translations/ca.yml
@@ -1191,6 +1191,7 @@ ca:
     you-need-to-know: necessites-saber
     bitcoin-paper: paper-bitcoin
     spend-bitcoin: gasta-bitcoins
+    submit-business: submit-business
   anchor:
     community:
       non-profit: sense-lucre

--- a/_translations/da.yml
+++ b/_translations/da.yml
@@ -702,6 +702,7 @@ da:
     vocabulary: ordliste
     you-need-to-know: du-boer-vide
     spend-bitcoin: bruge-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/de.yml
+++ b/_translations/de.yml
@@ -1197,6 +1197,7 @@ de:
     you-need-to-know: das-sollten-sie-wissen
     bitcoin-paper: bitcoin-paper
     spend-bitcoin: bitcoins-ausgeben
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/el.yml
+++ b/_translations/el.yml
@@ -699,6 +699,7 @@ el:
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -63,6 +63,7 @@ en:
     pcitext: "Accepting credit cards online typically requires extensive security checks in order to comply with the PCI standard. Bitcoin still requires you to <a href=\"#secure-your-wallet#\">secure your wallet</a> and your payment requests, however, you do not carry the costs and responsibilities that come with processing sensitive information from your customers like with credit card numbers."
     visibility: "Get some free visibility"
     visibilitytext: "Bitcoin is an emerging market of new customers who are searching for ways to spend their bitcoins. Accepting them is a good way to get new customers and give your business some new visibility. Accepting a new payment method has often shown to be a clever practice for online businesses."
+    visibilitylink: "Submit your business"
     multisig: "Multi-signature"
     multisigtext: "Bitcoin also includes a multi-signature feature which allows bitcoins to be spent only if a subset of a group of people authorize the transaction. This can be used by a board of directors, for example, to prevent members from making expenditures without enough consent from other members, as well as to track which members permitted particular transactions."
     transparency: "Accounting transparency"
@@ -1075,6 +1076,16 @@ en:
     business-map-text: "There are also many local businesses, like cafes and restaurants, that accept Bitcoin. You can use <a href=\"https://btcmap.org/\">btcmap.org</a> to browse thousands of businesses across the globe."
     business-search: "Global local and online business search"
     business-search-text: "<a href=\"https://bitcoinwide.com/\">BitcoinWide.com</a> is a global, open and free platform to search businesses, organizations or individuals who accept Bitcoin and other Cryptocurrency."
+  submit-business:
+    title: "Submit your business - Bitcoin"
+    pagetitle: "Submit your business"
+    summary: "Help people find your business when they are looking for places to spend Bitcoin."
+    map: "Add your location to BTC Map"
+    map-text: "If you serve customers at a physical location, add your business to <a href=\"https://btcmap.org/\">BTC Map</a> so nearby Bitcoin users can discover it."
+    directory: "Join a business directory"
+    directory-text: "Directories such as <a href=\"https://bitcoinwide.com/\">BitcoinWide.com</a> let customers search for businesses and organizations that accept Bitcoin."
+    keep-current: "Keep your listing current"
+    keep-current-text: "Keep your directory listings up to date, add clear payment instructions, and display the <a href=\"https://en.bitcoin.it/wiki/Promotional_graphics\">Bitcoin logo</a> on your website or storefront."
   support-bitcoin:
     title: "Support Bitcoin - Bitcoin"
     pagetitle: "Support Bitcoin"
@@ -1273,6 +1284,7 @@ en:
     bitcoin-paper: bitcoin-paper
     whitepaper-mirrors: whitepaper-mirrors
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/es.yml
+++ b/_translations/es.yml
@@ -669,6 +669,7 @@ es:
     vocabulary: vocabulario
     you-need-to-know: debes-saber
     spend-bitcoin: gastar-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: sin-animo-de-lucro

--- a/_translations/fa.yml
+++ b/_translations/fa.yml
@@ -667,6 +667,7 @@ fa:
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/fr.yml
+++ b/_translations/fr.yml
@@ -702,6 +702,7 @@ fr:
     vocabulary: vocabulaire
     you-need-to-know: vous-devez-savoir
     spend-bitcoin: depenser-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: organisation-sans-but-lucratif

--- a/_translations/he.yml
+++ b/_translations/he.yml
@@ -1148,6 +1148,7 @@ he:
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/hi.yml
+++ b/_translations/hi.yml
@@ -699,6 +699,7 @@ hi:
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/hu.yml
+++ b/_translations/hu.yml
@@ -1110,6 +1110,7 @@ hu:
     you-need-to-know: amit-tudnia-erdemes
     bitcoin-paper: papir-bitcoin
     spend-bitcoin: fizess-bitcoinnal
+    submit-business: submit-business
   anchor:
     community:
       non-profit: nonprofit

--- a/_translations/hy.yml
+++ b/_translations/hy.yml
@@ -1193,6 +1193,7 @@ hy:
     bitcoin-paper: bitcoin-paper
     whitepaper-mirrors: whitepaper-mirrors
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/id.yml
+++ b/_translations/id.yml
@@ -1186,6 +1186,7 @@ id:
     you-need-to-know: yang-perlu-anda-ketahui
     bitcoin-paper: makalah-bitcoin
     spend-bitcoin: menggunakan-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: nirlaba

--- a/_translations/it.yml
+++ b/_translations/it.yml
@@ -1190,6 +1190,7 @@ it:
     you-need-to-know: da-sapere
     bitcoin-paper: documento-bitcoin
     spend-bitcoin: spendi-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/ja.yml
+++ b/_translations/ja.yml
@@ -1116,6 +1116,7 @@ ja:
     you-need-to-know: you-need-to-know
     bitcoin-paper: bitcoin-paper
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/km.yml
+++ b/_translations/km.yml
@@ -1167,6 +1167,7 @@ km:
     bitcoin-paper: bitcoin-paper
     whitepaper-mirrors: whitepaper-mirrors
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
     
   anchor:
     community:

--- a/_translations/ko.yml
+++ b/_translations/ko.yml
@@ -699,6 +699,7 @@ ko:
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/nl.yml
+++ b/_translations/nl.yml
@@ -1191,6 +1191,7 @@ nl:
     you-need-to-know: wat-u-moet-weten
     bitcoin-paper: bitcoin-document
     spend-bitcoin: bitcoin-uitgeven
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/pl.yml
+++ b/_translations/pl.yml
@@ -702,6 +702,7 @@ pl:
     vocabulary: slownik
     you-need-to-know: co-potrzebujesz-wiedziec
     spend-bitcoin: zuzyc-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/pt_BR.yml
+++ b/_translations/pt_BR.yml
@@ -1186,6 +1186,7 @@ pt_BR:
     you-need-to-know: voce-precisa-saber
     bitcoin-paper: bitcoin-paper
     spend-bitcoin: gastar-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: sem-fins-lucrativos

--- a/_translations/ro.yml
+++ b/_translations/ro.yml
@@ -699,6 +699,7 @@ ro:
     vocabulary: vocabular
     you-need-to-know: ce-trebuie-sa-stii
     spend-bitcoin: petrece-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/ru.yml
+++ b/_translations/ru.yml
@@ -868,6 +868,7 @@ ru:
     you-need-to-know: you-need-to-know
     bitcoin-paper: bitcoin-paper
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/sl.yml
+++ b/_translations/sl.yml
@@ -661,6 +661,7 @@ sl:
     vocabulary: besednjak
     you-need-to-know: kaj-moram-vedeti
     spend-bitcoin: porabiti-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: neprofitne

--- a/_translations/sr.yml
+++ b/_translations/sr.yml
@@ -1182,6 +1182,7 @@ sr:
     you-need-to-know: trebali-bi-da-znate
     bitcoin-paper: bitkoin-papir
     spend-bitcoin: potrosi-bitkoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: neprofitna

--- a/_translations/sv.yml
+++ b/_translations/sv.yml
@@ -1184,6 +1184,7 @@ sv:
     you-need-to-know: du-behover-kanna-till
     bitcoin-paper: bitcoinartikel
     spend-bitcoin: spendera-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: ideell

--- a/_translations/tr.yml
+++ b/_translations/tr.yml
@@ -699,6 +699,7 @@ tr:
     vocabulary: kelime-haznesi
     you-need-to-know: bilmeniz-gerekenler
     spend-bitcoin: bitcoin-para-harcamak
+    submit-business: submit-business
   anchor:
     community:
       non-profit: kar-etmeyen

--- a/_translations/uk.yml
+++ b/_translations/uk.yml
@@ -948,6 +948,7 @@ uk:
     you-need-to-know: you-need-to-know
     bitcoin-paper: bitcoin-paper
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/zh_CN.yml
+++ b/_translations/zh_CN.yml
@@ -908,6 +908,7 @@ zh_CN:
     you-need-to-know: you-need-to-know
     bitcoin-paper: bitcoin-paper
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit

--- a/_translations/zh_TW.yml
+++ b/_translations/zh_TW.yml
@@ -699,6 +699,7 @@ zh_TW:
     vocabulary: vocabulary
     you-need-to-know: you-need-to-know
     spend-bitcoin: spend-bitcoin
+    submit-business: submit-business
   anchor:
     community:
       non-profit: non-profit


### PR DESCRIPTION
Closes #1583.

This adds a dedicated `submit-business` page for merchants who want customers to find their Bitcoin-accepting business. It keeps the implementation link-first rather than embedding third-party map data, matching the BTC Map direction discussed in #1583 and #4033.

Changes included:

- add a new `submit-business` template
- route the Getting Started visibility CTA to the new page
- add a visibility link from the Bitcoin for Businesses page
- add `submit-business` URL slugs for all current translation files so localized pages have valid routes
- keep the page focused on BTC Map, BitcoinWide, and clear listing/payment instructions

Bounty payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

Validation run locally:

- `git diff --check`
- YAML parse for all `_translations/*.yml`
- route-key check confirming `submit-business` exists for 31 language files
- template translation-key check for `_templates/submit-business.html`
- HTTP 200 checks for newly added external links: `https://btcmap.org/`, `https://bitcoinwide.com/`, and `https://en.bitcoin.it/wiki/Promotional_graphics`

I could not run the full `make valid` locally because this checkout requires Ruby 2.5.8 while the available system Ruby is 2.6.10; `bundle check` stops on that version mismatch.