### PR TITLE
Remove The Rock Trading from the exchanges page

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -231,8 +231,6 @@ id: exchanges
         <a class="marketplace-link" href="https://kriptomat.io/">Kriptomat</a>
         <br>
         <a class="marketplace-link" href="https://www.paymium.com/">Paymium</a>
-        <br>
-        <a class="marketplace-link" href="https://therocktrading.com">The Rock Trading</a>
       </p>
     </div>
 


### PR DESCRIPTION
Found during a link-health pass over the English site.

The Rock Trading, listed on the exchanges page for Europe, halted operations in February 2023 and was declared insolvent by the Court of Milan (case no. 203/2023). The domain has since been taken over by an unrelated Australian affiliate/comparison site for crypto CFD providers, which states in its own disclaimer: "This site is not operated by, affiliated with, or endorsed by The Rock Trading S.R.L." and "We do not provide custody, brokerage, or exchange services" (therocktrading.com/disclaimer).

So the exchanges page currently lists, as a European bitcoin exchange, a site that by its own words provides no exchange services at all. Same class of issue as the repurposed domain removed in #4907. Removes the listing (the anchor line and its separating <br>).