### PR TITLE
Trim the Events section from the contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The following quick guides will help you get started:
 + [Improving Developer Documentation](https://github.com/bitcoin-dot-org/developer.bitcoin.org/)
 + [Assisting with Translations](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md)
 + [Managing Wallets](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/managing-wallets.md)
-+ [Adding Events, Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
++ [Adding Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
 + [Adding Blog Posts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-blog-posts.md)
 + [Miscellaneous / Other](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/miscellaneous.md)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following quick guides will help you get started:
 + [Assisting with Translations](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md)
 + [Adding Exchanges](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-exchanges.md)
 + [Managing Wallets](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/managing-wallets.md)
-+ [Adding Events, Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
++ [Adding Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
 + [Adding Blog Posts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-blog-posts.md)
 + [Miscellaneous / Other](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/miscellaneous.md)
 

--- a/docs/adding-events-release-notes-and-alerts.md
+++ b/docs/adding-events-release-notes-and-alerts.md
@@ -1,25 +1,4 @@
-## Adding Events, Release Notes and Alerts
-
-### Events
-
-Events added to Bitcoin.org should have clear agendas that relate to Bitcoin
-in some way - e.g. it being used as a currency, harnessing its technology,
-speakers from bitcoin-related companies, etc.
-
-If you're not comfortable with GitHub pull requests, please open a [new issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?title=New%20event&body=%20%20%20%20-%20date%3A%20YYYY-MM-DD%0A%20%20%20%20%20%20title%3A%20%22%22%0A%20%20%20%20%20%20venue%3A%20%22%22%0A%20%20%20%20%20%20address%3A%20%22%22%0A%20%20%20%20%20%20city%3A%20%22%22%0A%20%20%20%20%20%20country%3A%20%22%22%0A%20%20%20%20%20%20link%3A%20%22%22).
-
-To create an event pull request, place the event in `_events.yml` and adhere to
-this format:
-
-```
-- date: 2014-02-21
-  title: "2014 Texas Bitcoin Conference"
-  venue: "Circuit of the Americas™ - Technology and Conference Center"
-  address: "9201 Circuit of the Americas Blvd"
-  city: "Austin, TX"
-  country: "United States"
-  link: "http://texasbitcoinconference.com/"
-```
+## Adding Release Notes and Alerts
 
 ### Release Notes
 

--- a/docs/become-a-contributor.md
+++ b/docs/become-a-contributor.md
@@ -26,8 +26,4 @@ Here are some ways you can help:
   using [Transifex](https://app.transifex.com/bitcoinorg/bitcoinorg/) or help
   review new and updated translations.
 
-* Add Bitcoin events to the [events page](https://bitcoin.org/en/events)
-  either by editing `_events.yml` according to the [event instructions](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
-  or by filling in a [pre-made events issue](https://github.com/bitcoin-dot-org/bitcoin.org/issues/new?title=New%20event&body=%20%20%20%20-%20date%3A%20YYYY-MM-DD%0A%20%20%20%20%20%20title%3A%20%22%22%0A%20%20%20%20%20%20venue%3A%20%22%22%0A%20%20%20%20%20%20address%3A%20%22%22%0A%20%20%20%20%20%20city%3A%20%22%22%0A%20%20%20%20%20%20country%3A%20%22%22%0A%20%20%20%20%20%20link%3A%20%22%22).
-
 * Help improve Bitcoin.org another way. [Open an issue](https://github.com/bitcoin-dot-org/Bitcoin.org/issues/new) on GitHub to let us know what you're interested in and how you'd like to get involved.


### PR DESCRIPTION
Refs #4801

Follow-up to #4921 (the Events page removal, now live): trims the contributor docs to match.

- `docs/adding-release-notes-and-alerts.md`: Events section removed, title adjusted to "Adding Release Notes and Alerts". Filename kept so existing links don't break; Release Notes and Alerts sections untouched (the Alerts part of #4801 is still pending).
- `docs/become-a-contributor.md`: removed the "Add Bitcoin events" bullet, which pointed at the removed page, the removed `_events.yml`, and the events issue template.
- `CONTRIBUTING.md` / `README.md`: link text updated to match the new title.