### PR TITLE
FAQ Transactions: fix confirmation timing and dated fee claims

### DIFF
--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -737,20 +737,21 @@ en:
       continue to be buried under every block after it, which will
       exponentially consolidate this consensus and decrease the risk of
       a reversed transaction.
-      Each confirmation takes between a few seconds and 90 minutes, with
-      10 minutes being the average. If the transaction pays too low a
-      fee or is otherwise atypical, getting the first confirmation can
-      take much longer.  Every user is free to determine at what
+      New blocks are added to the blockchain approximately every 10 minutes
+      on average, but block discovery is probabilistic—an individual
+      confirmation may arrive much sooner or much later, and there is no
+      guaranteed minimum or maximum delay. If the transaction pays a fee
+      below what the network is currently prioritizing, the first
+      confirmation may take considerably longer.  Every user is free to determine at what
       point they consider a transaction sufficiently confirmed, but <a href="#you-need-to-know##instant">6 confirmations</a>
       is often considered to be as safe as waiting 6 months on a credit
       card transaction.
 
     fee: "How much will the transaction fee be?"
     feetxt1: >
-      Transactions can be processed without fees, but trying to send
-      free transactions can require waiting days or weeks. Although fees
-      may increase over time, normal fees currently only cost a tiny
-      amount. By default, all <a href="#choose-your-wallet#">Bitcoin
+      Transactions are typically processed with a fee, and fees vary
+      over time with demand for space in the blockchain. By default,
+      all <a href="#choose-your-wallet#">Bitcoin
       wallets</a> listed on Bitcoin.org add what they think is an
       appropriate fee to your transactions; most of those wallets will
       also give you chance to review the fee before sending the
@@ -759,8 +760,8 @@ en:
     feetxt2: >
       Transaction fees are used as a protection against users sending
       transactions to overload the network and as a way to pay
-      miners for their work helping to secure the network. The precise manner in which
-      fees work is still being developed and will change over time.
+      miners for their work helping to secure the network. Fee levels
+      vary over time with network usage.
       Because the fee is not related to the amount of bitcoins being
       sent, it may seem extremely low or unfairly high. Instead, the
       fee is relative to the number of bytes in the transaction, so


### PR DESCRIPTION
Closes #4849

Fourth PR of the per-section FAQ pass (General #4844, Legal #4846, Economy #4848). Three keys changed in `_translations/en.yml`; no questions added, removed, or reordered.

### What changed

- `tenminutestxt1`: replaced "each confirmation takes between a few seconds and 90 minutes, with 10 minutes being the average" with the probabilistic description — new blocks arrive approximately every 10 minutes on average, but block discovery has no guaranteed minimum or maximum interval. This reuses the exact wording already merged on the "You need to know" page (#4842) for consistency across pages. The technically correct "exponentially consolidate" phrasing and the 6-confirmations guidance are unchanged.
- `feetxt1`: removed two claims that no longer hold — that transactions "can be processed without fees" (fee-less transactions are no longer relayed by the network in practice) and that "normal fees currently only cost a tiny amount" (a claim that fluctuates with demand and can mislead a newcomer reading it during a high-fee period). Replaced with demand-based phrasing that holds in any fee environment. The wallet guidance and its link are unchanged.
- `feetxt2`: replaced "the precise manner in which fees work is still being developed and will change over time" (2014-era) with "fee levels vary over time with network usage." The byte-based fee explanation (multisig, transaction size) is correct and unchanged.

### Verification

- YAML validates (folded blocks preserved); changes isolated to the `faq` key
- Internal links (`#you-need-to-know##instant`, `#choose-your-wallet#`) preserved
- Content-only change; no code, templates, or structure touched
