### PR TITLE
Add Bitcoin Core 30.3 and 31.1, and fix the release date field

### DIFF
--- a/_releases/v0.21.1.md
+++ b/_releases/v0.21.1.md
@@ -11,7 +11,7 @@ id: en-release-0.21.1
 name: release-0.21.1
 permalink: /en/releases/0.21.1/
 excerpt: Bitcoin Core version 0.21.1 is now available
-date: 2021-05-01
+optional_date: 2021-05-01
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers"

--- a/_releases/v22.0.md
+++ b/_releases/v22.0.md
@@ -10,7 +10,7 @@ id: en-release-22.0
 name: release-22.0
 permalink: /en/releases/22.0/
 excerpt: Bitcoin Core version 22.0 is now available
-date: 2021-09-13
+optional_date: 2021-09-13
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v25.0.md
+++ b/_releases/v25.0.md
@@ -10,7 +10,7 @@ id: en-release-25.0
 name: release-25.0
 permalink: /en/releases/25.0/
 excerpt: Bitcoin Core version 25.0 is now available
-date: 2023-05-26
+optional_date: 2023-05-26
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v27.0.md
+++ b/_releases/v27.0.md
@@ -10,7 +10,7 @@ id: en-release-27.0
 name: release-27.0
 permalink: /en/releases/27.0/
 excerpt: Bitcoin Core version 27.0 is now available
-date: 2024-04-02
+optional_date: 2024-04-02
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v27.1.md
+++ b/_releases/v27.1.md
@@ -10,7 +10,7 @@ id: en-release-27.1
 name: release-27.1
 permalink: /en/releases/27.1/
 excerpt: Bitcoin Core version 27.1 is now available
-date: 2024-06-17
+optional_date: 2024-06-17
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v27.2.md
+++ b/_releases/v27.2.md
@@ -10,7 +10,7 @@ id: en-release-27.2
 name: release-27.2
 permalink: /en/releases/27.2/
 excerpt: Bitcoin Core version 27.2 is now available
-date: 2024-11-04
+optional_date: 2024-11-04
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v28.0.md
+++ b/_releases/v28.0.md
@@ -10,7 +10,7 @@ id: en-release-28.0
 name: release-28.0
 permalink: /en/releases/28.0/
 excerpt: Bitcoin Core version 28.0 is now available
-date: 2024-10-02
+optional_date: 2024-10-02
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v28.1.md
+++ b/_releases/v28.1.md
@@ -10,7 +10,7 @@ id: en-release-28.1
 name: release-28.1
 permalink: /en/releases/28.1/
 excerpt: Bitcoin Core version 28.1 is now available
-date: 2025-01-09
+optional_date: 2025-01-09
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v28.2.md
+++ b/_releases/v28.2.md
@@ -10,7 +10,7 @@ id: en-release-28.2
 name: release-28.2
 permalink: /en/releases/28.2/
 excerpt: Bitcoin Core version 28.2 is now available
-date: 2025-06-26
+optional_date: 2025-06-26
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v28.3.md
+++ b/_releases/v28.3.md
@@ -10,7 +10,7 @@ id: en-release-28.3
 name: release-28.3
 permalink: /en/releases/28.3/
 excerpt: Bitcoin Core version 28.3 is now available
-date: 2025-10-17
+optional_date: 2025-10-17
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v28.4.md
+++ b/_releases/v28.4.md
@@ -10,7 +10,7 @@ id: en-release-28.4
 name: release-28.4
 permalink: /en/releases/28.4/
 excerpt: Bitcoin Core version 28.4 is now available
-date: 2026-03-18
+optional_date: 2026-03-18
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v29.0.md
+++ b/_releases/v29.0.md
@@ -10,7 +10,7 @@ id: en-release-29.0
 name: release-29.0
 permalink: /en/releases/29.0/
 excerpt: Bitcoin Core version 29.0 is now available
-date: 2025-04-14
+optional_date: 2025-04-14
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v29.1.md
+++ b/_releases/v29.1.md
@@ -10,7 +10,7 @@ id: en-release-29.1
 name: release-29.1
 permalink: /en/releases/29.1/
 excerpt: Bitcoin Core version 29.1 is now available
-date: 2025-09-04
+optional_date: 2025-09-04
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v29.2.md
+++ b/_releases/v29.2.md
@@ -10,7 +10,7 @@ id: en-release-29.2
 name: release-29.2
 permalink: /en/releases/29.2/
 excerpt: Bitcoin Core version 29.2 is now available
-date: 2025-10-14
+optional_date: 2025-10-14
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v29.3.md
+++ b/_releases/v29.3.md
@@ -10,7 +10,7 @@ id: en-release-29.3
 name: release-29.3
 permalink: /en/releases/29.3/
 excerpt: Bitcoin Core version 29.3 is now available
-date: 2026-02-10
+optional_date: 2026-02-10
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v30.0.md
+++ b/_releases/v30.0.md
@@ -10,7 +10,7 @@ id: en-release-30.0
 name: release-30.0
 permalink: /en/releases/30.0/
 excerpt: Bitcoin Core version 30.0 is now available
-date: 2025-10-10
+optional_date: 2025-10-10
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v30.1.md
+++ b/_releases/v30.1.md
@@ -10,7 +10,7 @@ id: en-release-30.1
 name: release-30.1
 permalink: /en/releases/30.1/
 excerpt: Bitcoin Core version 30.1 is now available
-date: 2026-01-02
+optional_date: 2026-01-02
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v30.2.md
+++ b/_releases/v30.2.md
@@ -10,7 +10,7 @@ id: en-release-30.2
 name: release-30.2
 permalink: /en/releases/30.2/
 excerpt: Bitcoin Core version 30.2 is now available
-date: 2026-01-10
+optional_date: 2026-01-10
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v30.3.md
+++ b/_releases/v30.3.md
@@ -1,0 +1,205 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 30.3
+title: Bitcoin Core 30.3
+id: en-release-30.3
+name: release-30.3
+permalink: /en/releases/30.3/
+excerpt: Bitcoin Core version 30.3 is now available
+optional_date: 2026-07-08
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [30, 3]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+v30.3 Release Notes
+===================
+
+Bitcoin Core version v30.3 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-30.3/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+This release fixes an issue where the chainstate database would repeatedly
+rewrite large portions of itself, causing excessive disk reads and writes
+during normal operation.
+
+### Validation
+
+- #35209 validation: correct lifetime of precomputed tx data
+- #35465 coins: compact chainstate regularly
+
+### Leveldb
+
+- #61(bitcoin-core/leveldb): Disable seek compaction
+
+### Wallet
+
+- #34358 wallet: fix removeprunedfunds bug with conflicting transactions
+- #34870 wallet: feebumper, fix crash when combined bump fee is unavailable
+- #34888 wallet: fix amount computed as boolean in coin selection
+- #35228 wallet: use outpoint when estimating input size
+
+### Net
+
+- #34093 netif: fix compilation warning in QueryDefaultGatewayImpl()
+- #34549 net: reduce log level for PCP/NAT-PMP NOT_AUTHORIZED failures
+
+### PSBT
+
+- #34272 psbt: Fix PSBTInputSignedAndVerified bounds assert
+- #34219 psbt: validate pubkeys in MuSig2 pubnonce/partial sig deserialization
+
+### Miniscript
+
+- #34434 miniscript: correct and_v() properties
+
+### Build
+
+- #34228 depends: Unset SOURCE_DATE_EPOCH in gen_id script
+- #34281 build: Temporarily remove confusing and brittle -fdebug-prefix-map
+- #34554 build: avoid exporting secp256k1 symbols
+- #34627 guix: use a temporary file over sponge, drop moreutils
+- #34713 depends: Allow building Qt packages after interruption
+- #34754 depends: Qt fixes for GCC 16 compatibility
+- #34787 build: fix native macOS deployment
+- #34848 cmake: Migrate away from deprecated SQLite3 target
+- #34956 depends, qt: Fix build on aarch64 macOS 26.4
+
+### Test
+
+- #34185 test: fix feature_pruning when built without wallet
+- #34282 qa: Fix Windows logging bug
+- #34390 test: allow overriding tar in get_previous_releases.py
+- #34409 test: use ModuleNotFoundError in interface_ipc.py
+- #34445 fuzz: Use AFL_SHM_ID for naming test directories
+- #34608 test: Fix broken --valgrind handling after bitcoin wrapper
+- #34690 test: Add missing timeout_factor to zmq socket
+- #34869 tests: applied PYTHON_GIL to the env for every test
+- #34918 fuzz: [refactor] Remove unused g_setup pointers
+- #35080 test: Add missing self.options.timeout_factor scale in tool_bitcoin_chainstate.py
+
+### Util
+
+- #34597 util: Fix UB in SetStdinEcho when ENOTTY
+
+### Doc
+
+- #34252 doc: add 433 (Pay to Anchor) to bips.md
+- #34413 doc: Remove outdated -fdebug-prefix-map section in dev notes
+- #34510 doc: fix broken bpftrace installation link
+- #34561 wallet: rpc: manpage: fix example missing `fee_rate` argument
+- #34671 doc: Update Guix install for Debian/Ubuntu
+- #34702 doc: Fix fee field in getblock RPC result
+- #34706 doc: Improve dependencies.md IPC documentation
+- #34789 doc: update build guides pre v31
+- #35283 doc: mention -DWITH_ZMQ=ON in BSD build guides
+
+### CI
+
+- #32513 ci: remove 3rd party js from windows dll gha job
+- #34344 ci: update GitHub Actions versions
+- #34453 ci: Always print low ccache hit rate notice
+- #34461 ci: Print verbose build error message in test-each-commit
+- #34802 ci: Bump GHA actions versions
+- #34815 ci: bump cirruslabs actions versions
+- #35202 ci: restore sockets in i686, no IPC job
+- #35378 ci: switch runners from cirrus to warpbuild
+- #35408 ci: 35378 followups
+
+### Misc
+
+- #35175 multi_index: fix compilation failure with boost >= 1.91
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- ANAVHEOBA
+- andrewtoth
+- brunoerg
+- Cory Fields
+- Daniel Pfeifer
+- darosior
+- fanquake
+- furszy
+- Hennadii Stepanov
+- jayvaliya
+- junbyjun1238
+- kevkevinpal
+- Lőrinc
+- m3dwards
+- marcofleon
+- MarcoFalke
+- mzumsande
+- nervana21
+- Padraic Slattery
+- ryanofsky
+- Sebastian Falbesoner
+- SomberNight
+- tboy1337
+- theuni
+- ToRyVand
+- willcl-ark
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>

--- a/_releases/v31.0.md
+++ b/_releases/v31.0.md
@@ -10,7 +10,7 @@ id: en-release-31.0
 name: release-31.0
 permalink: /en/releases/31.0/
 excerpt: Bitcoin Core version 31.0 is now available
-date: 2026-04-19
+optional_date: 2026-04-19
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers".

--- a/_releases/v31.1.md
+++ b/_releases/v31.1.md
@@ -1,0 +1,178 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 31.1
+title: Bitcoin Core 31.1
+id: en-release-31.1
+name: release-31.1
+permalink: /en/releases/31.1/
+excerpt: Bitcoin Core version 31.1 is now available
+optional_date: 2026-07-08
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [31, 1]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+v31.1 Release Notes
+===================
+
+Bitcoin Core version 31.1 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-31.1/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the installer
+(on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS) or
+`bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be
+migrated. Old wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on the following operating systems or
+newer: Linux Kernel 3.17, macOS 14, and Windows 10 (version 1903). Bitcoin Core
+should also work on most other Unix-like systems but is not as frequently tested
+on them. It is not recommended to use Bitcoin Core on unsupported systems.
+
+Notable changes
+===============
+
+### PrivateBroadcast
+
+This release fixes an ip address leak when using the -privatebroadcast feature.
+Under certain circumstances connections were being made over clearnet rather than
+the enabled privacy network.
+
+
+### Validation
+
+- #35209 validation: correct lifetime of precomputed tx data
+- #35465 coins: compact chainstate regularly
+
+### Leveldb
+
+- #61(bitcoin-core/leveldb): Disable seek compaction
+
+### P2P
+
+- #35032 net_processing: don't modify addrman for private broadcast connections
+- #35410 net: use the proxy if overriden when doing v2->v1 reconnections
+
+### Wallet
+
+- #35227 wallet: check the final BDB page LSN during migration
+- #35228 wallet: use outpoint when estimating input size
+
+### Musig
+
+- #35316 musig: Reject empty pubkey list in GetMuSig2KeyAggCache
+
+### Build
+
+- #34228 depends: Unset SOURCE_DATE_EPOCH in gen_id script
+
+### Test
+
+- #34425 test: Fix all races after a socket is closed gracefully
+- #34863 test: Clean shutdown in Socks5Server
+- #34991 test: fix feature_index_prune.py bug when using --usecli
+- #35080 test: Add missing self.options.timeout_factor scale in tool_bitcoin_chainstate.py
+- #35218 test: fix P2SH script in coins cache fuzz target
+- #35279 psbt, test: remove address type restrictions in test
+
+### Fuzz
+
+- #35289 fuzz: Fix timeout in txorphan
+
+### Util
+
+- #35384 util: Check write failures before renaming settings.json
+
+### Docs
+
+- #35283 doc: mention -DWITH_ZMQ=ON in BSD build guides
+
+### CI
+
+- #35202 ci: restore sockets in i686, no IPC job
+- #35230 ci: Move --usecli --extended from i386 task to alpine task
+- #35348 ci: switch to GitHub cache for all runners
+- #35378 ci: switch runners from cirrus to warpbuild
+- #35408 ci: 35378 followups
+- #35430 ci: use warp caching on warp runners
+- #35447 ci: use warpbuild cache for docker buildkit cache
+
+### Misc
+
+- #35044 contrib: Fix NameError in signet miner gbt()
+- #35175 multi_index: fix compilation failure with boost >= 1.91
+- #34953 crypto: disable ASan instrumentation of SSE4 SHA256 for GCC
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- andrewtoth
+- Cory Fields
+- Crypt-iQ
+- darosior
+- deadmanoz
+- fanquake
+- Greg Sanders
+- Hennadii Stepanov
+- junbyjun1238
+- Lőrinc
+- MarcoFalke
+- marcofleon
+- nervana21
+- optout21
+- Pol Espinasa
+- rkrux
+- Shrey
+- Torkel Rogstad
+- Vasil Dimov
+- willcl-ark
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>


### PR DESCRIPTION
This PR adds the two Bitcoin Core releases published on 2026-07-08, and fixes the date field used by the 19 most recent release notes.

### Part 1 — Add 30.3 and 31.1

| File | Version | Published |
|------|---------|-----------|
| `_releases/v30.3.md` | 30.3 | 2026-07-08 |
| `_releases/v31.1.md` | 31.1 | 2026-07-08 |

The release-note text is copied from `bitcoin/bitcoin` (`doc/release-notes/release-notes-XX.md`). The only change to that text is the insertion of blank lines before Markdown lists, per step 1 of the reformatting instructions in `docs/adding-release-notes-and-alerts.md`. Step 2 (URLs in angle brackets) required no change — the upstream files already follow it.

Both upstream files already begin with a `vXX.X Release Notes` heading, so none was added.

Dates are taken from the announcement URLs at `bitcoincore.org/en/2026/07/08/release-30.3/` and `bitcoincore.org/en/2026/07/08/release-31.1/`.

### Part 2 — Fix the date field

Every template that renders release information reads `optional_date`:

- `en/version-history.html` — sorts by it, and displays it
- `en/rss/releases.rss` — sorts by it, and uses it for `<pubDate>`
- `_layouts/release.html` — displays it under the page title

Since `v0.21.1` (May 2021), new release notes have used `date` instead. Nothing in the site reads that field, so those 19 files are invisible to the sort and to every date display.

Observable effects:

- **`/en/version-history` is out of order.** Files without `optional_date` are pushed to the end of the sort by the `'last'` argument, then to the top by `reversed`. Among themselves they appear in filesystem read order — the live page currently shows 31.0, 28.4, 29.3, 30.2, 30.1, 28.3, 29.2, 30.0, …
- **No date is displayed** for those 19 entries, since the template guards on `{% if p.optional_date %}`.
- **The RSS feed carries the wrong `pubDate`.** The `{% else %}` branch falls back to `site.time`, so all 19 entries currently show the last build date (`Thu, 25 Jun 2026`) instead of their release date. The template also emits `{% warn "This release doesn't have optional_date set" %}` for each of them on every build.

This PR renames `date` to `optional_date` in those 19 files. The values are unchanged.

### After this PR

`/en/version-history` becomes a single continuous chronological list, from 31.1 (2026-07-08) back to 0.3.21 (2010), with a date on every entry. The RSS feed carries real publication dates. The 19 build warnings stop.

Ordering remains chronological rather than by version number — 28.4 (March 2026) appears above 30.0 (October 2025), since Bitcoin Core maintains several branches in parallel. This is what the template intends; the assigned variable is named `date_sorted_releases`.

### Note — the 31.1 binaries need to go up before deploy

Once merged, `_plugins/releases.rb` sets `site.DOWNLOAD_VERSION` to 31.1 (the highest `required_version` across `_releases/`). `_templates/download.html` builds every download link from that value:

```liquid
{% capture PATH_PREFIX %}/bin/bitcoin-core-{{ site.DOWNLOAD_VERSION }}{% endcapture %}
```

`https://bitcoin.org/bin/bitcoin-core-31.1/` currently returns 404, so all ten `class="dl"` links on the download page would break once this is deployed.

CI does not catch this: `check-for-broken-bitcoin-core-download-links` exists in the Makefile but is not reached from the `travis` target — neither `pre-build-tests-fast` nor `post-build-tests-fast` invokes it. That is why #4746 built green while ten of its eleven releases had no binaries on the server (28.2 through 30.2 all still return 404 today).

Same situation as #4746, where the 31.0 binaries went up before the merge. I don't have server access, so this needs the binaries in place first.

### Verification

- All 84 files in `_releases/` now use `optional_date`; none use `date`.
- The 19 renamed files show exactly one changed line each: 19 deletions of `date: …` and 19 insertions of `optional_date: …`, with identical values. No other line was touched.
- The two new files were compared line by line against their upstream source; the content is identical apart from the blank lines inserted before lists.
- Neither new file contains the `][` sequence that `check-for-broken-markdown-reference-links` flags, and both carry the copyright header required by `check-for-missing-copyright-licenses`.

Relates to #4704.

cc @Cobra-Bitcoin 