### PR TITLE
Remove duplicate release notes headings from 30.x and 31.0

### DIFF
--- a/_releases/v30.0.md
+++ b/_releases/v30.0.md
@@ -33,9 +33,6 @@ optional_magnetlink:
 <div class="post-content" markdown="1">
   
 {% githubify https://github.com/bitcoin/bitcoin %}
-30.0 Release Notes
-==================
-
 v30.0 Release Notes
 ===================
 

--- a/_releases/v30.1.md
+++ b/_releases/v30.1.md
@@ -33,9 +33,6 @@ optional_magnetlink:
 <div class="post-content" markdown="1">
   
 {% githubify https://github.com/bitcoin/bitcoin %}
-30.1 Release Notes
-==================
-
 v30.1 Release Notes
 ===================
 

--- a/_releases/v30.2.md
+++ b/_releases/v30.2.md
@@ -33,9 +33,6 @@ optional_magnetlink:
 <div class="post-content" markdown="1">
   
 {% githubify https://github.com/bitcoin/bitcoin %}
-30.2 Release Notes
-==================
-
 v30.2 Release Notes
 ===================
 

--- a/_releases/v31.0.md
+++ b/_releases/v31.0.md
@@ -33,9 +33,6 @@ optional_magnetlink:
 <div class="post-content" markdown="1">
   
 {% githubify https://github.com/bitcoin/bitcoin %}
-31.0 Release Notes
-==================
-
 v31.0 Release Notes
 ===================
 


### PR DESCRIPTION
Four release notes files render two `Release Notes` headings instead of one.

Starting with 30.0, the upstream `doc/release-notes/release-notes-XX.md` files in `bitcoin/bitcoin` began including a `vXX.X Release Notes` heading at the top of the document. When these files were added in #4746, a `XX.X Release Notes` heading was inserted above the upstream text, following the convention used by earlier releases (28.x and older), whose upstream notes did not carry a heading.

The result is three `<h1>` elements on each affected page: the page title, the inserted heading, and the upstream heading. Example from the current `/en/releases/30.0/`:

```html
<h1>Bitcoin Core 30.0</h1>
<h1 id="release-notes">30.0 Release Notes</h1>
<h1 id="v300-release-notes">v30.0 Release Notes</h1>
```

This PR removes the inserted heading from the four affected files, leaving only the upstream one. This matches how bitcoincore.org renders the same releases.

### Files changed

| File | Removed |
|------|---------|
| `_releases/v30.0.md` | `30.0 Release Notes` + underline + blank line |
| `_releases/v30.1.md` | `30.1 Release Notes` + underline + blank line |
| `_releases/v30.2.md` | `30.2 Release Notes` + underline + blank line |
| `_releases/v31.0.md` | `31.0 Release Notes` + underline + blank line |

Total: 12 deletions, 0 insertions. No upstream text was modified.

### Verification

Each file now contains exactly one `Release Notes` heading, matching the upstream source: