### PR TITLE
Update the wallet backup guidance to the HD-wallet era

### DIFF
--- a/en/bitcoin-core/features/requirements.md
+++ b/en/bitcoin-core/features/requirements.md
@@ -174,15 +174,17 @@ help].
 
 <div class="not-displayed">
   <div id="backup_your_keys" title="Backup Your Keys" markdown="block">
-  By default, you need to backup Bitcoin Core after every 100
-  transactions.  This includes both transactions you send as well as
-  payments you request (whether or not you actually received the payment).
+  Bitcoin Core uses HD (hierarchical deterministic) wallets, so a
+  single backup is enough to recover your bitcoins at any time.
 
-  For example, you need to backup after sending 33 payments and requesting
-  67 payments (even though you only received 60 payments).
+  Regular backups (for example, weekly) are still recommended to
+  preserve wallet metadata such as labels, which cannot be recovered
+  from a blockchain rescan.
 
-  Bitcoin Core can be configured to allow you to go more transactions
-  between backups.  See the [`-keypool` setting][bcc configuration].
+  After encrypting your wallet or changing its passphrase, make a new
+  backup immediately: encryption generates a new seed, and bitcoins
+  received by it cannot be recovered from earlier backups.
+
   </div>
 
   <div id="secure_your_wallet" title="Secure Your Wallet" markdown="block">


### PR DESCRIPTION
The "Backup your keys" popup on the requirements page still gave pre-HD-wallet advice: "you need to backup Bitcoin Core after every 100 transactions", with worked examples and a `-keypool` reference. That guidance has been obsolete since Bitcoin Core 0.13 (2016) introduced HD wallets — and worse, it teaches users that old backups stop protecting their funds as transactions accumulate, which is no longer how the wallet works.

The upstream `doc/managing-wallets.md` (§1.5 Backup Frequency) states the current model: *"a single backup is enough to recover the coins at any time"*; regular backups remain recommended to preserve metadata such as labels (which a rescan cannot restore); and a fresh backup is needed immediately after encrypting the wallet, since encryption generates a new seed. The popup now says exactly that — facts from the upstream doc, wording this site's own. The every-100-keys rule survives upstream only for wallets created before 0.13.

The other three popups (secure your wallet, offline wallet, inheritance) remain accurate and are untouched.