### PR TITLE
Remove hijacked 0bin link from the bug reporting page

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -384,7 +384,6 @@ http://opensource.org/licenses/MIT.
 [#bitcoin-dev]: https://web.libera.chat/#bitcoin-core-dev
 [#bitcoin-mining]: https://web.libera.chat/#bitcoin-mining
 [#bitcoin-wiki]: https://web.libera.chat/#bitcoin-wiki
-[0bin]: http://0bin.net/
 [bcc automated testing]: https://github.com/bitcoin/bitcoin/blob/master/README.md#automated-testing
 [bcc configuration]: https://en.bitcoin.it/wiki/Running_Bitcoin
 [bcc data directory]: https://en.bitcoin.it/wiki/Data_directory
@@ -470,11 +469,9 @@ http://opensource.org/licenses/MIT.
 [open assets protocol]: https://github.com/OpenAssets/open-assets-protocol/blob/master/specification.mediawiki
 [Payment Request Generator]: https://github.com/gavinandresen/paymentrequest/blob/master/php/demo_website/createpaymentrequest.php
 [peter todd p2sh example]: https://github.com/petertodd/checklocktimeverify-demos/blob/master/lib/python-bitcoinlib/examples/publish-text.py
-[Piotr Piasecki's testnet faucet]: https://tpfaucet.appspot.com/
 [prime symbol]: https://en.wikipedia.org/wiki/Prime_%28symbol%29
 [protobuf]: https://developers.google.com/protocol-buffers/
 [python-bitcoinlib]: https://github.com/petertodd/python-bitcoinlib
-[python-blkmaker]: https://gitorious.org/bitcoin/python-blkmaker
 [Satoshi Nakamoto]: https://en.bitcoin.it/wiki/Satoshi_Nakamoto
 [setup tor]: https://www.torproject.org/
 [SHA256]: https://en.wikipedia.org/wiki/SHA-2

--- a/en/bitcoin-core/contribute/issues.md
+++ b/en/bitcoin-core/contribute/issues.md
@@ -55,7 +55,7 @@ new issue] providing the information listed below.
 3. Any relevant entries from your `debug.log` file. Note, this file can
    contain private information, so review it before posting or ask in
    the issue to email it directly to a developer rather than posting
-   publicly. You can publicly post logs on a [0bin service][0bin]. By
+   publicly. By
    default, the `debug.log` can be found at the following locations:
 
     - Windows: `%APPDATA%\Bitcoin\debug.log`


### PR DESCRIPTION
The bug reporting page (`/en/bitcoin-core/contribute/issues`) asks users to include entries from their `debug.log` and, right after warning that the file "can contain private information", suggests posting it publicly on a "0bin service". The `0bin.net` domain now serves an online casino (screenshot below).

This PR removes that sentence. The remaining instruction is complete and safer: review the log before posting, or email it directly to a developer if it is sensitive. No replacement pastebin is suggested, GitHub issues accept pasted logs and attachments directly, and the 0bin case illustrates why hardcoding third-party paste services ages badly.

Two orphaned reference definitions whose destinations are also dead were removed in the same pass:

- `[Piotr Piasecki's testnet faucet]: https://tpfaucet.appspot.com/`, serves only "Error: Server Error" (verified in a browser; returns 200 to curl, so link checkers don't catch it).
- `[python-blkmaker]: https://gitorious.org/bitcoin/python-blkmaker`, Gitorious shut down in 2015 and the domain no longer serves its archive (verified in a browser). Note: `_templates/development.html` links the same project directly at its current GitHub home; that link is unrelated to this reference definition and is untouched.

No page or template consumes these two reference definitions (verified by grepping the exact reference labels across `en/`, `_templates/`, `_layouts/` and `_includes/`).

Changes: 2 files, 4 deletions, 1 insertion (rejoined line).

### Evidence

What `0bin.net` serves today, note it still carries the old pastebin tagline ("All Pastes Are AES256 Encrypted, We Cannot Know What You Paste") above the casino content:

<img width="1453" height="738" alt="0bin.net today" src="https://github.com/user-attachments/assets/3212068d-c947-4e94-8078-ce045791aa68" />

Note: this branch touches lines adjacent to the IRC references being updated in #4868; whichever merges second may need a trivial rebase.