### PR TITLE
docs: modernize working-with-github.md and fix dead Travis CI URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to Bitcoin.org's Codebase
 
-Current Build Status: ![Build Status](https://travis-ci.org/bitcoin-dot-org/bitcoin.org.svg?branch=master)
+Current Build Status: ![Build Status](https://api.travis-ci.com/bitcoin-dot-org/bitcoin.org.svg?branch=master)
 
 Live site: [Bitcoin.org](https://bitcoin.org)
 

--- a/_templates/about-us.html
+++ b/_templates/about-us.html
@@ -425,7 +425,7 @@ id: about-us
       <span>Translation tools</span>
     </p>
     <p class="contributor">
-      <a class="contributor-name" href="https://travis-ci.org/">Travis CI</a>
+      <a class="contributor-name" href="https://www.travis-ci.com/">Travis CI</a>
       <span>Continuous integration</span>
     </p>
   </div>

--- a/docs/working-with-github.md
+++ b/docs/working-with-github.md
@@ -2,9 +2,9 @@
 
 GitHub allows you to make changes to a project using git, and later submit them
 in a "pull request" so they can be reviewed and discussed. In order to use
-GitHub, you need to [sign up](http://github.com/signup) and [set up
-git](https://help.github.com/articles/set-up-git). You will also need to
-[fork](https://help.github.com/articles/fork-a-repo/) the bitcoin.org repository
+GitHub, you need to [sign up](https://github.com/signup) and [set up
+git](https://docs.github.com/en/get-started/git-basics/set-up-git). You will also need to
+[fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the bitcoin.org repository
 from its [GitHub page](https://github.com/bitcoin-dot-org/bitcoin.org) and clone
 your GitHub repository into a local directory with the following command lines:
 
@@ -18,12 +18,12 @@ git remote add upstream https://github.com/bitcoin-dot-org/bitcoin.org.git
 
 1. Checkout to your master branch. `git checkout master`
 2. Create a new branch from the master branch. `git checkout -b (any name)`
-3. Edit files and [preview](#previewing) the result.
+3. Edit files and [preview](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/setting-up-your-environment.md) the result.
 4. Track changes in files. `git add -A`
 5. Commit your changes. `git commit -m '(short description for your change)'`
 6. Push your branch on your GitHub repository. `git push origin (name of your
    branch)`
-7. Click on your branch on GitHub and click the **Compare / pull request**
+7. Click on your branch on GitHub and click the **Compare & pull request**
    button to send a pull request.
 
 When submitting a pull request, please take required time to discuss your
@@ -33,7 +33,7 @@ changes into separate branches and pull requests.
 **Travis Continuous Integration (CI)**
 
 Shortly after your Pull Request (PR) is submitted, a Travis CI job will
-be added to [our queue](https://travis-ci.org/bitcoin-dot-org/bitcoin.org). This
+be added to [our queue](https://app.travis-ci.com/bitcoin-dot-org/bitcoin.org). This
 will build the site and run some basic checks. If the job fails, you
 will be emailed a link to the build log and the PR will indicate a
 failed job. Read the build report and try to correct the problem---but
@@ -49,9 +49,9 @@ builds before opening a pull request, it's really simple:
 1. Make sure the master branch of your repository is up to date with the
    bitcoin-dot-org/bitcoin.org master branch.
 
-2. Open [this guide](http://docs.travis-ci.com/user/getting-started/)
-   and perform steps one, two, and four. (The other steps are already
-   done in our master branch.)
+2. Open [this guide](https://docs.travis-ci.com/user/getting-started/)
+   and enable Travis CI for your repository. (The build configuration is
+   already present in our repository.)
 
 3. After you push a branch to your repository, go to your branches page
    (e.g. for user harding, github.com/harding/bitcoin.org/branches). A


### PR DESCRIPTION
Closes #4794.

`docs/working-with-github.md` hasn't had a substantive update since 2018 (commit 79399058) and accumulated several dead or outdated references. This also fixes the dead `travis-ci.org` build badge in `README.md` and the Travis CI contributor link in `about-us.html`. All replacements were verified with `curl`/`grep` against the repo.

### `docs/working-with-github.md`
- `sign up`, `set up git`, and `fork` links: `http://` -> `https://`, and `help.github.com` -> `docs.github.com` (the old paths only survive on a redirect)
- Travis CI queue link: `travis-ci.org` -> `app.travis-ci.com` (the `.org` domain was sunset in 2021; this matches the form already used in `adding-exchanges.md` and `assisting-with-translations.md`)
- **Compare / pull request** -> **Compare & pull request** (GitHub renamed the button)
- `[preview](#previewing)`: there is no "Previewing" heading anywhere in the repo, so the anchor pointed nowhere; repointed to `setting-up-your-environment.md` using the same cross-doc style as `assisting-with-translations.md`
- Travis fork-setup step: `http://` -> `https://`, and reworded - it told readers to "perform steps one, two, and four" of an external guide that has since been reorganized, so that numbering no longer maps to anything

### `README.md` / `_templates/about-us.html`
- README build badge: `travis-ci.org/.../bitcoin.org.svg` -> `api.travis-ci.com/.../bitcoin.org.svg` (verified to serve a valid SVG; the `/github/` form returns HTML and would render broken)
- about-us "Travis CI" contributor link: `travis-ci.org/` -> `www.travis-ci.com/`

### Deliberately not included
- The "How to send a pull request" steps still create branches from local `master`. Switching to `git fetch upstream` + `git checkout -b (any name) upstream/master` would be safer, but it changes recommended workflow, so I left it out here - happy to add it as a follow-up if preferred.
- `_posts/` and `_releases/` also reference the old `travis-ci.org` domain, but those are historical and correct as-is.

cc @Cobra-Bitcoin 