### PR TITLE
Update the OS and memory requirements on the Bitcoin Core requirements page

### DIFF
--- a/en/bitcoin-core/features/requirements.md
+++ b/en/bitcoin-core/features/requirements.md
@@ -98,8 +98,8 @@ help].
   Laptop<br>
   [Some ARM chipsets][wiki bitcoin core compatible devices arm] >1 GHz
 
-- {{OS}} Windows 7/8.x/10<br>
-  Mac OS X<br>
+- {{OS}} Windows 10+<br>
+  macOS 14+<br>
   Linux<br>
   Some BSDs
 
@@ -126,8 +126,8 @@ help].
   Laptop<br>
   [Most ARM chipsets][wiki bitcoin core compatible devices arm]
 
-- {{OS}} Windows 7/8.x/10<br>
-  Mac OS X<br>
+- {{OS}} Windows 10+<br>
+  macOS 14+<br>
   Linux<br>
   Some BSDs
 
@@ -150,14 +150,14 @@ help].
 
 - {{UPLOAD}} 5 GB/day (150 GB/month)
 
-- {{MEMORY}} 1 GB
+- {{MEMORY}} 2 GB
 
 - {{SYSTEM}} Desktop<br>
   Laptop<br>
   [Some ARM chipsets][wiki bitcoin core compatible devices arm] >1 GHz
 
-- {{OS}} Windows 7/8.x/10<br>
-  Mac OS X<br>
+- {{OS}} Windows 10+<br>
+  macOS 14+<br>
   Linux
 
 


### PR DESCRIPTION
The system-requirements tables on `/en/bitcoin-core/features/requirements` still listed "Windows 7/8.x/10" and "Mac OS X", operating systems Bitcoin Core no longer supports (Windows 7 and 8.x reached end of life in 2020/2023; "Mac OS X" is the retired branding). The release notes of the version this page announces (31.1) state the current compatibility line: *"Linux Kernel 3.17, macOS 14, and Windows 10 (version 1903)"*. All three tables now say "Windows 10+ / macOS 14+".

The "Minimum Recommended" memory was also raised from 1 GB to 2 GB, matching what this site's own full-node page (`/en/full-node`) already states as the memory requirement, the two pages contradicted each other.

Left as-is: the disk figures (driven by `_config.yml` variables, which are current — 740 GB chain / 7 GB pruned), the bandwidth estimates (still consistent with today's block sizes), and the "bare minimum" RAM figures for custom-settings scenarios, which have no authoritative upstream number to cite.

