### PR TITLE
Remove hijacked/dead non-profit org links, update Argentina

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -143,7 +143,7 @@ id: community
           <img class="organization-img" src="/img/flags/AR.svg?{{site.time | date: '%s'}}" alt="Argentinan flag">
           <div>
             <h3 class="organization-country" id="argentina">Argentina</h3>
-            <a class="organization-link" href="https://www.bitcoinargentina.org/">Fundación Bitcoin Argentina</a>
+            <a class="organization-link" href="https://bitcoin.ar/">ONG Bitcoin Argentina</a>
           </div>
         </div>
         
@@ -163,13 +163,6 @@ id: community
           </div>
         </div>
         
-        <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/CL.svg?{{site.time | date: '%s'}}" alt="Chilean flag">
-          <div>
-            <h3 class="organization-country" id="chile">Chile</h3>
-            <a class="organization-link" href="https://www.asociacionbitcoin.org/">Asociación Bitcoin Chile</a>
-          </div>
-        </div>
         
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/DE.svg?{{site.time | date: '%s'}}" alt="German flag">
@@ -179,13 +172,6 @@ id: community
           </div>
         </div>
 
-        <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/IE.svg?{{site.time | date: '%s'}}" alt="Irish flag">
-          <div>
-            <h3 class="organization-country" id="ireland">Ireland</h3>
-            <a class="organization-link" href="https://www.bani.org.uk/">Bitcoin Association of Northern Ireland</a>
-          </div>
-        </div>
         
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/IL.svg?{{site.time | date: '%s'}}" alt="Israeli flag">
@@ -203,13 +189,6 @@ id: community
           </div>
         </div>   
         
-        <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/NL.svg?{{site.time | date: '%s'}}" alt="Dutch flag">
-          <div>
-            <h3 class="organization-country" id="netherlands">Netherlands</h3>
-            <a class="organization-link" href="https://stichtingbitcoin.nl/">Stichting Bitcoin Nederland</a>
-          </div>
-        </div>
         
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/PL.svg?{{site.time | date: '%s'}}" alt="Polish flag">
@@ -227,13 +206,6 @@ id: community
           </div>
         </div>
         
-        <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/ES.svg?{{site.time | date: '%s'}}" alt="Spanish flag">
-          <div>
-            <h3 class="organization-country" id="spain">Spain</h3>
-            <a class="organization-link" href="http://avalbit.org/">Avalbit</a>
-          </div>
-        </div>
         
         <div class="row organizations-item">
           <img class="organization-img" src="/img/flags/CH.svg?{{site.time | date: '%s'}}" alt="Swiss flag">


### PR DESCRIPTION
Security cleanup of the non-profit organizations list on the Community page (`/en/community`). Four of the listed links now point to hijacked or dead domains and are removed here; one is updated to its current name and domain.

Each was verified in a browser, not just by HTTP status — a hijacked domain still returns 200 while serving unrelated content, so status codes alone miss this.

**Removed:**
- **Chile** (`asociacionbitcoin.org`) — domain taken over; still shows "ONG Bitcoin Chile" branding but serves crypto-casino reviews now, impersonating the original organization.
- **Ireland** (`bani.org.uk`) — now an unrelated furniture template site (lorem ipsum).
- **Netherlands** (`stichtingbitcoin.nl`) — flagged as phishing by the browser.
- **Spain** (`avalbit.org`) — domain no longer resolves (NXDOMAIN).

**Updated:**
- **Argentina** — the organization rebranded from "Fundación Bitcoin Argentina" to "ONG Bitcoin Argentina" (same entity, est. 2013, also known as Asociación Civil DECODES). Both the name and the link (`bitcoinargentina.org` → `bitcoin.ar`) are updated.

**Intentionally left in place:**
- **Italy** (`bitcoin-italia.org`) — the site is still online but dormant since 2021. It's a real organization that went quiet, not a hijacked or dead link, so removing it is an editorial call left for discussion in #4826.

English source only (`_templates/community.html`); translations follow via Transifex.

Refs #4826