### PR TITLE
Point historical mailing list citations at their canonical archive locations

### DIFF
--- a/en/bitcoin-core/capacity-increases-faq.md
+++ b/en/bitcoin-core/capacity-increases-faq.md
@@ -105,7 +105,7 @@ filled with standard single-signature P2PKH transactions would be about
 be about 2.0MB.
 
 [current proposal]: https://youtu.be/fst1IK_mrng?t=2234
-[calculations]: http://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-December/011869.html
+[calculations]: https://gnusha.org/pi/bitcoindev/20151208045803.GA1042@sapphire.erisian.com.au/
 
 ## Segregated witness sounds complicated; will the ecosystem be prepared for its deployment?  {#ecosystem-ready}
 
@@ -185,7 +185,7 @@ increases the maximum block size.
 
 No. That is not part of the [roadmap][].
 
-[roadmap]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-December/011865.html
+[roadmap]: https://gnusha.org/pi/bitcoindev/CAAS2fgQyVs1fAEj+vqp8E2=FRnqsgs7VUKqALNBHNxRMDsHdVg@mail.gmail.com/
 
 ## If there's eventually going to be a hard fork, why not do it now? {#why-not-now}
 

--- a/en/bitcoin-core/capacity-increases.md
+++ b/en/bitcoin-core/capacity-increases.md
@@ -45,6 +45,6 @@ Other versions of this page:
 
 Signatures may be added to Bitcoin.org pull request [#1165](https://github.com/bitcoin-dot-org/bitcoin.org/pull/1165)
 
-[1]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-December/011865.html
+[1]: https://gnusha.org/pi/bitcoindev/CAAS2fgQyVs1fAEj+vqp8E2=FRnqsgs7VUKqALNBHNxRMDsHdVg@mail.gmail.com/
 </div>
 </div>


### PR DESCRIPTION
Follow-up to #4900, prompted by the review comment there: the three historical bitcoin-dev citations in the capacity-increases pages pointed at `lists.linuxfoundation.org/pipermail/...`, which currently resolve through a redirect chain (LF 301 → `gnusha.org/url` → canonical location) — and, per the maintainer of that redirect service, there is no guarantee the LF subdomain will continue honoring it.

The citations now point directly at their canonical archive locations on gnusha.org's public-inbox:

- `pipermail/bitcoin-dev/2015-December/011869.html` → `gnusha.org/pi/bitcoindev/20151208045803.GA1042@sapphire.erisian.com.au/`
- `pipermail/bitcoin-dev/2015-December/011865.html` (cited on both pages) → `gnusha.org/pi/bitcoindev/CAAS2fgQyVs1fAEj+vqp8E2=FRnqsgs7VUKqALNBHNxRMDsHdVg@mail.gmail.com/`

These are addressed by Message-ID — a permanent identifier derived from the email itself, which survives any future archive migration. The redirect chain was traced with curl (301s shown above); the final destinations verified in a browser to show the correct December 2015 messages.

cc @kanzure 