### PR TITLE
Add HTML hreflang metadata for translated pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
+url: "https://bitcoin.org"
+
 langsorder:
 - 'id'
 - 'ca'

--- a/_includes/layout/base/hreflang.html
+++ b/_includes/layout/base/hreflang.html
@@ -1,3 +1,8 @@
+{% comment %}
+This file is licensed under the MIT License (MIT) available on
+https://opensource.org/licenses/MIT.
+{% endcomment %}
+
 {% for alternate in page.hreflang_alternates %}
 <link rel="alternate"
       hreflang="{{ alternate.lang }}"

--- a/_includes/layout/base/hreflang.html
+++ b/_includes/layout/base/hreflang.html
@@ -1,0 +1,11 @@
+{% for alternate in page.hreflang_alternates %}
+<link rel="alternate"
+      hreflang="{{ alternate.lang }}"
+      href="{{ alternate.url | escape }}">
+{% endfor %}
+
+{% if page.hreflang_x_default %}
+<link rel="alternate"
+      hreflang="x-default"
+      href="{{ page.hreflang_x_default | escape }}">
+{% endif %}

--- a/_includes/layout/base/html-head.html
+++ b/_includes/layout/base/html-head.html
@@ -8,6 +8,7 @@ https://opensource.org/licenses/MIT.
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>{% capture title %}{% translate title %}{% endcapture %}{% if title != '' %}{{ title }}{% else %}{{ page.title }}{% endif %}</title>
 {% capture metadescription %}{% translate metadescription %}{% endcapture %}{% if metadescription != '' %}<meta name="description" content="{{ metadescription }}">{% endif %}
+{% include layout/base/hreflang.html %}
 <link rel="stylesheet" href="/css/font-awesome-4.4.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="/css/main.css?{{site.time | date: '%s'}}">
 <!--[if lt IE 8]><link rel="stylesheet" href="/css/ie.css"><script type="text/javascript" src="/js/ie.js"></script><![endif]-->

--- a/_plugins/hreflang.rb
+++ b/_plugins/hreflang.rb
@@ -1,0 +1,67 @@
+# This file is licensed under the MIT License (MIT) available on
+# https://opensource.org/licenses/MIT.
+
+module Jekyll
+  class HreflangGenerator < Generator
+    safe true
+    priority :lowest
+
+    def generate(site)
+      origin = site.config.fetch('url', 'https://bitcoin.org')
+                          .sub(%r{/$}, '')
+      language_order = Array(site.config['langsorder'])
+      groups = Hash.new { |hash, id| hash[id] = [] }
+
+      site.pages.each do |page|
+        id = page.data['id']
+        lang = page.data['lang']
+
+        next if id.nil? || lang.nil?
+
+        path = public_path(page.url)
+
+        # Excludes /, /404.html and other non-localized pages.
+        next unless path.start_with?("/#{lang}/")
+
+        groups[id] << [page, lang, path]
+      end
+
+      groups.each do |id, entries|
+        # Use only one URL for each language.
+        by_language = {}
+        entries.each { |entry| by_language[entry[1]] ||= entry }
+
+        # A page with only one language has no translated alternatives.
+        next if by_language.length < 2
+
+        alternates = by_language.values.sort_by do |_page, lang, _path|
+          language_order.index(lang) || language_order.length
+        end.map do |_page, lang, path|
+          {
+            'lang' => lang.tr('_', '-'),
+            'url'  => origin + path
+          }
+        end
+
+        entries.each do |page, _lang, _path|
+          page.data['hreflang_alternates'] = alternates
+
+          # / selects or redirects to the appropriate language.
+          if id == 'index'
+            page.data['hreflang_x_default'] = origin + '/'
+          end
+        end
+      end
+    end
+
+    private
+
+    def public_path(url)
+      path = url.to_s
+      path = "/#{path}" unless path.start_with?('/')
+
+      path.sub(%r{/index\.html$}, '/')
+          .sub(/\.html$/, '')
+    end
+  end
+end

--- a/_plugins/sitemap.rb
+++ b/_plugins/sitemap.rb
@@ -1,8 +1,8 @@
 # This file is licensed under the MIT License (MIT) available on
 # https://opensource.org/licenses/MIT.
 
-#sitemap.rb generates a sitemap.xml file, which also includes
-#alternate hreflang for each translated version of each page.
+# sitemap.rb generates the sitemap.xml file.
+# Translated alternatives are declared in each page's HTML head.
 
 require 'yaml'
 require 'cgi'
@@ -11,90 +11,156 @@ module Jekyll
 
   class SitemapFile < StaticFile
     def write(dest)
-      # do nothing
+      # Do nothing. The sitemap is written by SitemapGenerator.
     end
   end
 
   class SitemapGenerator < Generator
     def generate(site)
-      #Do nothing if plugin is disabled
-      if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('sitemap').nil?
-        print 'Sitemap disabled' + "\n"
+      # Do nothing if the plugin is disabled.
+      if !ENV['ENABLED_PLUGINS'].nil? &&
+         ENV['ENABLED_PLUGINS'].index('sitemap').nil?
+        puts 'Sitemap disabled'
         return
       end
-      #Load translations
+
+      # Load translations.
       locs = {}
-      enabled = ENV['ENABLED_LANGS'];
-      enabled = enabled.split(' ') if !enabled.nil?
+
+      enabled = ENV['ENABLED_LANGS']
+      enabled = enabled.split(' ') unless enabled.nil?
+
       Dir.foreach('_translations') do |file|
-        next if file == '.' or file == '..' or file == 'COPYING'
-        lang=file.split('.')[0]
-        #Ignore lang if disabled
-        if lang != 'en' and !enabled.nil? and !enabled.include?(lang)
+        next if file == '.'
+        next if file == '..'
+        next if file == 'COPYING'
+
+        lang = file.split('.')[0]
+
+        # Ignore the language if it is disabled.
+        if lang != 'en' &&
+           !enabled.nil? &&
+           !enabled.include?(lang)
           next
         end
-        locs[lang] = YAML.unsafe_load_file('_translations/'+file)[lang]
+
+        translation_file = File.join('_translations', file)
+        locs[lang] = YAML.unsafe_load_file(translation_file)[lang]
       end
-      #Create destination directory if does not exists
-      if !File.directory?(site.dest)
-        Dir.mkdir(site.dest)
-      end
-      File.open(File.join(site.dest, 'sitemap.xml'), 'w+') do |sitemap|
-        #Open sitemap
+
+      # Create the destination directory if it does not exist.
+      Dir.mkdir(site.dest) unless File.directory?(site.dest)
+
+      sitemap_path = File.join(site.dest, 'sitemap.xml')
+
+      File.open(sitemap_path, 'w+') do |sitemap|
+        # Open the sitemap.
         sitemap.puts '<?xml version="1.0" encoding="UTF-8"?>'
-        sitemap.puts '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"'
-        sitemap.puts '	xmlns:xhtml="http://www.w3.org/1999/xhtml">'
-        #Add translated pages with their alternative in each languages
-        locs['en']['url'].each do |id,value|
-          locs.each do |lang,value|
-            #Don't add a page if their url is not translated
-            next if locs[lang]['url'][id].nil? or locs[lang]['url'][id] == ''
+        sitemap.puts '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+
+        # Add translated pages as normal sitemap URLs.
+        #
+        # hreflang links are generated in each page's HTML head instead
+        # of being duplicated in the sitemap.
+        locs['en']['url'].each_key do |id|
+          locs.each_key do |lang|
+            translated_url = locs[lang]['url'][id]
+
+            # Do not add a page if its URL is not translated.
+            next if translated_url.nil? || translated_url.empty?
+
             sitemap.puts '<url>'
-            sitemap.puts '  <loc>https://bitcoin.org/'+lang+'/'+CGI::escape(locs[lang]['url'][id])+'</loc>'
-            locs.each do |altlang,value|
-              next if locs[altlang]['url'][id].nil? or locs[altlang]['url'][id] == '' or altlang == lang
-              sitemap.puts '  <xhtml:link'
-              sitemap.puts '    rel="alternate"'
-              sitemap.puts '    hreflang="'+altlang+'"'
-              sitemap.puts '    href="https://bitcoin.org/'+altlang+'/'+CGI::escape(locs[altlang]['url'][id])+'" />'
-            end
+            sitemap.puts(
+              '  <loc>https://bitcoin.org/' +
+              lang + '/' +
+              CGI::escape(translated_url) +
+              '</loc>'
+            )
             sitemap.puts '</url>'
           end
         end
-	#Add static non-translated pages
-        Dir.glob('en/**/*.{md,html}').concat(Dir.glob('*.{md,html}')).each do |file|
-          next if file == 'index.html' or file == '404.html' or file == 'README.md'
-          #Ignore google webmaster tools
+
+        # Add static non-translated pages.
+        static_pages = Dir.glob('en/**/*.{md,html}')
+        static_pages.concat(Dir.glob('*.{md,html}'))
+
+        static_pages.each do |file|
+          next if file == 'index.html'
+          next if file == '404.html'
+          next if file == 'README.md'
+
+          # Ignore Google webmaster verification files.
           data = File.read(file)
-          next if !data.index('google-site-verification:').nil?
+          next unless data.index('google-site-verification:').nil?
+
+          public_path = file
+                        .gsub('.html', '')
+                        .gsub('.md', '')
+
           sitemap.puts '<url>'
-          sitemap.puts '  <loc>https://bitcoin.org/'+file.gsub('.html','').gsub('.md','')+'</loc>'
+          sitemap.puts(
+            '  <loc>https://bitcoin.org/' +
+            public_path +
+            '</loc>'
+          )
           sitemap.puts '</url>'
         end
-        #Add alerts pages
+
+        # Add alert pages.
         Dir.foreach('_alerts') do |file|
-          next if file == '.' or file == '..'
+          next if file == '.'
+          next if file == '..'
+
+          alert_path = file
+                       .gsub('.html', '')
+                       .gsub('.md', '')
+
           sitemap.puts '<url>'
-          sitemap.puts '  <loc>https://bitcoin.org/en/alert/'+file.gsub('.html','')+'</loc>'
+          sitemap.puts(
+            '  <loc>https://bitcoin.org/en/alert/' +
+            alert_path +
+            '</loc>'
+          )
           sitemap.puts '</url>'
         end
-        #Add releases pages
+
+        # Add release pages.
         Dir.foreach('_releases') do |file|
-          next if file == '.' or file == '..'
-          file = file.split('-')
-          next if file.length < 4
-          file.shift()
-          file.shift()
-          file.shift()
-          file = file.join('-')
+          next if file == '.'
+          next if file == '..'
+
+          release_parts = file.split('-')
+          next if release_parts.length < 4
+
+          # Remove the YYYY-MM-DD date prefix.
+          release_parts.shift
+          release_parts.shift
+          release_parts.shift
+
+          release_path = release_parts
+                         .join('-')
+                         .gsub('.md', '')
+                         .gsub('.html', '')
+
           sitemap.puts '<url>'
-          sitemap.puts '  <loc>https://bitcoin.org/en/release/'+file.gsub('.md','').gsub('.html','')+'</loc>'
+          sitemap.puts(
+            '  <loc>https://bitcoin.org/en/release/' +
+            release_path +
+            '</loc>'
+          )
           sitemap.puts '</url>'
         end
-        #Close sitemap
+
+        # Close the sitemap.
         sitemap.puts '</urlset>'
       end
-      site.static_files << SitemapFile.new(site, site.source, '', 'sitemap.xml')
+
+      site.static_files << SitemapFile.new(
+        site,
+        site.source,
+        '',
+        'sitemap.xml'
+      )
     end
   end
 


### PR DESCRIPTION
Adds build-time hreflang metadata to help search engines identify equivalent translated pages and return the appropriate language version. Removes the old duplicate hreflang implementation from sitemap.xml.