### PR TITLE
Fix license detection: keep LICENSE MIT-only, move NOTE to README

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,0 @@
-The intellectual property rights in the files are owned by the respective
-authors. Some of the files can be licensed under MIT License (MIT) available on
-http://opensource.org/licenses/MIT or other licenses. Appropriate licensing
-information can be found in the header of the file or in the folder containing
-the file.

--- a/LICENSE
+++ b/LICENSE
@@ -17,11 +17,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-***
-
-NOTE: The intellectual property rights in the files are owned by the respective
-authors. Some of the files can be licensed under MIT License (MIT) available on
-[https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT) or
-other licenses. Appropriate licensing information can be found in the header of
-the file or in the folder containing the file.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ The following quick guides will help you get started:
 ### Code of Conduct
 
 Participation in this project is subject to a [Code of Conduct](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/CODE_OF_CONDUCT.md).
+
+## License
+
+This repository is released under the terms of the [MIT license](https://opensource.org/licenses/MIT). See [LICENSE](LICENSE) for more information.
+
+The intellectual property rights in the files are owned by the respective
+authors. Some of the files can be licensed under MIT License (MIT) available on
+http://opensource.org/licenses/MIT or other licenses. Appropriate licensing
+information can be found in the header of the file or in the folder containing
+the file.


### PR DESCRIPTION
Closes #4839

GitHub currently reports "Unknown, Unknown licenses found" for this repository. As diagnosed in the issue, Licensee finds two license files it cannot classify: `LICENSE` combines the verbatim MIT text with a trailing NOTE (dropping the MIT similarity to 65.96%, below the ~90% threshold), and the root `COPYING` is a near-duplicate of that NOTE matching nothing.

### The fix — files reorganized, no terms changed

- **LICENSE** now contains only the MIT text. Not a single word of it changed.
- **The NOTE** (per-file/per-folder licensing of assets) moves **verbatim** to a new "License" section in the README, where it remains just as visible without confusing the detector.
- **The root COPYING** is removed — its content was the same NOTE, now in the README. The per-folder `COPYING` files (`img/*/COPYING`, `_translations/COPYING`, etc.), which hold the actual per-asset licensing information the NOTE points to, are untouched. The site plugins that skip files named `COPYING` are also unaffected.

### Verification

Running Licensee locally on this branch:

```
License:        MIT
Matched files:  LICENSE, README.md
LICENSE:
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
```

From "Unknown" at 65.96% similarity to an exact match at 100%. Once merged, the repository page should display the MIT license badge.
