### PR TITLE
docs: add missing context to miscellaneous.md

### DIFF
--- a/docs/miscellaneous.md
+++ b/docs/miscellaneous.md
@@ -1,31 +1,36 @@
 ## Miscellaneous
 
-### Redirections
+### Redirects
 
-Redirections can be defined in ```_config.yml```.
+Redirects are defined under the `redirects` key in `_config.yml` and are turned
+into redirect pages at build time by `_plugins/redirects.rb`. Most existing
+entries redirect paths whose content has moved to `developer.bitcoin.org`, and
+there are also some internal slug renames. For example:
 
-```
-  /news: /en/version-history
-```
+    redirects:
+      /news: /en/version-history
 
 ### Aliases For Contributors
 
-Aliases for contributors are defined in ```_config.yml```.
+The site's contributor lists are generated from the GitHub contributor data for
+`bitcoin/bitcoin` and `bitcoin-dot-org/bitcoin.org` (see
+`_plugins/contributors.rb`). The `aliases` map in `_config.yml` normalizes the
+names returned by GitHub to canonical display names. For example:
 
-```
-aliases:
-  s_nakamoto: Satoshi Nakamoto
-  --author=Satoshi Nakamoto: Satoshi Nakamoto
-```
+    aliases:
+      s_nakamoto: Satoshi Nakamoto
+      --author=Satoshi Nakamoto: Satoshi Nakamoto
 
 ### Developer PGP keys
 
-The site hosts the PGP keys for several Bitcoin Core contributors. Here
-are some notes about updating those keys based on previous experience:
+The site hosts the PGP keys of several Bitcoin contributors. They are stored as
+`.asc` files in the root of the repository, and include both individual
+contributor keys and release-signing keys (such as `laanwj-releases.asc`).
 
-1. If a key is revoked, update the key with the revocation immediately.
-   Anyone with commit access to the site repository may do this without
-   prior review, but they should post the commit ID to an open issue or
-   PR so other people can review it. After the revoked key is uploaded,
-   discussion about verifying/adding a replacement key may continue at a
-   slower pace.
+Notes on updating these keys, based on past experience:
+
+1. If a key is revoked, update the key with the revocation immediately. Anyone
+   with commit access to the site repository may do this without prior review,
+   but they should post the commit ID to an open issue or PR so other people can
+   review it. After the revoked key is uploaded, discussion about
+   verifying/adding a replacement key may continue at a slower pace.


### PR DESCRIPTION
docs/miscellaneous.md has been essentially unchanged since 2017. Its three sections are accurate but terse, they state where things are defined without saying what they are for or where they live. This adds that context:

- Redirects: name the consuming plugin (_plugins/redirects.rb) and note most entries redirect paths that have moved to developer.bitcoin.org.
- Aliases For Contributors: explain that the aliases map normalizes the GitHub contributor names used to build the site's contributor lists (_plugins/contributors.rb). The existing example is unchanged.
- Developer PGP keys: note the keys live as .asc files in the repo root and include both contributor keys and release-signing keys (e.g.laanwj-releases.asc); "Bitcoin contributors" instead of "Bitcoin Core contributors" (e.g. Andreas Schildbach's key is not a Core key).

No policy is changed. Two related questions for the maintainer, which I did not want to decide in this PR:

1. The keys section documents only one revocation procedure. In practice keys have been handled both by replacing the .asc in place with a revoked version (Pieter Wuille, 2015, 93404350) and by deleting the file (Luke Dashjr, 2023, 58abc453). Should one be the documented standard?

2. Inactive contributors' keys have sometimes been removed (Niels Schneider, 2021, 8af6c7f2; "Drop inactive contributors", 2018). Document a policy, or leave it case-by-case?

cc @Cobra-Bitcoin