### PR TITLE
Fix release pages rendering the wrong release notes (shared Liquid cache path)

### DIFF
--- a/_plugins/releases.rb
+++ b/_plugins/releases.rb
@@ -25,6 +25,7 @@ module Jekyll
 
       ## Read in the file's YAML header
       self.read_yaml(File.join(base, srcdir), src)
+      self.data["path"] = srcdir + "/" + src
 
       ## Die if required_ variables aren't set
       if self.data['required_version']


### PR DESCRIPTION
## Problem

55 release pages are serving the wrong body, every Liquid-bearing release (v0.10.0 through 31.1) renders the 29.0 release notes under its own title and date. Live examples: [v0.21.0](https://bitcoin.org/en/release/v0.21.0), [29.4](https://bitcoin.org/en/releases/29.4/).

## Root cause

`ReleasePage` reports the same `path` (`"en/release/"`) for every generated page, and Jekyll 4's `LiquidRenderer` caches parsed templates per path, so the first Liquid-bearing release parsed becomes the template for all of them. Pages without Liquid skip the renderer, which is why pre-v0.10 pages are unaffected. Introduced by the Jekyll upgrade in #4896; unrelated to the recent server fixes.

## Fix

One line: set `data['path']` to the source file, as `alerts.rb` already does (which is why alert pages with Liquid render correctly).

Validated with clean local builds on the pinned stack: 55/85 pages corrupted before the patch, 0/85 after. The next auto-deploy after merge regenerates all 55 pages correctly.