### PR TITLE
Update Bull Bitcoin regions

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -224,6 +224,8 @@ id: exchanges
         <br>
         <a class="marketplace-link" href="https://bitvavo.com/">Bitvavo</a>
         <br>
+        <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+        <br>
         <a class="marketplace-link" href="https://coinmama.com/">Coinmama</a>
         <br>
         <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
@@ -349,6 +351,8 @@ id: exchanges
         <p>
           <a class="marketplace-link" href="https://bitso.com/">Bitso</a>
           <br>
+          <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+          <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>
       </div>
@@ -381,6 +385,16 @@ id: exchanges
   <h2 class="exchanges-tab-title exchanges-central-america-title" id="central-america">Central America &amp; Caribbean</h2>
   <div class="marketplace-row">
 
+    <div class="row marketplace">
+      <img class="marketplace-flag" src="/img/flags/CR.svg?{{site.time | date: '%s'}}" alt="Costa Rican flag">
+      <div>
+        <h3 id="costa-rica" class="no_toc">Costa Rica</h3>
+        <p>
+          <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+        </p>
+      </div>
+    </div>
+
   </div>
 </div>
 
@@ -393,6 +407,8 @@ id: exchanges
       <div>
         <h3 id="argentina" class="no_toc">Argentina</h3>
         <p>
+          <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
+          <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
           <br>
           <a class="marketplace-link" href="https://www.satoshitango.com/">SatoshiTango</a>
@@ -440,6 +456,8 @@ id: exchanges
         <h3 id="colombia" class="no_toc">Colombia</h3>
         <p>
           <a class="marketplace-link" href="https://www.buda.com/">Buda</a>
+          <br>
+          <a class="marketplace-link" href="https://www.bullbitcoin.com/">Bull Bitcoin</a><img style="width:90px;height:27px;" src="/img/bo_tag/bo_tag.png?{{site.time | date: '%s'}}" alt="Bitcoin Only tag">
           <br>
           <a class="marketplace-link" href="https://currency.com/">Currency.com</a>
         </p>


### PR DESCRIPTION
Add Bull Bitcoin availability for  Europe, Mexico, Argentina, Costa Rica and Colombia. Also add a section for Costa Rica. In the future, bitcoin.org maintainers may want a dedicated section for Central America, but for now just Costa Rica is fine.