### PR TITLE
Fix braille whitepaper credit link after repository move

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -462,7 +462,7 @@ id: bitcoin-paper
            href="/files/bitcoin-paper/bitcoin-braille.pdf">Braille</a>
          <div>
            <span>{% translate translated_by %}</span>
-           <a href="https://github.com/neatnik/braille-bitcoin-whitepaper">@NeatNik</a>
+           <a href="https://github.com/11-tools/braille-bitcoin-whitepaper">@NeatNik</a>
          </div>
         </li>
         


### PR DESCRIPTION
Found during a link-health pass over the English site. The bitcoin-paper page lists a braille transcription of the whitepaper (the PDF itself is hosted locally at /files/bitcoin-paper/bitcoin-braille.pdf and was never affected). The author credit, however, pointed at the transcription's old repository under neatnik/, which returns 404 after the project moved to 11-tools/braille-bitcoin-whitepaper. Verified via the GitHub API that the new location is the same project rather than a third-party fork (fork: false, matching description; the repository is archived by its owner, i.e. deliberately preserved read-only). One-line href fix; the @NeatNik credit text is unchanged.