### PR TITLE
wallets: update BitPay to the current mobile app listing

### DIFF
--- a/_wallets/bitpay.md
+++ b/_wallets/bitpay.md
@@ -5,7 +5,7 @@
 id: bitpay
 title: "BitPay Wallet"
 titleshort: "BitPay"
-compat: "mobile desktop android ios windows mac linux"
+compat: "mobile android ios"
 user: beginner
 level: 3
 platform:
@@ -14,7 +14,7 @@ platform:
     default: &DEFAULT
       text: "walletbitpay"
       link: "https://bitpay.com/wallet"
-      source: "https://github.com/bitpay/copay"
+      source: "https://github.com/bitpay/bitpay-app"
       screenshot: "bitpay.png"
       features: "legacy_addresses multisig"
       check:
@@ -32,31 +32,5 @@ platform:
       - name: android
         <<: *DEFAULT
       - name: ios
-        <<: *DEFAULT
-  - desktop:
-    name: desktop
-    default: &DEFAULT
-      text: "walletbitpay"
-      link: "https://bitpay.com/wallet"
-      source: "https://github.com/bitpay/copay"
-      screenshot: "bitpay.png"
-      features: "legacy_addresses multisig"
-      check:
-        control: "checkgoodcontrolfull"
-        validation: "checkfailvalidationcentralized"
-        transparency: "checkpasstransparencyopensource"
-        environment: "checkfailenvironmentdesktop"
-        privacy: "checkpassprivacybasic"
-        fees: "checkpassfeecontroloverride"
-      privacycheck:
-        privacyaddressreuse: "checkpassprivacyaddressrotation"
-        privacydisclosure: "checkfailprivacydisclosurecentralized"
-        privacynetwork: "checkfailprivacynetworknosupporttor"
-    os:
-      - name: windows
-        <<: *DEFAULT
-      - name: mac
-        <<: *DEFAULT
-      - name: linux
         <<: *DEFAULT
 ---


### PR DESCRIPTION
## Summary
- limit the BitPay listing to the currently maintained mobile platforms
- update the source link from the inactive `bitpay/copay` repository to `bitpay/bitpay-app`
- remove the outdated desktop platform entries

## Notes
- kept the public wallet landing page URL unchanged
- this PR focuses on the platform and source mismatch documented in the issue

Closes #4669