### PR TITLE
Delink dead translator credits on the paper page

### DIFF
--- a/_templates/bitcoin-paper.html
+++ b/_templates/bitcoin-paper.html
@@ -163,7 +163,7 @@ id: bitcoin-paper
             href="/files/bitcoin-paper/bitcoin_is.pdf">Íslenska</a>
           <div>
             <span>{% translate translated_by %}</span>
-            <a href="https://www.pega-pool.com/">PEGA Pool</a>
+            PEGA Pool
           </div>
         </li>
 
@@ -297,7 +297,7 @@ id: bitcoin-paper
             href="/files/bitcoin-paper/bitcoin_ur.pdf">اُردُو</a>
           <div>
             <span>{% translate translated_by %}</span>
-            <a href="https://aharix.com/MSJ">Muhammad Safdar Jamal</a>
+            Muhammad Safdar Jamal
           </div>
         </li>
 
@@ -416,7 +416,7 @@ id: bitcoin-paper
            href="/files/bitcoin-paper/bitcoin_bn.pdf">বাংলা</a>
          <div>
            <span>{% translate translated_by %}</span>
-           <a href="https://x.com/shafiunmiraz0">Shafiun Miraz</a>,
+           Shafiun Miraz,
            <a href="https://github.com/tonmoy10ms">Tonmoy Sarkar</a>
          </div>
         </li>


### PR DESCRIPTION
Found during a manual pass over the translator credits on the bitcoin-paper page. Three credit links no longer lead to the credited party:

- PEGA Pool (Icelandic): pega-pool.com forwards through redirect chains to varying third-party destinations (an affiliate comparison site under curl, an ad-tracking endpoint in a real browser) - a parked domain reselling traffic.
- Muhammad Safdar Jamal (Urdu): aharix.com lands on a hosting provider's default error page served from an unrelated server.
- Shafiun Miraz (Bengali): the X account is suspended.

Links removed, credit text kept; the locally hosted PDFs are unaffected. Every other credit on the page was verified alive in the same pass.