### PR TITLE
docs: Remove stale bounty program section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@ Live site: [Bitcoin.org](https://bitcoin.org)
 
 Report problems or help improve the site by opening a [new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new) or [pull request](https://github.com/bitcoin-dot-org/bitcoin.org/compare).
 
-## Earn Bitcoin for Contributing
-Open issues [labeled with "Bounty"](https://github.com/bitcoin-dot-org/bitcoin.org/labels/Bounty)
-have bounties on them. Viewing the issue will reveal the value of the bounty.
-Submit a pull request resolving the issue along with an accompanying note or
-comment containing a bitcoin address and automatically receive a payment in the
-amount of the bounty if it gets merged.
-
 ## How to Participate
 The following quick guides will help you get started:
 
@@ -27,6 +20,10 @@ The following quick guides will help you get started:
 + [Adding Blog Posts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-blog-posts.md)
 + [Miscellaneous / Other](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/miscellaneous.md)
 
-### Code of Conduct
+## Code of Conduct
 
 Participation in this project is subject to a [Code of Conduct](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/CODE_OF_CONDUCT.md).
+
+## Questions?
+
+Please contact Will Binns([will@bitcoin.org](mailto:will@bitcoin.org)) if you need help.


### PR DESCRIPTION
## Summary

Removes the "Earn Bitcoin for Contributing" section from README.md that advertises an inactive bounty program.

## Background

The README currently advertises an active bounty program in present tense, promising automatic bitcoin payment for merged PRs resolving issues labeled with `Bounty`. However:

- No issue has been created with the `Bounty` label since **July 2018** (~8 years ago)
- The 6 remaining open bounty issues are all from 2015-2018
- The label has no description
- Recent `updated_at` timestamps are from external reference events, not actual engagement

This is stale documentation promising money for a program with no sign of activity in eight years.

## Changes

- Removed lines 9-14 from README.md ("Earn Bitcoin for Contributing" section)
- No other changes needed - this is pure documentation cleanup

## Impact

- Removes misleading information that could confuse new contributors
- No functional changes to the site or contribution process
- Other contribution guides remain intact

Closes #4805