### PR TITLE
Point the offline-transactions reference at the upstream signing tutorial

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -466,7 +466,7 @@ https://opensource.org/licenses/MIT.
 [native irc client]: https://en.wikipedia.org/wiki/List_of_IRC_clients
 [netcat]: https://en.wikipedia.org/wiki/Netcat
 [nop opcodes]: https://en.bitcoin.it/wiki/Script#Reserved_words
-[offline transactions]: https://bitcoin.stackexchange.com/a/34122/21052
+[offline transactions]: https://github.com/bitcoin/bitcoin/blob/master/doc/offline-signing-tutorial.md
 [open a pull request]: https://github.com/bitcoin-dot-org/bitcoin.org#working-with-github
 [open an issue]: https://github.com/bitcoin-dot-org/bitcoin.org/issues/new
 [open assets protocol]: https://github.com/OpenAssets/open-assets-protocol/blob/master/specification.mediawiki


### PR DESCRIPTION
The "Offline Wallet" popup on the requirements page pointed its "Creating and signing offline transactions" reference at a 2015 Stack Exchange answer, pre-PSBT methodology. Since BIP174, offline signing works differently, and Bitcoin Core ships an official walkthrough of the modern flow: `doc/offline-signing-tutorial.md`.

The reference (used by the requirements page) now points at that upstream tutorial. Same principle as the rest of this week's work: community links from 2015 upgraded to the canonical documentation where one exists. The neighbouring references were checked too: the `Running_Bitcoin` wiki page (configuration) and the estate-planning link remain, both alive, and no upstream equivalent exists for either topic.
