### PR TITLE
wallets: update Passport to the canonical Foundation URL

### DIFF
--- a/_wallets/passport.md
+++ b/_wallets/passport.md
@@ -13,7 +13,7 @@ platform:
     os:
       - name: hardware
         text: "walletpassport"
-        link: "https://foundationdevices.com/passport/"
+        link: "https://foundation.xyz/passport-core/"
         source: "https://github.com/Foundation-Devices/passport2"
         screenshot: "passport.png"
         features: "bech32 hardware_wallet legacy_addresses multisig segwit taproot"


### PR DESCRIPTION
## Summary
- update the Passport wallet listing to the current canonical Foundation URL
- avoid the legacy foundationdevices.com -> foundation.xyz redirect chain
- keep the existing product name unchanged for now

Closes #4673

## Testing
- not run (wallet metadata change only)