### PR TITLE
Fix sha256sum generation on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ build:
 	$S grep -r -L 'Note: this file is built non-deterministically' _site/ \
 	  | egrep -v 'sha256sums.txt' \
 	  | sort \
-	  | xargs -d '\n' sha256sum > _site/sha256sums.txt
+	  | while IFS= read -r file; do sha256sum "$$file"; done > _site/sha256sums.txt
 	$S git log -1 --format="%H" > _site/commit.txt
 
 ## Jekyll annoyingly returns success even when it emits errors and


### PR DESCRIPTION
The build currently uses GNU-specific xargs -d '\n', which is not supported by the macOS/BSD version of xargs.
Replace it with a portable while read loop so sha256sums.txt can be generated correctly on macOS.
Tested locally with make clean && make build.
Both _site/sha256sums.txt and _site/commit.txt were generated successfully.