### PR TITLE
Remove links to deleted X accounts from translator credits

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -435,7 +435,7 @@ id: bitcoin-paper
            href="/files/bitcoin-paper/bitcoin_al.pdf">Albanian</a>
          <div>
            <span>{% translate translated_by %}</span>
-           <a href="https://x.com/TonyXhufi">Tony Xhufi</a>
+           Tony Xhufi
          </div>
         </li>
 
@@ -471,7 +471,7 @@ id: bitcoin-paper
            href="/files/bitcoin-paper/bitcoin_np.pdf">Nepali</a>
          <div>
            <span>{% translate translated_by %}</span>
-           <a href="https://x.com/iamkrishnadahal">Krishna Dahal</a>, <a href="https://x.com/bibekblockchain">Bibek Koirala</a>
+           <a href="https://x.com/iamkrishnadahal">Krishna Dahal</a>, Bibek Koirala
          </div>
         </li>
         


### PR DESCRIPTION
Found during a link-health pass over the English site. Two translator credits on the bitcoin-paper page — Tony Xhufi and Bibek Koirala — pointed at X accounts that return 404 (deleted or renamed). The links are removed and the names kept: the credit belongs to the person, not the URL. Krishna Dahal's credit, on the same line as one of them, keeps its link since his account is still live.