### PR TITLE
Add Bitcoin Basics to Learn resources

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -22,6 +22,9 @@ id: resources
           <a href="https://learnmeabitcoin.com">Learn Me A Bitcoin</a>
         </p>
         <p>
+          <a href="https://btcbasicsforeveryone.com/">Bitcoin Basics</a>
+        </p>
+        <p>
           <a href="https://www.lopp.net/bitcoin-information.html">Jameson Lopp's Bitcoin Resources</a>
         </p>
         <p>


### PR DESCRIPTION
Adds [Bitcoin Basics](https://btcbasicsforeveryone.com/) to the Learn section — free, plain-language Bitcoin lessons for total beginners, organized as a path from the basics to self-custody. Written and maintained by one Bitcoiner, with no email gate and no paywall on the fundamentals.

Same category as the beginner-education sites already listed here.