### PR TITLE
Drop the removed events plugin from the environment docs

### DIFF
--- a/docs/setting-up-your-environment.md
+++ b/docs/setting-up-your-environment.md
@@ -145,7 +145,7 @@ Then to enable some plugins or languages, you can add them back in.
 For example:
 
     ## Slower (but still pretty fast) build and test
-    ENABLED_PLUGINS="events autocrossref" ENABLED_LANGS="en fr" make -i valid
+    ENABLED_PLUGINS="autocrossref" ENABLED_LANGS="en fr" make -i valid
 
 Plugins include:
 
@@ -154,7 +154,6 @@ Plugins include:
 | alerts       | 5       | --             | Network alert pages
 | autocrossref | 90      | --             | Developer documentation
 | contributors | 5       | GitHub.com     | Contributor listings
-| events       | 5       | Google Maps    | Events page
 | glossary     | 30      | --             | Developer glossary
 | redirects    | 20      | --             | Redirects from old URLs
 | releases     | 10      | --             | Bitcoin Core release notes; Download page


### PR DESCRIPTION
Refs #4801

Small follow-up to #4921/#4922: `docs/setting-up-your-environment.md` still referenced the events plugin removed in #4921 — an `ENABLED_PLUGINS` example and the plugin table row. Example now uses the remaining plugin only; table
row dropped.