### PR TITLE
Point download links at the canonical bitcoincore.org binaries

### DIFF
--- a/_templates/download.html
+++ b/_templates/download.html
@@ -20,7 +20,7 @@ lin64: "x86_64-linux-gnu.tar.gz"
 {% if site.env.BITCOINORG_BUILD_TYPE %}
 <!-- Note: this file exempt from check-for-subheading-anchors check -->
 
-{% capture PATH_PREFIX %}/bin/bitcoin-core-{{ site.DOWNLOAD_VERSION }}{% endcapture %}
+{% capture PATH_PREFIX %}https://bitcoincore.org/bin/bitcoin-core-{{ site.DOWNLOAD_VERSION }}{% endcapture %}
 {% capture FILE_PREFIX %}bitcoin-{{ site.DOWNLOAD_VERSION }}{% endcapture %}
 <link rel="alternate" type="application/rss+xml" href="/en/rss/releases.rss" title="Bitcoin Core releases">
 
@@ -107,7 +107,7 @@ lin64: "x86_64-linux-gnu.tar.gz"
         </div>
 
         <div class="corecard linux-card">
-          <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-powerpc64le-linux-gnu.tar.gz" class="dl">PPC64 Linux</a>
+          <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-powerpc64-linux-gnu.tar.gz" class="dl">PPC64 Linux</a>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-powerpc64-linux-gnu.tar.gz" class="dl download-link" id="ppclin64">64 bit</a> 
         </div>
 


### PR DESCRIPTION
Every download button on `/en/download` currently returns a 404: the page announces the latest version (31.1) via `DOWNLOAD_VERSION`, but the local mirror at `bitcoin.org/bin/` stops at 31.0 — 31.1, 30.3, and 29.4 were never uploaded (the safeguards described in docs/adding-release-notes-and-alerts.md, Travis verifying download links before merge, binaries being uploaded by the release manager, no longer operate").

| Version | bitcoin.org/bin/ | bitcoincore.org/bin/ |
|---|---|---|
| 31.0 | 200 | 200 |
| 31.1 | **404** | 200 |
| 30.3 | **404** | 200 |
| 29.4 | **404** | 200 |

This changes `PATH_PREFIX` (one line) to point the binary links at `https://bitcoincore.org/bin/`, the canonical location where the Bitcoin Core team publishes and signs the releases. The signature link on the same page already works exactly this way. With this, the page can never again announce a version whose binaries don't exist, and users get byte-for-byte what the source publishes.

All 13 file links the template builds were verified against bitcoincore.org for 31.1: 12 return 200 (including the torrent and every OS/architecture variant). The one exception is `powerpc64le-linux-gnu.tar.gz`, that variant no longer exists upstream at all, so its link was dead regardless of the mirror; the PPC64 label now points at `powerpc64-linux-gnu.tar.gz`, matching the working "64 bit" link beside it.