### PR TITLE
Add Bitcoin Core 29.4

### DIFF
--- a/_releases/v29.4.md
+++ b/_releases/v29.4.md
@@ -1,0 +1,148 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+# Text originally from Bitcoin Core project
+# Metadata and small formatting changes from Bitcoin.org project
+
+required_version: 29.4
+title: Bitcoin Core 29.4
+id: en-release-29.4
+name: release-29.4
+permalink: /en/releases/29.4/
+excerpt: Bitcoin Core version 29.4 is now available
+optional_date: 2026-07-13
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [29, 4]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink:
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+
+<div class="post-content" markdown="1">
+  
+{% githubify https://github.com/bitcoin/bitcoin %}
+29.4 Release Notes
+==================
+
+Bitcoin Core version 29.4 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-29.4/>
+
+This release includes various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and tested on operating systems using the
+Linux Kernel 3.17+, macOS 13+, and Windows 10+. Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+Notable changes
+===============
+
+This release fixes an issue where the chainstate database would repeatedly
+rewrite large portions of itself, causing excessive disk reads and writes
+during normal operation.
+
+### Validation
+
+- #35209 validation: correct lifetime of precomputed tx data
+- #35465 coins: compact chainstate regularly
+
+### Leveldb
+
+- #61(bitcoin-core/leveldb): Disable seek compaction
+
+### Net
+
+- #34093 netif: fix compilation warning in QueryDefaultGatewayImpl()
+
+### Wallet
+
+- #35228 wallet: use outpoint when estimating input size
+
+### Build
+
+- #34228 depends: Unset SOURCE_DATE_EPOCH in gen_id script
+- #34848 cmake: Migrate away from deprecated SQLite3 target
+
+### Test
+
+- #34918 fuzz: [refactor] Remove unused g_setup pointers
+
+### Doc
+
+- #34510 doc: fix broken bpftrace installation link
+- #34561 wallet: rpc: manpage: fix example missing `fee_rate` argument
+- #34671 doc: Update Guix install for Debian/Ubuntu
+- #35283 doc: mention -DWITH_ZMQ=ON in BSD build guides
+
+### CI
+
+- #35202 ci: restore sockets in i686, no IPC job
+- #35378 ci: switch runners from cirrus to warpbuild
+- #35408 ci: 35378 followups
+
+### Misc
+
+- #35175 multi_index: fix compilation failure with boost >= 1.91
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- andrewtoth
+- Cory Fields
+- Daniel Pfeifer
+- darosior
+- fanquake
+- Hennadii Stepanov
+- jayvaliya
+- junbyjun1238
+- Lőrinc
+- MarcoFalke
+- SomberNight
+- ToRyVand
+- willcl-ark
+
+As well as to everyone that helped with translations on
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}
+
+</div>


### PR DESCRIPTION
Bitcoin Core 29.4 (the 29.x backport of the chainstate compaction fix, same batch as 30.3) is listed on bitcoincore.org, announced July 13, 2026, binaries at `bitcoincore.org/bin/bitcoin-core-29.4/`, but has no release file here: it was announced after #4863 (which added 30.3 and 31.1) was prepared, so this site's version history never picked it up.

This adds `_releases/v29.4.md` following the existing conventions: release notes verbatim from the upstream `doc/release-notes/release-notes-29.4.md`, frontmatter matching the 29.x series, `optional_date: 2026-07-13` per the bitcoincore.org announcement (the same date source the existing files use). The download button is unaffected 31.1 remains latest; 29.4 slots into the version history chronologically.

