### PR TITLE
Add pre-build YAML syntax check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ pre-build-tests-fast: check-for-non-ascii-urls check-for-wrong-filename-assignme
     check-for-consistent-bitcoin-core-titles \
     check-for-too-many-wallets-on-one-platform \
     check-validate-yaml \
+    check-yaml-syntax \
     check-wallet-description-length \
 
 ## Post-build tests which, aggregated together, take less than 10 seconds to run on a typical PC
@@ -299,3 +300,6 @@ check-validate-yaml:
 check-wallet-description-length:
 ## Ensure wallet descriptions are 320 characters or less
 	$S sed -n '/^  choose-your-wallet:/,/^  [-a-z]\+:/{/wallet.*:.\{320\}/p} ' _translations/en.yml | eval $(ERROR_ON_OUTPUT)
+check-yaml-syntax:
+## Ensure every YAML file parses with Psych, the parser used by the build
+	$S ruby _contrib/check-yaml.rb

--- a/_contrib/check-yaml.rb
+++ b/_contrib/check-yaml.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# This file is licensed under the MIT License (MIT) available on
+# https://opensource.org/licenses/MIT.
+
+# Validates that every tracked YAML file parses with Psych, the same
+# parser the build uses. A syntax error fails fast here with the file
+# name and position, instead of aborting the Jekyll build later with
+# no obvious culprit. Proposed in issue 4911.
+
+require 'yaml'
+
+files = `git ls-files -z -- '*.yml' '*.yaml'`.split("\0")
+abort 'check-yaml: no YAML files found' if files.empty?
+
+failures = 0
+files.each do |f|
+  begin
+    if YAML.respond_to?(:unsafe_load_file)
+      YAML.unsafe_load_file(f)
+    else
+      YAML.load_file(f)
+    end
+  rescue StandardError => e
+    warn "check-yaml: #{f}: #{e.message}"
+    failures += 1
+  end
+end
+
+if failures.zero?
+  puts "check-yaml: #{files.length} YAML files parsed OK"
+else
+  warn "check-yaml: #{failures} invalid YAML file(s)"
+  exit 1
+end


### PR DESCRIPTION
## Problem

An invalid YAML escape in `_translations/en.yml` aborted the Jekyll build, and no check named the file. The existing `check-validate-yaml` only schema-validates `_wallets/`; the plain YAML files the build loads are never syntax-checked.

## Fix

New `check-yaml-syntax` target in `pre-build-tests-fast` (runs before Jekyll in `test`, `valid`, `travis` and `deployment`): parses every tracked `*.yml`/`*.yaml` with Psych  and fails naming each invalid file. Stdlib only, no new dependencies. Implements #4911.

## Validation

Passes on master (34 files). Re-introducing an invalid escape into `en.yml` fails with the file name and position:

    check-yaml: _translations/en.yml: found unknown escape character while parsing a quoted scalar at line 8 column 13
    
    
cc @Cobra-Bitcoin    