### PR TITLE
Remove stale will@bitcoin.org maintainer contact references

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -612,7 +612,7 @@ text:
   ## Values last updated 2026-04-17
   ## All variable names must indicate unit type for easy translation of adjacent text,
   ##   such as: subsidy_in_decimal_bitcoins or
-  ##   bitcoin_org_docs_maintainer_email_link
+  ##   bitcoin_datadir_gb
   ## For increasing variables, like chain size, choose a somewhat higher
   ##   value so we don't need to update too often
   subsidy_in_decimal_bitcoins: 3.125
@@ -627,7 +627,6 @@ text:
   total_tx_count_in_millions: 1300
   typical_ibd_time_in_hours: 4
   typical_144_block_catchup_time_in_minutes: 5
-  bitcoin_org_docs_maintainer_email_link: '<a href="mailto:will@bitcoin.org">Will Binns</a>'
   ## Before updating this, verify all assertions are still correct: git grep site.text.assertion_month
   ## Use ISO-8601 format, but feel free to round to the nearest month
   assertion_month: 2017-06-01

--- a/_posts/2015-09-14-new-bitcoin-core-pages.md
+++ b/_posts/2015-09-14-new-bitcoin-core-pages.md
@@ -74,9 +74,8 @@ In addition, we hope to provide more resources that help businesses
 understand the benefits of validating the transactions they receive with
 their own full nodes.
 
-If you want to help, please feel free to email the Bitcoin.org
-documentation maintainer,
-{{site.text.bitcoin_org_docs_maintainer_email_link}}.
+If you want to help, please feel free to
+[open an issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new).
 </div>
 
 <div class="toccontent-block boxexpand expanded" markdown="1">

--- a/_posts/2018-05-01-test-the-new-site-design.md
+++ b/_posts/2018-05-01-test-the-new-site-design.md
@@ -38,7 +38,6 @@ before it goes live.
 **[Help test the new design.](https://bitcoin.cryptopelago.com/)**
 
 If you visited the link above and experienced any issues or have feedback, please
-[send us an email](mailto:will@bitcoin.org?subject=Redesign%20Feedback") or
 [open an issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?title=Redesign%20Feedback)
 on Bitcoin.org's GitHub repository. Please also make sure to note your device,
 operating system and browser version(s), when applicable, to give us additional

--- a/en/bitcoin-core/contribute/documentation.md
+++ b/en/bitcoin-core/contribute/documentation.md
@@ -63,8 +63,7 @@ To contribute, you can [edit the guide][edit bandwidth sharing
 guide] using the same GitHub web interface as described in the
 previous section.
 
-*Need help getting started? You can [open an issue][] or email Bitcoin.org
-documentation maintainer {{site.text.bitcoin_org_docs_maintainer_email_link}}.*
+*Need help getting started? You can [open an issue][].*
 
 ## Bitcoin Wiki
 
@@ -110,8 +109,7 @@ To contribute RPC edits, the easiest way is to:
 6. At the bottom of the page, fill out the Propose File Change form and
    submit it.
 
-*Need help getting started? You can [open an issue][] or email
-Bitcoin.org documentation maintainer {{site.text.bitcoin_org_docs_maintainer_email_link}}.*
+*Need help getting started? You can [open an issue][].*
 
 <br class="clear big">
 <div class="prevnext" markdown="block">


### PR DESCRIPTION
Resolves #3679.

[#3679](https://github.com/bitcoin-dot-org/Bitcoin.org/issues/3679) (opened by @jlopp in 2021) reported that several pages still list Will Binns as a point of contact. Will hasn't held a role on the project for years, and the `will@bitcoin.org` address no longer works, so contributors who follow these prompts hit a dead end.

This removes the remaining **live** references that direct people to that address:

- **`_config.yml`** — dropped the `bitcoin_org_docs_maintainer_email_link` variable (and updated the naming-convention comment that used it as an example).
- **`en/bitcoin-core/contribute/documentation.md`** (×2) — removed the "or email maintainer Will Binns" clause. Each spot already offered "[open an issue]" as the first option, so the guidance still works.
- **`_posts/2015-09-14-new-bitcoin-core-pages.md`** — reworded the contact line to point to opening an issue.
- **`_posts/2018-05-01-test-the-new-site-design.md`** — removed the `mailto:` link, keeping the existing "[open an issue]" link (also drops a stray quote in the old URL).

### Intentionally left untouched
Historical references to Will Binns are **not** changed, since they're accurate records: post author credits, the release-notes contributor lists (v0.13/v0.14), the `wbnns` alias that renders those credits, and `.mailmap`. This PR only touches places that present the address as a *current* contact.