### PR TITLE
Update Bitcoin Safe

### DIFF
--- a/_wallets/bitcoinsafe.md
+++ b/_wallets/bitcoinsafe.md
@@ -18,7 +18,7 @@ platform:
       features: "bech32 hardware_wallet multisig segwit"
       check: &DEFAULT-CHECK
         control: "checkgoodcontrolfull"
-        validation: "checkfailvalidationcentralized"
+        validation: "checkpassvalidationservers"
         transparency: "checkpasstransparencyopensource"
         environment: "checkfailenvironmentdesktop"
         privacy: "checkpassprivacybasic"


### PR DESCRIPTION
In Version 2.0 of Bitcoin Safe the default sync method is Compact Block Filters via the bdk [kyoto](https://github.com/2140-dev/kyoto/) library. 

This PR improves the `validation score` to `checkpassvalidationservers`.  (see also https://github.com/bitcoin-dot-org/Bitcoin.org/pull/4522#issuecomment-3513842238   )