### PR TITLE
community: refresh stale social and meetup links

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -71,7 +71,7 @@ id: community
           <a href="https://vk.com/bitcoin">Страница на ВКонтакте</a>
         </p>{% endif %}
         <p>
-          <a href="https://twitter.com/search?q=bitcoin">{% translate linktwitter %}</a>
+          <a href="https://x.com/search?q=bitcoin">{% translate linktwitter %}</a>
         </p>
         <p>{% translate facebook %}</p>
       </div>
@@ -83,7 +83,7 @@ id: community
           <a href="/{{ page.lang }}/{% translate events url %}">{% translate meetupevents %}</a>
         </p>
         <p>
-          <a href="https://bitcoin.meetup.com/">{% translate meetupgroup %}</a>
+          <a href="https://www.meetup.com/topics/bitcoin/">{% translate meetupgroup %}</a>
         </p>
         <p>
           <a href="https://bitcointalk.org/index.php?board=86.0">{% translate meetupbitcointalk %}</a>

--- a/_templates/community.html
+++ b/_templates/community.html
@@ -73,7 +73,6 @@ id: community
         <p>
           <a href="https://x.com/search?q=bitcoin">{% translate linktwitter %}</a>
         </p>
-        <p>{% translate facebook %}</p>
       </div>
     
       <div class="community-card card">
@@ -108,9 +107,6 @@ id: community
         </p>
         <p>#bitcoin-market
           <small>{% translate chanmarket %}</small>
-        </p>
-        <p>#bitcoin-mining
-          <small>{% translate chanmining %}</small>
         </p>
         {% if page.lang == 'fr' %}
         <p>#bitcoin-fr


### PR DESCRIPTION
## Summary
- update the Bitcoin social search link from Twitter to X
- remove the outdated Facebook hashtag entry
- replace the dead Bitcoin Meetup Groups URL with the working Meetup topic page
- remove the inactive #bitcoin-mining IRC listing

## Testing
- verified the old Meetup URL returns 404
- verified the new Meetup topic URL returns 200

Closes #4825