### PR TITLE
Point Marco Falke credit at his renamed GitHub account

### DIFF
--- a/_includes/bitcoin-core/capability-increases-sigs.md
+++ b/_includes/bitcoin-core/capability-increases-sigs.md
@@ -37,7 +37,7 @@ https://opensource.org/licenses/MIT.
 - [Mark Friedenbach](https://github.com/maaku)
 - [Eric Martindale](https://github.com/martindale)
 - [Manuel Aráoz](https://github.com/maraoz)
-- [Marco Falke](https://github.com/MarcoFalke)
+- [Marco Falke](https://github.com/maflcko)
 - [Matt Corallo](https://github.com/TheBlueMatt)
 - [Midnight Magic](https://github.com/midnightmagic)
 - [Michael Ford](https://github.com/fanquake)


### PR DESCRIPTION
Found during a link-health pass over the English site. Marco Falke's GitHub account was renamed to maflcko, and GitHub does not redirect renamed profile pages, so his credit on the capability-increases signatories list served a 404. One-line fix. Identity verified via GitHub's own rename attestation: the API reports his old repository path as "Moved Permanently" to the same repository ID, now under the maflcko account.