### PR TITLE
Modernize the Bitcoin for Individuals page for 2026

### DIFF
--- a/_templates/bitcoin-for-individuals.html
+++ b/_templates/bitcoin-for-individuals.html
@@ -52,6 +52,18 @@ id: bitcoin-for-individuals
         {% include animations/herecomesbitcoin/sir.html %}
       </div>
     </div>
+
+    <div class="card individuals-card">
+      <img src="/img/icons/ico_lightning.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="lightning">{% translate lightning %}</h2>
+      <p>{% translate lightningtext %}</p>
+    </div>
+
+    <div class="card individuals-card">
+      <img src="/img/icons/ico_own.svg?{{site.time | date: '%s'}}" alt="Icon" />
+      <h2 id="selfcustody">{% translate selfcustody %}</h2>
+      <p>{% translate selfcustodytext %}</p>
+    </div>
   </div>
 
   <div class="btn-container ">

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -110,7 +110,7 @@ en:
     pagetitle: "Bitcoin for Individuals"
     summary: "Bitcoin lets you send and receive money directly, anywhere in the world."
     mobile: "Mobile payments made easy"
-    mobiletext: "Bitcoin when used on a mobile device allows you to pay with a simple two-step scan-and-pay. There's no need to sign up, swipe your card, type a PIN, or sign anything. All you need to receive Bitcoin payments is to display the QR code in your Bitcoin wallet app and let the other party scan it, or tap a phone or card on a contactless reader (using NFC technology)."
+    mobiletext: "Bitcoin when used on a mobile device allows you to pay with a simple two-step scan-and-pay. There's no need to sign up, swipe your card, type a PIN, or sign anything. All you need to receive Bitcoin payments is to display the QR code in your Bitcoin wallet app and let the other party scan it, or tap to pay with a contactless reader where supported (using NFC technology)."
     international: "Fast international payments"
     internationaltext: >
       Sending bitcoins across borders is as easy as sending them across
@@ -134,9 +134,9 @@ en:
       amount does not by itself cost more than moving a small one.
 
     anonymous: "Protect your identity"
-    anonymoustext: "With Bitcoin, there's no credit card number that malicious actors can collect in order to steal from you. Bitcoin transactions are recorded publicly and permanently on the block chain, so your identity is not attached to your payments by default, though it can be revealed through how you use them. Some effort is required to <a href=\"#protect-your-privacy#\">protect your privacy</a>."
+    anonymoustext: "With Bitcoin, there's no credit card number that malicious actors can collect in order to steal from you. Bitcoin transactions are recorded publicly and permanently on the block chain. While Bitcoin addresses are not inherently tied to real-world identities, they can sometimes be linked to individuals depending on how Bitcoin is used. Some effort is required to <a href=\"#protect-your-privacy#\">protect your privacy</a>."
     lightning: "Instant, low-cost payments"
-    lightningtext: "The <a href=\"#resources##lightning\">Lightning Network</a> lets you send and receive bitcoin instantly, even for very small amounts, with minimal fees. Built on top of Bitcoin, it settles payments off-chain so they confirm in a moment rather than waiting for a block."
+    lightningtext: "The <a href=\"#resources##lightning\">Lightning Network</a> lets you send and receive bitcoin near-instantly, even for very small amounts, with minimal fees. Built on top of Bitcoin, it settles payments off-chain so they confirm in a moment rather than waiting for a block."
     selfcustody: "Be your own bank"
     selfcustodytext: "With Bitcoin, you can hold your money yourself instead of trusting a bank or company to hold it for you. Your wallet keeps the keys that control your funds. This freedom comes with responsibility: it is up to you to <a href=\"#secure-your-wallet#\">secure your wallet</a>."
   bitcoin-paper:

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -108,32 +108,37 @@ en:
   bitcoin-for-individuals:
     title: "Bitcoin for Individuals - Bitcoin"
     pagetitle: "Bitcoin for Individuals"
-    summary: "Bitcoin is the easiest way to transact at a very low cost."
+    summary: "Bitcoin lets you send and receive money directly, anywhere in the world."
     mobile: "Mobile payments made easy"
-    mobiletext: "Bitcoin when used on a mobile device allows you to pay with a simple two-step scan-and-pay. There's no need to sign up, swipe your card, type a PIN, or sign anything. All you need to receive Bitcoin payments is to display the QR code in your Bitcoin wallet app and let the other party scan your mobile, or touch the two phones together (using NFC radio technology)."
+    mobiletext: "Bitcoin when used on a mobile device allows you to pay with a simple two-step scan-and-pay. There's no need to sign up, swipe your card, type a PIN, or sign anything. All you need to receive Bitcoin payments is to display the QR code in your Bitcoin wallet app and let the other party scan it, or tap a phone or card on a contactless reader (using NFC technology)."
     international: "Fast international payments"
     internationaltext: >
       Sending bitcoins across borders is as easy as sending them across
       the street. There are no banks to make you wait three business
-      days, no extra fees for making an international transfer, and no
-      special limitations on the minimum or maximum amount you can send.
+      days and no special limitations on the minimum or maximum amount
+      you can send. You pay the network fee you choose, the same whether
+      the payment crosses the street or the planet.
 
     simple: "Works everywhere, anytime"
     simpletext: "Similarly to email, you don't need to ask recipients you're sending bitcoin to, to use the same software, wallets or service providers. You just need their bitcoin address and then you can transact with them anytime. The Bitcoin network is always running and never sleeps, even on weekends and holidays."
     secure: "Security and control over your money"
-    securetext: "Bitcoin transactions are secured by mathematics and energy. <a href=\"https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm\">Cryptographic signatures</a> prevent other people from spending your money. Energy spent by <a href=\"https://en.bitcoin.it/wiki/Proof_of_work\">proof of work (PoW)</a> prevents other people from undoing, rearranging or losing your transactions. So long as you take the required steps to <a href=\"#secure-your-wallet#\">protect your wallet</a>, Bitcoin can give you control over your money and a strong level of protection against many types of fraud."
+    securetext: "Bitcoin transactions are secured by mathematics and energy. <a href=\"https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm\">Cryptographic signatures</a> (ECDSA and, since the 2021 Taproot upgrade, Schnorr signatures) prevent other people from spending your money. Energy spent by <a href=\"https://en.bitcoin.it/wiki/Proof_of_work\">proof of work (PoW)</a> prevents other people from undoing, rearranging or losing your transactions. So long as you take the required steps to <a href=\"#secure-your-wallet#\">protect your wallet</a>, Bitcoin can give you control over your money and a strong level of protection against many types of fraud."
     lowfee: "Choose your own fees"
     lowfeetext: >
       There is no fee to receive bitcoins, and many wallets let you
       control how large a fee to pay when spending. Most wallets have
       reasonable default fees, and higher fees can encourage faster <a
       href="#you-need-to-know##instant">confirmation</a> of your
-      transactions. Fees are unrelated to the amount transferred, so it's
-      possible to send 100,000 bitcoins for the same fee it costs to
-      send 1 bitcoin.
+      transactions. The fee depends on the size of the transaction in
+      data, not on the amount of value being sent, so moving a large
+      amount does not by itself cost more than moving a small one.
 
     anonymous: "Protect your identity"
-    anonymoustext: "With Bitcoin, there's no credit card number that malicious actors can collect in order to steal from you. In fact, it's even possible in some cases to send a payment without revealing your identity, almost like with physical money. You should, however, take note that some effort can be required to <a href=\"#protect-your-privacy#\">protect your privacy</a>."
+    anonymoustext: "With Bitcoin, there's no credit card number that malicious actors can collect in order to steal from you. Bitcoin transactions are recorded publicly and permanently on the block chain, so your identity is not attached to your payments by default, though it can be revealed through how you use them. Some effort is required to <a href=\"#protect-your-privacy#\">protect your privacy</a>."
+    lightning: "Instant, low-cost payments"
+    lightningtext: "The <a href=\"#resources##lightning\">Lightning Network</a> lets you send and receive bitcoin instantly, even for very small amounts, with minimal fees. Built on top of Bitcoin, it settles payments off-chain so they confirm in a moment rather than waiting for a block."
+    selfcustody: "Be your own bank"
+    selfcustodytext: "With Bitcoin, you can hold your money yourself instead of trusting a bank or company to hold it for you. Your wallet keeps the keys that control your funds. This freedom comes with responsibility: it is up to you to <a href=\"#secure-your-wallet#\">secure your wallet</a>."
   bitcoin-paper:
     title: "Bitcoin: A Peer-to-Peer Electronic Cash System"
     pagetitle: "Bitcoin: A Peer-to-Peer Electronic Cash System"

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -135,8 +135,8 @@ en:
 
     anonymous: "Protect your identity"
     anonymoustext: "With Bitcoin, there's no credit card number that malicious actors can collect in order to steal from you. Bitcoin transactions are recorded publicly and permanently on the block chain. While Bitcoin addresses are not inherently tied to real-world identities, they can sometimes be linked to individuals depending on how Bitcoin is used. Some effort is required to <a href=\"#protect-your-privacy#\">protect your privacy</a>."
-    lightning: "Instant, low-cost payments"
-    lightningtext: "The <a href=\"#resources##lightning\">Lightning Network</a> lets you send and receive bitcoin near-instantly, even for very small amounts, with minimal fees. Built on top of Bitcoin, it settles payments off-chain so they confirm in a moment rather than waiting for a block."
+    lightning: "Fast, low-cost payments"
+    lightningtext: "The <a href=\"#resources##lightning\">Lightning Network</a> lets you send and receive bitcoin near-instantly, even for very small amounts, with minimal fees. Built on top of Bitcoin, it settles payments off-chain so they confirm in seconds rather than waiting for a block."
     selfcustody: "Be your own bank"
     selfcustodytext: "With Bitcoin, you can hold your money yourself instead of trusting a bank or company to hold it for you. Your wallet keeps the keys that control your funds. This freedom comes with responsibility: it is up to you to <a href=\"#secure-your-wallet#\">secure your wallet</a>."
   bitcoin-paper:


### PR DESCRIPTION
Closes #4812

Modernizes `/en/bitcoin-for-individuals` for 2026. Every change was verified against primary sources (current fee data, Taproot/Schnorr, NFC payment products, Lightning). Touches `en.yml` (English source of truth; the 30 translations follow via Transifex) and the page template (the two new cards require markup).

### Existing cards
- **summary** — "easiest way to transact at a very low cost" is an absolute claim on-chain fees don't always support; reframed around direct, global payments.
- **mobile** — replaced the phone-to-phone "touch the two phones together" flow with contactless tap-to-pay where supported. NFC stays (it's current in 2026); only the outdated mechanism changed.
- **international** — "no extra fees for international" ignored the network fee; softened to acknowledge the fee the user chooses.
- **secure** — signatures were linked only to ECDSA; now also mentions Schnorr, added in the 2021 Taproot upgrade.
- **lowfee** — kept the principle (fee independent of value) but removed the "100,000 bitcoins" relic and the imprecise "fees are unrelated to the amount"; reworded to: fee depends on transaction size in data, not value sent.
- **anonymous** — corrected the overstated anonymity; notes transactions are public and permanent and that addresses can sometimes be linked to individuals. Title and illustration kept.

The **simple** card was accurate and is unchanged.

### New cards
- **Lightning ("Fast, low-cost payments")** — links to the existing Lightning section on the resources page (`#resources##lightning`).
- **Self-custody ("Be your own bank")** — links to `secure-your-wallet`. This is a new editorial theme rather than a pure framing fix; included because self-custody is central to how individuals use Bitcoin in 2026. Happy to drop it if there's an objection.

### Verification
- New internal link targets exist on master: `id="lightning"` in `resources.html`, and URL keys `resources` / `secure-your-wallet` in `en.yml`.
- Icons already in the repo: `ico_lightning.svg`, `ico_own.svg`.
- External links (ECDSA, PoW) verified HTTP 200.