### PR TITLE
Fix links and small errors across the Bitcoin Core contribute pages

### DIFF
--- a/en/bitcoin-core/contribute/documentation.md
+++ b/en/bitcoin-core/contribute/documentation.md
@@ -31,7 +31,7 @@ is available and how you can contribute.
 
 ## Bitcoin Core Docs Directory
 
-The [developer.bitcoin.org GitHub repository](https://github.com/bitcoin-dot-org/developer.bitcoin.org)
+The Bitcoin Core [`doc/` directory][Bitcoin Core docs directory]
 contains various files describing aspects of Bitcoin Core. Almost all of
 the files are meant for developers and testers rather than users.
 

--- a/en/bitcoin-core/contribute/index.md
+++ b/en/bitcoin-core/contribute/index.md
@@ -27,7 +27,7 @@ Thank you for considering contributing to Bitcoin Core!  We have
 instructions below to help you get started contributing in several different
 ways.
 
-If want to contribute in another way, please visit the [#bitcoin-core-dev][#bitcoin-dev]
+If you want to contribute in another way, please visit the [#bitcoin-core-dev][#bitcoin-dev]
 IRC chatroom and discuss your plan with a developer.
 
 <div markdown="block" class="row card-row">
@@ -49,7 +49,7 @@ IRC chatroom and discuss your plan with a developer.
 <div class="card core-card" markdown="block">
 <img src="/img/icons/ico_documentation.svg?{{site.time | date: '%s'}}" alt="icon">
 
-[Documentation](https://github.com/bitcoin-dot-org/developer.bitcoin.org)
+[Documentation][bcc contribute documentation]
 <p>Write documentation for users and developers</p>
 
 </div>

--- a/en/bitcoin-core/contribute/issues.md
+++ b/en/bitcoin-core/contribute/issues.md
@@ -25,7 +25,7 @@ breadcrumbs:
 <div class="container" markdown="block">
 
 If you discover a bug or other problem with Bitcoin Core, please report
-it.  The are two different processes, [responsible disclosure](#disclosure) for
+it.  There are two different processes, [responsible disclosure](#disclosure) for
 security bugs and [public issue tracking](#public-issue-tracking) for all other bugs.
 
 <div class="warning" markdown="block">
@@ -60,7 +60,7 @@ new issue] providing the information listed below.
 
     - Windows: `%APPDATA%\Bitcoin\debug.log`
 
-    - OS X: `$HOME/Library/Application Support/Bitcoin/debug.log`
+    - macOS: `$HOME/Library/Application Support/Bitcoin/debug.log`
 
     - Linux: `$HOME/.bitcoin/debug.log`
 

--- a/en/bitcoin-core/contribute/support.md
+++ b/en/bitcoin-core/contribute/support.md
@@ -39,7 +39,7 @@ Core questions.
 
 - [Bitcoin StackExchange][] is a community dedicated entirely to
   answering questions about Bitcoin and related technology.  Many
-  questions about Bitcoin Core can be found under the [Bitcoin-Qt
+  questions about Bitcoin Core can be found under the [bitcoin-core
   tag][bitcoin stackexchange tag bitcoin-qt]
 
 - [BitcoinTalk Technical Support][forum tech support] is a
@@ -58,7 +58,7 @@ Core questions.
 
 ## Live
 
-Internet Relay Chat (IRC) is the most popular way to get live online
+Internet Relay Chat (IRC) is a popular way to get live online
 help with Bitcoin Core.  When providing links to documentation, most
 chatrooms require you post full links (not links shortened using
 services like TinyURL or Bit.ly).


### PR DESCRIPTION
A consistency pass over the four pages of `/en/bitcoin-core/contribute/` (the fifth, translations, was refreshed in #4875). Eight small fixes across four files:

**`index.md`**
- Grammar: "If want to contribute" → "If you want to contribute".
- The Documentation card linked directly to the `bitcoin-dot-org/developer.bitcoin.org` GitHub repository, while the other four cards all point at pages within this contribute flow. It now points at the internal documentation page, which explains the contribution paths with context.

**`documentation.md`**
- The "Bitcoin Core Docs Directory" section opened by linking the `developer.bitcoin.org` repository — the subject of a *different* section on the same page (the RPC/REST reference), leaving two sections pointing at one repo and none pointing at the directory the section actually describes ("various files... meant for developers and testers"). It now links the Bitcoin Core `doc/` directory via the existing `[Bitcoin Core docs directory]` reference (`github.com/bitcoin/bitcoin/tree/master/doc`), which had been sitting orphaned in `references.md`.
- The RPC/REST section still directs edits to the `developer.bitcoin.org` repository. Flagging for awareness: that repo's last push was 2024-06-05 (148 open issues) per the GitHub API. 

**`issues.md`**
- Grammar: "The are two different processes" → "There are".
- "OS X" → "macOS" in the `debug.log` locations list (name retired in 2016; the path itself is unchanged and correct).

**`support.md`** — this page shares paragraphs with the help page fixed in #4868, and was left behind:
- The visible Stack Exchange label still read "Bitcoin-Qt tag" while the shared reference already points at the `bitcoin-core` tag since #4868 — label and destination now match.
- "IRC is the most popular way" → "IRC is a popular way", matching the same fix on the help page.

A pattern sweep across the directory (remaining "Bitcoin-Qt", plain-http URLs, stale version numbers, dead services) found nothing further. The TinyURL/Bit.ly mention in support.md is deliberate — the page cites them as examples of what *not* to use.