### PR TITLE
Point the Bitcoin Core page RSS link at the releases feed

### DIFF
--- a/en/bitcoin-core/index.md
+++ b/en/bitcoin-core/index.md
@@ -129,7 +129,7 @@ breadcrumbs:
   For more News, see the complete list
   </div>
   <div class="corecard rss-card" markdown="block">
-  <a type="application/atom+xml" href="/en/rss/blog.xml">Subscribe to the RSS feed</a>
+  <a type="application/rss+xml" href="/en/rss/releases.rss">Subscribe to the RSS feed</a>
   For more notifications of new releases
   </div>
 </div>


### PR DESCRIPTION
The News section of `/en/bitcoin-core/` offers an RSS subscription labelled "For more notifications of new releases", but the link points at `/en/rss/blog.xml`, the site blog feed, whose most recent entry is from September 2019. Anyone who subscribed expecting release notifications has received nothing since.

The correct feed exists and works: `/en/rss/releases.rss`. The page itself already knows this — its own `<head>` metadata (line 17 of `en/bitcoin-core/index.md`) declares:

```html
<link rel="alternate" type="application/rss+xml" href="/en/rss/releases.rss" title="Bitcoin Core releases">
```

This PR makes the visible link match the metadata, and fixes the `type` attribute to `application/rss+xml` for consistency (both feeds are RSS 2.0, not Atom).

One line changed:

```diff
-  <a type="application/atom+xml" href="/en/rss/blog.xml">Subscribe to the RSS feed</a>
+  <a type="application/rss+xml" href="/en/rss/releases.rss">Subscribe to the RSS feed</a>
```

Verified: `/en/rss/releases.rss` returns 200; `blog.xml`'s latest `<pubDate>` is 2019-09-26.

Note: this is independent of #4801 (which proposes retiring the blog infrastructure), whatever is decided there, the subscription link in a section about releases should point at the releases feed.