### PR TITLE
Update FinCEN 2013 guidance link to its current canonical page

### DIFF
--- a/_templates/press.html
+++ b/_templates/press.html
@@ -139,7 +139,7 @@ dialogs:
             <a href="https://www.ecb.europa.eu/pub/pdf/other/virtualcurrencyschemes201210en.pdf">Virtual Currency Schemes - European Central Bank</a>
           </li>
           <li>
-            <a href="https://www.fincen.gov/statutes_regs/guidance/pdf/FIN-2013-G001.pdf">Application of FinCEN’s Regulations to Persons Administering, Exchanging, or Using Virtual Currencies</a>
+            <a href="https://www.fincen.gov/resources/statutes-regulations/guidance/application-fincens-regulations-persons-administering">Application of FinCEN’s Regulations to Persons Administering, Exchanging, or Using Virtual Currencies</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Found during a link-health pass over the English site. FinCEN restructured its website and the 2013 virtual-currency guidance PDF path on the press page returns 404. The link now points at the document's current canonical guidance page on fincen.gov (verified HTTP 200), which is more stable than a deep PDF path. Link text unchanged.