### PR TITLE
Rename adding-events-release-notes-and-alerts.md to match its title

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The following quick guides will help you get started:
 + [Improving Developer Documentation](https://github.com/bitcoin-dot-org/developer.bitcoin.org/)
 + [Assisting with Translations](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md)
 + [Managing Wallets](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/managing-wallets.md)
-+ [Adding Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
++ [Adding Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-release-notes-and-alerts.md)
 + [Adding Blog Posts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-blog-posts.md)
 + [Miscellaneous / Other](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/miscellaneous.md)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following quick guides will help you get started:
 + [Assisting with Translations](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/assisting-with-translations.md)
 + [Adding Exchanges](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-exchanges.md)
 + [Managing Wallets](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/managing-wallets.md)
-+ [Adding Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md)
++ [Adding Release Notes and Alerts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-release-notes-and-alerts.md)
 + [Adding Blog Posts](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-blog-posts.md)
 + [Miscellaneous / Other](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/miscellaneous.md)
 

--- a/docs/adding-release-notes-and-alerts.md
+++ b/docs/adding-release-notes-and-alerts.md
@@ -67,7 +67,7 @@ is the particular version:
    do this locally or in GitHub's web GUI.
 
 2. Follow the instructions in the [Release
-   Notes](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-events-release-notes-and-alerts.md#release-notes)
+   Notes](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-release-notes-and-alerts.md#release-notes)
    section to create a new release.  You should leave the `optional_date` blank
    unless you happen to know the date of the planned release.
 


### PR DESCRIPTION
Refs #4801

Follow-up to #4922. That PR kept the old filename to avoid breaking links; after reviewing where those links actually live (5 of 8 are in my own issue/PR bodies, which I'll update after merge; the other 3 are closed issues from ~2018), I'm renaming after all so the filename matches the guide's title:

`docs/adding-events-release-notes-and-alerts.md` → `docs/adding-release-notes-and-alerts.md`

Internal links updated in the same commit (CONTRIBUTING, README, and the guide's own self-link).