### PR TITLE
Prune archived projects and fix moved repository URLs on the development page

### DIFF
--- a/_templates/development.html
+++ b/_templates/development.html
@@ -114,13 +114,11 @@ Want to contribute to a different project?
   <li><a href="https://bitbucket.org/ckolivas/ckpool">ckpool</a> - A fast mining pool server application, written in C.</li>
   <li><a href="https://github.com/spesmilo/electrum">Electrum</a> - A fast server-trusting wallet, written in Python.</li>
   <li><a href="https://github.com/luke-jr/eloipool">Eloipool</a> - A fast mining pool server application, written in Python.</li>
-  <li><a href="https://github.com/haskoin/haskoin">Haskoin</a> - An implementation of the Bitcoin protocol, written in Haskell.</li>
-  <li><a href="https://github.com/libbitcoin/libbitcoin">Libbitcoin</a> - A cross-platform development toolkit, written in C++.</li>
+  <li><a href="https://github.com/jprupp/haskoin-core">Haskoin</a> - An implementation of the Bitcoin protocol, written in Haskell.</li>
+  <li><a href="https://github.com/libbitcoin/libbitcoin-system">Libbitcoin</a> - A cross-platform development toolkit, written in C++.</li>
   <li><a href="https://github.com/libbitcoin/libbitcoin-server/">Libbitcoin Server</a> - A full node and query server, built on libbitcoin.</li>
   <li><a href="https://github.com/libbitcoin/libbitcoin-explorer">Libbitcoin Explorer</a> - A command line tool, built on libbitcoin.</li>
-  <li><a href="https://github.com/bitcoin/libblkmaker">Libblkmaker</a> - A client library for the getblocktemplate mining protocol, written in C.</li>
   <li><a href="https://github.com/MetacoSA/NBitcoin">NBitcoin</a> - A cross-platform library, written in C#.</li>
-  <li><a href="https://github.com/jgarzik/picocoin">picocoin</a> - A tiny library with lightweight client and utilities, written in C.</li>
   <li><a href="https://github.com/petertodd/python-bitcoinlib">python-bitcoinlib</a> - A library for structures and protocols, written in Python.</li>
   <li><a href="https://github.com/luke-jr/python-blkmaker">Python Blkmaker</a> - A client library for the getblocktemplate mining protocol, written in Python.</li>
   <li class="more"><a onclick="librariesShow(event)" ontouchstart="librariesShow(event);" class="link-js">{% translate moremore %}</a></li>


### PR DESCRIPTION
The "Want to contribute to a different project?" list on `/en/development` includes two repositories that GitHub has archived, meaning they are read-only and cannot accept issues or pull requests, which contradicts the section's purpose:

- **picocoin** (`jgarzik/picocoin`) — archived by the owner on Feb 14, 2024.
- **Libblkmaker** (`bitcoin/libblkmaker`) — archived by the owner on Apr 24, 2025.

Both entries are removed.

Two other entries point at repository names that no longer exist (GitHub redirects, but the canonical names changed):

- **Haskoin**: `haskoin/haskoin` → `jprupp/haskoin-core` (active, last push Dec 2025).
- **Libbitcoin**: `libbitcoin/libbitcoin` → `libbitcoin/libbitcoin-system` (active, last push this week).

The remaining sixteen entries were all checked via the GitHub API (or in a browser, for ckpool on Bitbucket): none are archived, and the list spans from very active (Electrum, btcd, BTCPay Server — pushes this week) to dormant-but-open (Eloipool, last push 2020; Python Blkmaker, 2021; BFGMiner, 2023). Dormant repositories still accept contributions, so removing them would be an editorial call rather than a factual fix left as-is, flagged here for awareness.