### PR TITLE
wallets: point Mycelium to the canonical Android source repo

### DIFF
--- a/_wallets/mycelium.md
+++ b/_wallets/mycelium.md
@@ -14,7 +14,7 @@ platform:
       - name: android
         text: "walletmyceliumwallet"
         link: "https://play.google.com/store/apps/details?id=com.mycelium.wallet"
-        source: "https://github.com/mycelium-com/wallet"
+        source: "https://github.com/mycelium-com/wallet-android"
         screenshot: "mycelium.png"
         features: "bech32 hardware_wallet legacy_addresses segwit taproot"
         check:


### PR DESCRIPTION
## Summary
- update the Mycelium Android source link to the canonical repository path
- keep the current Android-only wallet listing unchanged

## Notes
- this intentionally does not add the separate iOS wallet listing
- the existing URL works via redirect, but this points the entry directly to `wallet-android`

Closes #4677