### PR TITLE
Update the release documentation to match the current process

### DIFF
--- a/docs/adding-release-notes-and-alerts.md
+++ b/docs/adding-release-notes-and-alerts.md
@@ -2,146 +2,45 @@
 
 ### Release Notes
 
-To create a new Bitcoin Core release, create a new file in the
-`_releases/` directory. Any file name ending in `.md` is fine, but we
-recommend naming it after the release, such as `0.10.0.md`
+To add a new Bitcoin Core release, create a new file in the
+`_releases/` directory named after the release, such as `v29.4.md`.
 
-Then copy in the following YAML header (the part between the three dashes, ---):
-```
----
-# This file is licensed under the MIT License (MIT) available on
-# https://opensource.org/licenses/MIT.
+The easiest way to get the format right is to copy the most recent
+file in `_releases/` and update its frontmatter fields for the new
+version: `required_version`, `title`, `id`, `name`, `permalink`,
+`excerpt`, and the `release` array (one element per decimal place,
+e.g. `29.4` becomes `[29, 4]`).
 
-## Required value below populates the %v variable (note: % needs to be escaped
-in YAML if it starts a value)
-required_version: 0.10.0
-## Optional release date.  May be filled in hours/days after a release
-optional_date: 2015-02-16
-## Optional title.  If not set, default is: Bitcoin Core version %v released
-optional_title: Bitcoin Core version %v released
-## Optional magnet link.  To get it, open the torrent in a good BitTorrent
-client
-## and View Details, or install the transmission-cli Debian/Ubuntu package
-## and run: transmission-show -m <torrent file>
-#
-## Link should be enclosed in quotes and start with: "magnet:?
-optional_magnetlink:
+For `optional_date`, use the date bitcoincore.org announced the
+release on its blog -- this is the convention the existing files
+follow. The field may also be left blank and filled in later.
 
-## The --- below ends the YAML header. After that, paste the release notes.
-## Warning: this site's Markdown parser commonly requires you make two
-## changes to the release notes from the Bitcoin Core source tree:
-##
-## 1. Make sure both ordered and unordered lists are preceded by an empty
-## (whitespace only) line, like the empty line before this list item.
-##
-## 2. Place URLs inside angle brackets, like <https://bitcoin.org/bin>
----
-```
+For the body, paste the release notes from the upstream Bitcoin Core
+repository (`doc/release-notes/release-notes-<VERSION>.md` in
+`bitcoin/bitcoin`). This site's Markdown parser commonly requires two
+changes to that text:
 
-Then start at the top of the YAML header and read the comments, filling
-in and replacing information as necessary, and then reformatting the
-release notes (if necessary) as described by the last lines of the YAML
-header.
+1. Make sure both ordered and unordered lists are preceded by an
+   empty (whitespace only) line.
 
-Download links will automatically be set to the defaults using the current
-release version number, but if you need to change any download URL, edit
-the file `_templates/download.html`
+2. Place bare URLs inside angle brackets, like
+   `<https://bitcoincore.org/bin>`.
 
-You can then create a pull request to the
-master branch and Travis CI will automatically build it and make sure
-the links you provided return a "200 OK" HTTP header. (The actual files
-will not be downloaded to save bandwidth.) Alternatively, you can build
-the site locally with `make all` to run the same quality assurance tests.
+Download links update automatically: `_plugins/releases.rb` selects
+the highest version present in `_releases/` as the site-wide download
+version, and the download page links the binaries directly from
+`https://bitcoincore.org/bin/` -- the canonical location where the
+Bitcoin Core team publishes and signs releases -- so no binary uploads
+to this site are required. If you ever need to change a download URL,
+edit `_templates/download.html`.
 
-The file can be edited later to add any optional information (such as a
-release date) that you didn't have when you created the file.
+Then open a pull request to the master branch; Travis CI will build
+the site from the branch. We recommend the title "Add Bitcoin Core
+<VERSION>".
 
-#### Preparing a release in advance
-
-It's nice to prepare a release pull request in advance so that the
-Bitcoin Core developers can just click "Merge Pull Request" when the new
-version is released.  Here's the recommended recipe, where `<VERSION>`
-is the particular version:
-
-1. Create a new branch named `bitcoin-core-<VERSION>`.  You can either
-   do this locally or in GitHub's web GUI.
-
-2. Follow the instructions in the [Release
-   Notes](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/adding-release-notes-and-alerts.md#release-notes)
-   section to create a new release.  You should leave the `optional_date` blank
-   unless you happen to know the date of the planned release.
-
-3. Push the branch to the https://github.com/bitcoin-dot-org/bitcoin.org
-   repository so any contributor can edit it. **Don't** open a pull
-   request yet.
-
-4. Travis CI will build the site from the branch and then run the tests.
-   The tests will fail because they expect the release binaries to be
-   present and you're preparing this release request in advance of them
-   being uploaded.
-
-5. Open the failed Travis CI log.  At the end, it will say something like:
-```
-ERROR:
-Error: Could not retrieve /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win64-setup.exe
-Error: Could not retrieve /bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win32-setup.exe
-[...]
-```
-6. Copy the errors from above into a text file and remove everything
-   except for the URLs so that what's left are lines that look like:
-```
-/bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win64-setup.exe
-/bin/bitcoin-core-0.10.1/bitcoin-0.10.1-win32-setup.exe
-[...]
-```
-7. Optional, but nice: sort the lines into alphabetical order.
-
-8. Now open a pull request from the `bitcoin-core-<VERSION>` branch to
-   the `master` branch. We recommend that you use this title: "Releases:
-   Add Bitcoin Core <VERSION>".
-
-   We recommend that you use the following text with any changes you
-   think are appropriate. **Note:** read all the way to the end of this
-   enumerated point before submitting your pull request.
-```
-This updates the download links to point to <VERSION> and adds the <VERSION>
-release notes to the site. I'll keep it updated throughout the RC cycle, but it
-can be merged by anyone with commit access once <VERSION> final is released (see
-TODO lists below).
-
-CC: @laanwj
-```
-
-Essential TODO:
-
-* [ ] Make sure the download links work. This is automatically checked as part
-  of the Travis CI build, so trigger a rebuild and, if it passes, this should be
-safe to merge.
-
-Optional TODO (may be done in commits after merge):
-
-* [ ] Add the actual release date to the YAML header in `_releases/0.10.1.md`
-* [ ] Add the magnet URI to the YAML header in `_releases/0.10.1.md` (brief
-  instructions for creating the link are provided as comments in that file)
-
-Expected URLs for the Bitcoin Core binaries:
-
-Underneath the line 'Expected URLs', paste the URLs you retrieved from Travis CI
-earlier.
-
-Note that @laanwj is Wladimir J. van der Laan, who is usually responsible for
-uploading the Bitcoin Core binaries.  If someone else is responsible for this
-release, CC them instead.  If you don't know who is responsible, ask in
-#bitcoin-dev on Freenode.
-
-9. After creating the pull request, use the Labels menu to assign it the
-   "Releases" label. This is important because it's what the Bitcoin
-   Core release manager will be looking for.
-
-10. After each new Release Candidate (RC) is released, update the
-    release notes you created in the `_releases` directory. (But don't
-    worry about this too much; we can always upload updated release
-    notes after the release.)
+To prepare a release in advance, create the file from the upstream
+draft release notes, leave `optional_date` blank, and open the pull
+request once the release is announced.
 
 ### Alerts
 


### PR DESCRIPTION
Follow-up to #4926: the Release Notes section of `docs/adding-release-notes-and-alerts.md` described a process whose every moving part has stopped a 2015-era frontmatter example that no longer matches the real files, a Travis check that "will make sure the links return 200 OK" (it doesn't; that's how the site came to announce 31.1 with no binaries), and a ten-step "preparing in advance" recipe built around deliberately failing CI, pasting "Expected URLs" from the log to upload binaries to the local mirror, and asking in #bitcoin-dev on Freenode.

The section is rewritten to describe the process as it works today (and as #4925 was produced this morning): copy the most recent `_releases/` file and update its frontmatter (the fields are listed), use the bitcoincore.org announcement date for `optional_date` (the convention the existing files follow), paste the upstream release notes with the two Markdown adjustments (which remain true), and open a PR. Since #4926 the download page links binaries directly from `bitcoincore.org/bin/`, so no uploads to this site are involved; "preparing in advance" collapses to one paragraph.

The **Alerts** section, including its contact list, is deliberately untouched: who can publish alerts and whose signatures the auto-build accepts is a governance matter for the site owner, not a documentation fix.