### PR TITLE
Point the source code link at the announced release tag

### DIFF
--- a/_templates/download.html
+++ b/_templates/download.html
@@ -59,7 +59,7 @@ lin64: "x86_64-linux-gnu.tar.gz"
         <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}.torrent" class="dl core-link">{% translate downloadtorrent %}</a>
         {% if site.DOWNLOAD_MAGNETLINK %}
         <a href="{{ site.DOWNLOAD_MAGNETLINK | replace: '&', '\&amp;'}}" class="magnetlink core-link" data-proofer-ignore></a>{% endif %}
-        <a href="https://github.com/bitcoin/bitcoin" class="dl core-link">{% translate source %}</a>
+        <a href="https://github.com/bitcoin/bitcoin/tree/v{{ site.DOWNLOAD_VERSION }}" class="dl core-link">{% translate source %}</a>
         <a href="/en/version-history" class="core-link">{% translate versionhistory %}</a>
       </div>
       


### PR DESCRIPTION
The "Source code" link on the download page pointed at the repository root — i.e. the master branch — so a user expecting the source of the announced version got development code instead. Reported via user feedback in 2020 and still true today.

The link now points at `github.com/bitcoin/bitcoin/tree/v{{ site.DOWNLOAD_VERSION }}` — the exact tag of the version the page announces. It stays in sync automatically as releases are added, the same way the binary links do since #4926. Tag URL verified live for v31.1.

Fixes #3319.