### PR TITLE
Add a browsable BIP reference to Bitcoin.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ _cache
 .jekyll-metadata
 .jekyll-cache/
 .sass-cache/
+__pycache__/
+/bip/
 
 # To prevent accidental push of translations from
 # Transifex.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 dist: jammy
 rvm:
   - "3.3.10"
+addons:
+  apt:
+    packages:
+      - pandoc
 cache: bundler
 env:
   # https://docs.travis-ci.com/user/environment-variables/#Global-Variables

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ S=@  ## Silent: only print errors by default;
 SHELL=/bin/bash
 SITEDIR=_site
 JEKYLL_LOG=._jekyll.log
+BIP_GENERATOR=_build/generate_bips.py
 
 #######################
 ## REGULAR ARGUMENTS ##
@@ -16,7 +17,7 @@ JEKYLL_LOG=._jekyll.log
 default: clean build
 
 ## `make preview`: start the built-in Jekyll preview
-preview: clean
+preview: clean generate-bips
 	$S export LANG=C.UTF-8 ; bundle exec jekyll serve --incremental
 
 ## `make test`: don't build, but do run all tests
@@ -62,6 +63,7 @@ pre-build-tests-fast: check-for-non-ascii-urls check-for-wrong-filename-assignme
     check-validate-yaml \
     check-yaml-syntax \
     check-wallet-description-length \
+    check-bip-generator
 
 ## Post-build tests which, aggregated together, take less than 10 seconds to run on a typical PC
 post-build-tests-fast: check-site-was-built check-for-build-errors ensure-each-svg-has-a-png check-for-liquid-errors \
@@ -71,7 +73,8 @@ post-build-tests-fast: check-site-was-built check-for-build-errors ensure-each-s
     check-for-empty-title-tag \
     check-for-subheading-anchors \
     check-jshint \
-    check-for-javascript-in-svgs
+    check-for-javascript-in-svgs \
+    check-bip-pages
 
 ## All pre-build tests, including those which might take multiple minutes
 pre-build-tests: pre-build-tests-fast
@@ -104,13 +107,22 @@ clean:
 
 ## Always build using the default locale so log messages can be grepped.
 ## This should not affect webpage output.
-build:
+build: generate-bips
 	$S export LANG=C.UTF-8 ; set -o pipefail ; bundle exec jekyll build 2>&1 | tee $(JEKYLL_LOG)
 	$S grep -r -L 'Note: this file is built non-deterministically' _site/ \
 	  | egrep -v 'sha256sums.txt' \
 	  | sort \
 	  | while IFS= read -r file; do sha256sum "$$file"; done > _site/sha256sums.txt
 	$S git log -1 --format="%H" > _site/commit.txt
+
+generate-bips:
+	$S python3 $(BIP_GENERATOR)
+
+check-bip-generator:
+	$S python3 _build/test_bips.py
+
+check-bip-pages:
+	$S python3 $(BIP_GENERATOR) --check-output $(SITEDIR)/bip
 
 ## Jekyll annoyingly returns success even when it emits errors and
 ## exceptions, so we'll grep its output for error strings
@@ -147,8 +159,11 @@ check-for-missing-anchors:
 
 check-for-broken-markdown-reference-links:
 ## Report Markdown reference-style links which weren't converted to HTML
-## links in the output, indicating there's no reference definition
-	$S find $(SITEDIR) -name '*.html' -type f | xargs grep '\]\[' | eval $(ERROR_ON_OUTPUT)
+## links in the output, indicating there's no reference definition. BIP source
+## contains protocol examples where adjacent brackets are intentional and is
+## validated separately by check-bip-pages.
+	$S find $(SITEDIR) -path $(SITEDIR)/bip -prune -o -name '*.html' -type f -print0 \
+	  | xargs -0 grep '\]\[' | eval $(ERROR_ON_OUTPUT)
 
 check-for-non-ascii-urls:
 ## Always check all translated urls don't contain non-ASCII

--- a/_build/bips-source.json
+++ b/_build/bips-source.json
@@ -1,0 +1,9 @@
+{
+  "_license": "MIT; see https://opensource.org/licenses/MIT",
+  "repository": "https://github.com/bitcoin/bips.git",
+  "commit": "60f5b33b0a7be3cf09b933d97b78071d684db7d1",
+  "cache_directory": "_cache/bitcoin-bips",
+  "output_directory": "bip",
+  "expected_bip_count": 210,
+  "expected_image_asset_count": 79
+}

--- a/_build/generate_bips.py
+++ b/_build/generate_bips.py
@@ -1111,13 +1111,20 @@ class OutputInspector(HTMLParser):
         self.legacy_links: list[str] = []
         self.document_links: list[tuple[str, str]] = []
         self.images_without_alt: list[str] = []
+        self.unsafe_document_html: list[str] = []
+        self.found_bip_document = False
         self.in_bip_document = False
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attributes = dict(attrs)
         classes = (attributes.get("class") or "").split()
         if tag == "article" and "bip-document" in classes:
+            self.found_bip_document = True
             self.in_bip_document = True
+        if self.in_bip_document:
+            unsafe = UNSAFE_HTML.search(self.get_starttag_text() or "")
+            if unsafe:
+                self.unsafe_document_html.append(unsafe.group(0))
         if attributes.get("id"):
             self.ids.append(str(attributes["id"]))
         for name in ("href", "src"):
@@ -1155,9 +1162,15 @@ def check_output(config_path: Path, output_root: Path) -> None:
     identifiers_by_bip: dict[int, set[str]] = {}
     for page in pages:
         content = page.read_text(encoding="utf-8")
-        validate_rendered_html(content, str(page))
         inspector = OutputInspector()
         inspector.feed(content)
+        if not inspector.found_bip_document:
+            raise BuildError(f"Missing BIP document in {page}")
+        if inspector.unsafe_document_html:
+            raise BuildError(
+                f"Unsafe HTML in BIP document {page}: "
+                f"{inspector.unsafe_document_html[0]!r}"
+            )
         duplicates = [name for name, count in collections.Counter(inspector.ids).items() if count > 1]
         if duplicates:
             raise BuildError(f"Duplicate IDs in {page}: {', '.join(duplicates[:10])}")

--- a/_build/generate_bips.py
+++ b/_build/generate_bips.py
@@ -75,6 +75,7 @@ class Bip:
     body: str
     rendered_html: str = ""
     description: str = ""
+    span_tables: dict[str, str] = dataclasses.field(default_factory=dict)
 
     @property
     def title(self) -> str:
@@ -142,6 +143,34 @@ def run(command: list[str], cwd: Path | None = None, input_text: str | None = No
     if process.stderr.strip():
         print(process.stderr.strip(), file=sys.stderr)
     return process.stdout.strip()
+
+
+MINIMUM_PANDOC_VERSION = (2, 9)
+
+
+def parse_pandoc_version(version_output: str) -> tuple[int, int]:
+    match = re.match(r"pandoc(?:\.exe)?\s+(\d+)\.(\d+)", version_output)
+    if not match:
+        raise BuildError(f"Unable to parse the Pandoc version from: {version_output!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def ensure_pandoc_version() -> None:
+    """Refuse to build with a Pandoc older than the tested range.
+
+    The generator is exercised against Pandoc 2.9 (Ubuntu jammy), 3.1 and
+    3.10; releases older than 2.9 have not been tested and may silently
+    produce different HTML.
+    """
+    version_output = run(["pandoc", "--version"]).splitlines()[0]
+    version = parse_pandoc_version(version_output)
+    if version < MINIMUM_PANDOC_VERSION:
+        minimum = ".".join(str(part) for part in MINIMUM_PANDOC_VERSION)
+        raise BuildError(
+            f"Pandoc {version[0]}.{version[1]} is older than the minimum tested "
+            f"version {minimum}; found: {version_output}"
+        )
+    print(f"Using {version_output}")
 
 
 def ensure_source(config: dict[str, object], explicit_source: Path | None = None) -> tuple[Path, str]:
@@ -259,13 +288,15 @@ def parse_bip(path: Path) -> Bip:
 
 
 def render_with_pandoc(bip: Bip, source_root: Path) -> str:
-    body = (
-        preprocess_mediawiki_references(
-            preprocess_mediawiki_blocks(preprocess_mediawiki_files(bip.body))
+    if bip.source_format == "mediawiki":
+        despanned, bip.span_tables = preprocess_mediawiki_spanned_tables(
+            preprocess_mediawiki_table_spacing(bip.body)
         )
-        if bip.source_format == "mediawiki"
-        else normalize_markdown_footnotes(bip.body)
-    )
+        body = preprocess_mediawiki_references(
+            preprocess_mediawiki_blocks(preprocess_mediawiki_files(despanned))
+        )
+    else:
+        body = normalize_markdown_footnotes(bip.body)
     input_format = "mediawiki+gfm_auto_identifiers" if bip.source_format == "mediawiki" else "gfm"
     output = run(
         [
@@ -323,6 +354,198 @@ def wrap_document_tables(rendered: str) -> str:
     if depth != 0:
         raise BuildError("Unbalanced table markup after HTML normalization")
     return "".join(output)
+
+
+SPAN_ATTRIBUTE = re.compile(r'\b(colspan|rowspan)\s*=\s*"?(\d+)"?', re.IGNORECASE)
+
+
+def convert_wiki_cell_inline(content: str) -> str:
+    """Minimally convert MediaWiki inline markup inside an HTML-converted cell."""
+    # A rare <ref> inside a table cell becomes an inline parenthetical; the
+    # protected table is substituted after reference preprocessing runs.
+    content = re.sub(
+        r"<ref[^>]*>(.*?)</ref\s*>", r" (\1)", content, flags=re.IGNORECASE | re.DOTALL
+    )
+    content = re.sub(r"<ref[^>]*/\s*>", "", content, flags=re.IGNORECASE)
+    # Escape angle brackets that do not start an HTML tag, e.g. <33 byte ...>.
+    content = re.sub(r"<(?![A-Za-z/!])", "&lt;", content)
+    content = re.sub(r"\[\[([^|\]]+)\|([^\]]+)\]\]", r'<a href="\1">\2</a>', content)
+    content = re.sub(r"\[\[([^\]]+)\]\]", r'<a href="\1">\1</a>', content)
+    content = re.sub(r"'''(.+?)'''", r"<strong>\1</strong>", content)
+    content = re.sub(r"''(.+?)''", r"<em>\1</em>", content)
+    return content
+
+
+def wiki_table_to_html(table: str) -> str:
+    """Convert one complete MediaWiki table to a plain HTML table.
+
+    Pandoc's MediaWiki reader fixes the column count from the first row and
+    silently drops the remaining cells of wider rows (jgm/pandoc#1696), so
+    tables using colspan/rowspan must bypass it entirely. Cell content may
+    continue on following lines; those lines belong to the current cell.
+    """
+    lines = mask_protected_pipes(table).splitlines()
+    caption = ""
+    rows = []
+    current = []
+
+    def append_cells(raw: str, tag: str, separator: str) -> None:
+        for cell in re.split(separator, raw):
+            attributes = ""
+            if "|" in cell:
+                prefix, _, remainder = cell.partition("|")
+                if "=" in prefix and "[[" not in prefix:
+                    spans = SPAN_ATTRIBUTE.findall(prefix)
+                    attributes = "".join(
+                        f' {name.lower()}="{value}"' for name, value in spans
+                    )
+                    cell = remainder
+            current.append([tag, attributes, convert_wiki_cell_inline(cell.strip())])
+
+    for line in lines[1:-1]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("|+"):
+            caption = convert_wiki_cell_inline(stripped[2:].strip())
+        elif stripped.startswith("|-"):
+            if current:
+                rows.append(current)
+                current = []
+        elif stripped.startswith("!"):
+            append_cells(stripped[1:], "th", r"!!")
+        elif stripped.startswith("|") and not stripped.startswith("|}"):
+            append_cells(stripped[1:], "td", r"\|\|")
+        elif current:
+            # A single newline inside a MediaWiki cell is a soft wrap.
+            current[-1][2] += " " + convert_wiki_cell_inline(stripped)
+    if current:
+        rows.append(current)
+    body = "".join(
+        "<tr>" + "".join(f"<{t}{a}>{c}</{t}>" for t, a, c in row) + "</tr>"
+        for row in rows
+        if row
+    )
+    caption_markup = f"<caption>{caption}</caption>" if caption else ""
+    return f"<table>{caption_markup}{body}</table>"
+
+
+def preprocess_mediawiki_table_spacing(source: str) -> str:
+    """Insert a blank line before tables glued to a preceding raw-HTML line.
+
+    Pandoc's MediaWiki reader treats a line such as <br/> as the start of a
+    raw HTML block and swallows a directly following table as part of it,
+    silently dropping the table (BIP 75). A preceding table-syntax line is
+    left untouched so nested tables are unaffected.
+    """
+    return re.sub(
+        r"^(?!\s*$)(?![|!{]).*\n(?=\{\|)",
+        lambda match: match.group(0) + "\n",
+        source,
+        flags=re.MULTILINE,
+    )
+
+
+PROTECTED_PIPE_SPANS = re.compile(
+    r"<(code|tt|nowiki)\b[^>]*>.*?</\1\s*>", re.IGNORECASE | re.DOTALL
+)
+
+
+def mask_protected_pipes(text: str) -> str:
+    """Turn pipes inside inline code into entities before cell splitting.
+
+    A cell such as <code>hash(A || B)</code> contains the OR operator, not
+    two cell separators; the entity renders identically and keeps the code
+    span within a single cell.
+    """
+    return PROTECTED_PIPE_SPANS.sub(
+        lambda match: match.group(0).replace("|", "&#124;"), text
+    )
+
+
+def wiki_table_row_widths(table: str) -> list[int]:
+    """Count the cells of each row, honouring multi-line cell content."""
+    widths: list[int] = []
+    current = 0
+    for line in mask_protected_pipes(table).splitlines()[1:-1]:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("|+"):
+            continue
+        if stripped.startswith("|-"):
+            if current:
+                widths.append(current)
+                current = 0
+        elif stripped.startswith("!"):
+            # Structural width counts every cell, including empty ones —
+            # an empty corner header is still a rendered column.
+            current += len(re.split(r"!!", stripped[1:]))
+        elif stripped.startswith("|") and not stripped.startswith("|}"):
+            current += len(re.split(r"\|\|", stripped[1:]))
+    if current:
+        widths.append(current)
+    return widths
+
+
+def preprocess_mediawiki_spanned_tables(source: str) -> str:
+    """Keep every column of tables that use colspan/rowspan.
+
+    Most affected tables only use a single full-width colspan header as a
+    visual title; converting that row to a MediaWiki caption lets Pandoc
+    parse the rest of the table correctly. Tables with any remaining span
+    are converted to plain HTML tables instead.
+    """
+    title_row = re.compile(
+        r"^\{\|(?P<table_start>[^\n]*)\n"
+        r"(?P<separator>\|-[^\n]*\n)?"
+        r'!\s*colspan\s*=\s*"?\d+"?[^|\n]*\|\s*(?P<title>[^\n]*)\n',
+        re.MULTILINE,
+    )
+
+    def to_caption(match: "re.Match[str]") -> str:
+        title = match.group("title").strip()
+        return "{|" + match.group("table_start") + "\n|+ " + title + "\n"
+
+    tables: dict[str, str] = {}
+
+    def transform_table(match: "re.Match[str]") -> str:
+        table = match.group(0)
+        widths = wiki_table_row_widths(table)
+        # Pandoc locks the column count to the first row and silently drops
+        # the extra cells of any wider row, whether the mismatch comes from
+        # colspan/rowspan markup or from a header that is simply narrower
+        # than the data rows (jgm/pandoc#1696).
+        ragged = bool(widths) and max(widths) > widths[0]
+        if not SPAN_ATTRIBUTE.search(table) and not ragged:
+            # Pipes inside inline code split cells on some Pandoc versions
+            # (2.9 drops whole tables of BIP 150); the entity renders the
+            # same and parses identically everywhere.
+            return mask_protected_pipes(table)
+        table = title_row.sub(to_caption, table, count=1)
+        widths = wiki_table_row_widths(table)
+        ragged = bool(widths) and max(widths) > widths[0]
+        if not SPAN_ATTRIBUTE.search(table) and not ragged:
+            return mask_protected_pipes(table)
+        # Protect the converted table from Pandoc entirely: its HTML reader
+        # drops rowspan attributes when rebalancing rows, so the finished
+        # table is substituted back after HTML normalization.
+        token = f"BIPSPANTABLETOKEN{len(tables)}"
+        # Apply the same unknown-tag escaping the rest of the document gets,
+        # so placeholders such as <keytype> stay visible as text.
+        tables[token] = escape_unknown_html_tags(wiki_table_to_html(table))
+        return token
+
+    source = re.sub(
+        r"^\{\|.*?^\|\}", transform_table, source, flags=re.MULTILINE | re.DOTALL
+    )
+    return source, tables
+
+
+def restore_spanned_tables(rendered: str, tables: dict[str, str]) -> str:
+    """Substitute protected span tables back after Pandoc normalization."""
+    for token, markup in tables.items():
+        rendered = rendered.replace(f"<p>{token}</p>", markup)
+        rendered = rendered.replace(token, markup)
+    return rendered
 
 
 def preprocess_mediawiki_blocks(source: str) -> str:
@@ -427,6 +650,81 @@ def reference_name(attributes: str) -> str | None:
     return next((value for value in match.groups() if value), None) if match else None
 
 
+REF_TOKEN = re.compile(
+    r"<ref(?P<self_attributes>\s[^>]*?)?\s*/>"
+    r"|<ref(?P<open_attributes>\s[^>]*)?>"
+    r"|</ref\s*>",
+    re.IGNORECASE,
+)
+
+
+def find_reference_spans(source: str) -> list[dict]:
+    """Locate top-level <ref> elements with balanced tag matching.
+
+    The previous non-greedy regex paired an outer opening tag with the first
+    closing tag it met, so a nested <ref>…</ref> scrambled the surrounding
+    text (BIP 324) or broke newer Pandoc on the orphaned closer. A depth
+    counter pairs each opener with its own closer instead; stray closers are
+    consumed silently and an unterminated opener is treated as literal text.
+    """
+    spans: list[dict] = []
+    depth = 0
+    current: dict | None = None
+    for token in REF_TOKEN.finditer(source):
+        text = token.group(0)
+        if text.lower().startswith("</"):
+            if depth == 0:
+                continue
+            depth -= 1
+            if depth == 0 and current is not None:
+                current["end"] = token.end()
+                current["content"] = source[current["content_start"] : token.start()]
+                spans.append(current)
+                current = None
+        elif token.group("self_attributes") is not None or text.rstrip().endswith("/>"):
+            if depth == 0:
+                spans.append(
+                    {
+                        "start": token.start(),
+                        "end": token.end(),
+                        "attributes": token.group("self_attributes") or "",
+                        "content": "",
+                    }
+                )
+        else:
+            if depth == 0:
+                current = {
+                    "start": token.start(),
+                    "content_start": token.end(),
+                    "attributes": token.group("open_attributes") or "",
+                }
+            depth += 1
+    return spans
+
+
+def convert_note_blocks(content: str) -> str:
+    """Make block-level MediaWiki markup survive inside a raw-HTML note.
+
+    Note bodies are emitted inside a raw <div>, where Pandoc no longer
+    parses MediaWiki block syntax: tables vanished entirely (BIP 85) and
+    indented code blocks collapsed into run-on text. Convert both to HTML
+    here instead.
+    """
+    content = re.sub(
+        r"^\{\|.*?^\|\}",
+        lambda match: wiki_table_to_html(match.group(0)),
+        content,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+    def to_pre(match: re.Match[str]) -> str:
+        lines = [line[1:] for line in match.group(0).splitlines()]
+        return "<pre>" + html.escape("\n".join(lines), quote=False) + "</pre>"
+
+    content = re.sub(r"(?:^ \S[^\n]*\n?)+", to_pre, content, flags=re.MULTILINE)
+    return content
+
+
 def preprocess_mediawiki_references(source: str) -> str:
     """Replace MediaWiki references before Pandoc sees nested list markup.
 
@@ -441,51 +739,70 @@ def preprocess_mediawiki_references(source: str) -> str:
         r"|<ref(?P<short_attributes>\s[^>]*)?\s*/>",
         re.IGNORECASE | re.DOTALL,
     )
-    matches = list(reference_pattern.finditer(source))
+    matches = find_reference_spans(source)
     if not matches:
         return re.sub(r"<references\b[^>]*>", "", source, flags=re.IGNORECASE)
 
     named_content: dict[str, str] = {}
-    for match in matches:
-        attributes = match.group("full_attributes") or match.group("short_attributes") or ""
-        name = reference_name(attributes)
-        content = (match.group("content") or "").strip()
-        if name and content and name not in named_content:
-            named_content[name] = content
+
+    def collect_names(spans: list[dict]) -> None:
+        for span in spans:
+            name = reference_name(span["attributes"])
+            content = span["content"].strip()
+            if name and content and name not in named_content:
+                named_content[name] = content
+            if content:
+                collect_names(find_reference_spans(content))
+
+    collect_names(matches)
 
     notes: list[dict[str, object]] = []
     named_notes: dict[str, dict[str, object]] = {}
     output: list[str] = []
     cursor = 0
 
-    for match in matches:
-        output.append(source[cursor : match.start()])
-        attributes = match.group("full_attributes") or match.group("short_attributes") or ""
+    def marker_for(attributes: str, content: str) -> str:
         name = reference_name(attributes)
-        content = (match.group("content") or "").strip()
-
+        content = content.strip()
         note = named_notes.get(name) if name else None
         if note is None:
             if not content and name:
                 content = named_content.get(name, "")
+            # Reserve the number before recursing so notes are numbered in
+            # reading order even when references nest.
+            note = {"number": len(notes) + 1, "content": "", "uses": 0}
+            notes.append(note)
+            if name:
+                named_notes[name] = note
             if not content:
                 # Preserve a visible marker rather than silently inventing text
                 # for a malformed upstream reference.
                 content = "Reference text is not available in the source document."
-            note = {"number": len(notes) + 1, "content": content, "uses": 0}
-            notes.append(note)
-            if name:
-                named_notes[name] = note
-
+            else:
+                content = convert_note_blocks(replace_spans(content))
+            note["content"] = content
         note["uses"] = int(note["uses"]) + 1
         number = int(note["number"])
         use = int(note["uses"])
-        output.append(
+        return (
             f'<sup><span id="bip-ref-{number}-{use}"></span>'
             f'&#91;[[#bip-note-{number}|{number}]]&#93;</sup>'
         )
-        cursor = match.end()
 
+    def replace_spans(text: str) -> str:
+        pieces: list[str] = []
+        position = 0
+        for span in find_reference_spans(text):
+            pieces.append(text[position : span["start"]])
+            pieces.append(marker_for(span["attributes"], span["content"]))
+            position = span["end"]
+        pieces.append(text[position:])
+        return "".join(pieces)
+
+    for match in matches:
+        output.append(source[cursor : match["start"]])
+        output.append(marker_for(match["attributes"], match["content"]))
+        cursor = match["end"]
     output.append(source[cursor:])
     processed = "".join(output)
 
@@ -507,7 +824,8 @@ def preprocess_mediawiki_references(source: str) -> str:
         processed = references_pattern.sub("", processed)
     else:
         processed += "\n\n==Footnotes==\n\n" + notes_markup
-    return processed
+    # A stray closer with no matching opener would abort newer Pandoc.
+    return re.sub(r"</ref\s*>", "", processed, flags=re.IGNORECASE)
 
 
 def escape_unknown_html_tags(rendered: str) -> str:
@@ -749,6 +1067,58 @@ def rewrite_links(
 
     rendered = re.sub(r"<img\b[^>]*>", add_image_alt, rendered, flags=re.IGNORECASE)
     return rendered
+
+
+MASKED_INLINE = re.compile(
+    r"<(code|tt|nowiki)\b[^>]*>.*?</\1\s*>", re.IGNORECASE | re.DOTALL
+)
+STRIPPED_BLOCKS = re.compile(
+    r"<!--.*?-->|<pre\b[^>]*>.*?</pre\s*>", re.IGNORECASE | re.DOTALL
+)
+
+
+def count_source_table_cells(body: str) -> int:
+    """Count the table cells a faithful rendering of this document must show.
+
+    Comments and literal <pre> examples are excluded; pipes inside inline
+    code are masked so an || operator is not miscounted as a cell separator.
+    The count is a lower bound: renderers may add padding cells but must
+    never drop content cells.
+    """
+    body = STRIPPED_BLOCKS.sub(" ", body)
+    body = MASKED_INLINE.sub(lambda match: match.group(0).replace("|", " "), body)
+    cells = 0
+    for table in re.finditer(r"^\{\|.*?^\|\}", body, re.MULTILINE | re.DOTALL):
+        for line in table.group(0).splitlines():
+            line = line.strip()
+            if not line or line.startswith(("{|", "|}", "|-", "|+")):
+                continue
+            if line.startswith("!"):
+                # A lone full-width colspan header is rendered as a table
+                # caption, not as a cell, so it is excluded from the bound.
+                if re.match(r"!\s*colspan\s*=", line) and "!!" not in line:
+                    continue
+                parts = re.split(r"!!", line[1:])
+            elif line.startswith("|"):
+                parts = re.split(r"\|\|", line[1:])
+            else:
+                continue
+            # Empty cells (upstream double-separator typos) are not required.
+            cells += sum(1 for part in parts if part.strip())
+    return cells
+
+
+def validate_table_cell_parity(bip: "Bip") -> None:
+    """Fail the build if rendering lost table cells (see jgm/pandoc#1696)."""
+    expected = count_source_table_cells(bip.body)
+    if not expected:
+        return
+    rendered = len(re.findall(r"<t[dh]\b", bip.rendered_html))
+    if rendered < expected:
+        raise BuildError(
+            f"Table cells lost in {bip.filename}: the source contains "
+            f"{expected} cells but only {rendered} were rendered"
+        )
 
 
 def validate_rendered_html(rendered: str, context: str) -> None:
@@ -1042,6 +1412,7 @@ def build(
         print("BIPs disabled")
         return
 
+    ensure_pandoc_version()
     source_root, commit = ensure_source(config, explicit_source)
     tracked_files = tracked_source_files(source_root)
     source_paths = sorted(
@@ -1069,6 +1440,7 @@ def build(
         rendered = render_with_pandoc(bip, source_root)
         rendered = escape_unknown_html_tags(rendered)
         rendered = normalize_html_with_pandoc(rendered, source_root)
+        rendered = restore_spanned_tables(rendered, bip.span_tables)
         rendered = wrap_document_tables(rendered)
         rendered = normalize_ids(rendered)
         validate_rendered_html(rendered, bip.filename)
@@ -1086,6 +1458,7 @@ def build(
             identifiers_by_bip,
         )
         validate_rendered_html(bip.rendered_html, bip.filename)
+        validate_table_cell_parity(bip)
         bip.description = description_for(bip)
 
     for index, bip in enumerate(bips):

--- a/_build/generate_bips.py
+++ b/_build/generate_bips.py
@@ -671,7 +671,7 @@ def rewrite_links(
             return f'{attribute}="{fragment}"'
 
         if url in {"README.mediawiki", "./README.mediawiki"}:
-            return f'{attribute}="/bip/"'
+            return f'{attribute}="/bips/"'
 
         auxiliary_match = auxiliary.fullmatch(url)
         if auxiliary_match:
@@ -981,8 +981,8 @@ def write_index(output_root: Path, bips: list[Bip], commit: str) -> None:
                 "Browse Bitcoin Improvement Proposals by number, title, type and "
                 "current repository status."
             ),
-            f"canonical_url: {yaml_value('https://bitcoin.org/bip/')}",
-            f"permalink: {yaml_value('/bip/')}",
+            f"canonical_url: {yaml_value('https://bitcoin.org/bips/')}",
+            f"permalink: {yaml_value('/bips/')}",
             f"bip_count: {len(bips)}",
             f"bip_source_commit: {yaml_value(commit)}",
             "---",
@@ -1155,7 +1155,8 @@ def check_output(config_path: Path, output_root: Path) -> None:
             f"Found {len(pages)} rendered BIP pages in {output_root}; "
             f"expected {expected_bip_count}"
         )
-    if not (output_root / "index.html").is_file() or not (output_root / "110" / "index.html").is_file():
+    index_page = output_root.parent / "bips" / "index.html"
+    if not index_page.is_file() or not (output_root / "110" / "index.html").is_file():
         raise BuildError("The BIP index or BIP 110 page was not rendered")
 
     inspectors: dict[int, OutputInspector] = {}

--- a/_build/generate_bips.py
+++ b/_build/generate_bips.py
@@ -1,0 +1,1235 @@
+#!/usr/bin/env python3
+
+# This file is licensed under the MIT License (MIT) available on
+# https://opensource.org/licenses/MIT.
+
+"""Build static, styled HTML pages from a pinned bitcoin/bips revision."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import dataclasses
+import html
+from html.parser import HTMLParser
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+from typing import Iterable
+from urllib.parse import quote, unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = ROOT / "_build" / "bips-source.json"
+IMAGE_EXTENSIONS = {".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"}
+REQUIRED_HEADERS = {"BIP", "Authors", "Assigned", "Status", "Title", "Type"}
+UNSAFE_HTML = re.compile(
+    r"<\s*(?:base|embed|form|iframe|input|link|meta|object|script|style)(?=[\s/>])"
+    r"|\s+on[a-z]+\s*="
+    r"|\s+(?:href|src)\s*=\s*['\"]\s*(?:data|javascript):",
+    re.IGNORECASE,
+)
+UNSAFE_SVG = re.compile(
+    r"<\s*(?:foreignObject|iframe|script)(?=[\s/>])"
+    r"|\s+on[a-z]+\s*="
+    r"|\s+(?:href|xlink:href)\s*=\s*['\"]\s*(?:data|javascript|https?):",
+    re.IGNORECASE,
+)
+
+STANDARD_HTML_TAGS = {
+    "a", "abbr", "aside", "b", "big", "blockquote", "br", "caption",
+    "center", "cite", "code", "col", "colgroup", "dd", "del", "details",
+    "div", "dl", "dt", "em", "figcaption", "figure", "font", "h1", "h2",
+    "h3", "h4", "h5", "h6", "hr", "i", "img", "kbd", "li", "mark",
+    "ol", "p", "pre", "q", "s", "samp", "section", "small", "span",
+    "strike", "strong", "sub", "summary", "sup", "table", "tbody", "td",
+    "tfoot", "th", "thead", "tr", "tt", "u", "ul", "var",
+}
+
+# A few upstream documents contain historical fragment names which no longer
+# match their target headings. Keep those links useful without modifying the
+# canonical BIP text.
+LEGACY_FRAGMENT_ALIASES = {
+    23: {"block-proposals": "block-proposal"},
+    36: {"variable-length-string": "specification"},
+    94: {"time-warp-fix": "3-time-warp-attack-prevention"},
+}
+
+
+class BuildError(RuntimeError):
+    """A deterministic BIP build failure."""
+
+
+@dataclasses.dataclass
+class Bip:
+    number: int
+    filename: str
+    source_path: Path
+    source_format: str
+    headers: dict[str, str]
+    body: str
+    rendered_html: str = ""
+    description: str = ""
+
+    @property
+    def title(self) -> str:
+        return self.headers["Title"]
+
+    @property
+    def status(self) -> str:
+        return self.headers["Status"]
+
+    @property
+    def status_slug(self) -> str:
+        return slug(self.status)
+
+    @property
+    def type_slug(self) -> str:
+        return slug(self.headers["Type"])
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def load_config(path: Path) -> dict[str, object]:
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BuildError(f"Unable to read BIP source configuration {path}: {exc}") from exc
+
+    commit = str(config.get("commit", ""))
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise BuildError("The configured BIP commit must be a full 40-character SHA-1")
+    if str(config.get("repository", "")) not in {
+        "https://github.com/bitcoin/bips",
+        "https://github.com/bitcoin/bips.git",
+    }:
+        raise BuildError("The BIP repository must be the bitcoin/bips HTTPS repository")
+    for key in ("expected_bip_count", "expected_image_asset_count"):
+        try:
+            value = int(config[key])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BuildError(f"The BIP source configuration requires an integer {key}") from exc
+        if value < 1:
+            raise BuildError(f"The BIP source configuration requires a positive {key}")
+    return config
+
+
+def run(command: list[str], cwd: Path | None = None, input_text: str | None = None) -> str:
+    try:
+        process = subprocess.run(
+            command,
+            cwd=cwd,
+            input=input_text,
+            text=True,
+            encoding="utf-8",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise BuildError(f"Required command not found: {command[0]}") from exc
+
+    if process.returncode != 0:
+        detail = process.stderr.strip() or process.stdout.strip() or "unknown error"
+        raise BuildError(f"Command failed ({' '.join(command)}): {detail}")
+    if process.stderr.strip():
+        print(process.stderr.strip(), file=sys.stderr)
+    return process.stdout.strip()
+
+
+def ensure_source(config: dict[str, object], explicit_source: Path | None = None) -> tuple[Path, str]:
+    expected_commit = str(config["commit"])
+    environment_source = os.environ.get("BIPS_SOURCE_DIR")
+    source = explicit_source or (Path(environment_source) if environment_source else None)
+
+    if source is not None:
+        source = source.expanduser().resolve()
+        if not (source / ".git").exists() or not (source / "README.mediawiki").is_file():
+            raise BuildError(f"BIPS_SOURCE_DIR is not a bitcoin/bips checkout: {source}")
+        actual_commit = run(["git", "rev-parse", "HEAD"], cwd=source)
+        if actual_commit != expected_commit:
+            raise BuildError(
+                f"BIPS_SOURCE_DIR is at {actual_commit}, but {expected_commit} is pinned"
+            )
+        return source, actual_commit
+
+    cache = ROOT / str(config["cache_directory"])
+    repository = str(config["repository"])
+    cache.parent.mkdir(parents=True, exist_ok=True)
+
+    if cache.exists() and not (cache / ".git").exists():
+        shutil.rmtree(cache)
+    if not cache.exists():
+        cache.mkdir()
+        run(["git", "init", "--quiet"], cwd=cache)
+        run(["git", "remote", "add", "origin", repository], cwd=cache)
+    else:
+        remotes = run(["git", "remote"], cwd=cache).splitlines()
+        if "origin" not in remotes:
+            run(["git", "remote", "add", "origin", repository], cwd=cache)
+        else:
+            run(["git", "remote", "set-url", "origin", repository], cwd=cache)
+
+    try:
+        actual_commit = run(["git", "rev-parse", "HEAD"], cwd=cache)
+    except BuildError:
+        actual_commit = ""
+
+    if actual_commit != expected_commit:
+        run(["git", "fetch", "--depth", "1", "origin", expected_commit], cwd=cache)
+        run(["git", "checkout", "--detach", "--force", "FETCH_HEAD"], cwd=cache)
+
+    actual_commit = run(["git", "rev-parse", "HEAD"], cwd=cache)
+    if actual_commit != expected_commit:
+        raise BuildError(f"Fetched BIP revision {actual_commit}; expected {expected_commit}")
+    return cache, actual_commit
+
+
+def tracked_source_files(source_root: Path) -> list[Path]:
+    """Return only files committed in the pinned repository revision."""
+
+    names = run(["git", "ls-files", "-z"], cwd=source_root).split("\0")
+    return [source_root / name for name in names if name]
+
+
+def header_blocks(text: str, source_format: str) -> Iterable[re.Match[str]]:
+    if source_format == "mediawiki":
+        return re.finditer(r"<pre>\s*\n(?P<header>.*?)\n</pre>", text, re.DOTALL)
+    return re.finditer(r"```[^\n]*\n(?P<header>.*?)\n```", text, re.DOTALL)
+
+
+def parse_header_lines(raw_header: str) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    current_key: str | None = None
+
+    for raw_line in raw_header.splitlines():
+        match = re.match(r"^\s{2}([A-Za-z][A-Za-z-]*):\s*(.*)$", raw_line)
+        if match:
+            current_key = match.group(1)
+            if current_key in headers:
+                raise BuildError(f"Duplicate BIP header: {current_key}")
+            headers[current_key] = match.group(2).strip()
+            continue
+        if current_key and re.match(r"^\s{3,}\S", raw_line):
+            headers[current_key] += "\n" + raw_line.strip()
+            continue
+        if raw_line.strip():
+            raise BuildError(f"Invalid BIP header line: {raw_line!r}")
+
+    missing = sorted(REQUIRED_HEADERS - set(headers))
+    if missing:
+        raise BuildError(f"Missing required BIP headers: {', '.join(missing)}")
+    return headers
+
+
+def parse_bip(path: Path) -> Bip:
+    source_format = "mediawiki" if path.suffix == ".mediawiki" else "markdown"
+    text = path.read_text(encoding="utf-8-sig")
+    selected: re.Match[str] | None = None
+
+    for block in header_blocks(text, source_format):
+        if re.search(r"^\s*BIP:\s*\d+\s*$", block.group("header"), re.MULTILINE):
+            selected = block
+            break
+    if selected is None:
+        raise BuildError(f"No RFC 822 BIP header found in {path.name}")
+
+    headers = parse_header_lines(selected.group("header"))
+    number = int(headers["BIP"])
+    filename_match = re.fullmatch(r"bip-(\d{4})\.(?:mediawiki|md)", path.name)
+    if filename_match is None or int(filename_match.group(1)) != number:
+        raise BuildError(f"BIP number does not match filename: {path.name}")
+
+    body = (text[: selected.start()].rstrip() + "\n\n" + text[selected.end() :].lstrip()).strip()
+    return Bip(
+        number=number,
+        filename=path.name,
+        source_path=path,
+        source_format=source_format,
+        headers=headers,
+        body=body,
+    )
+
+
+def render_with_pandoc(bip: Bip, source_root: Path) -> str:
+    body = (
+        preprocess_mediawiki_references(
+            preprocess_mediawiki_blocks(preprocess_mediawiki_files(bip.body))
+        )
+        if bip.source_format == "mediawiki"
+        else normalize_markdown_footnotes(bip.body)
+    )
+    input_format = "mediawiki+gfm_auto_identifiers" if bip.source_format == "mediawiki" else "gfm"
+    output = run(
+        [
+            "pandoc",
+            f"--from={input_format}",
+            "--to=html5",
+            "--wrap=none",
+            "--strip-comments",
+        ],
+        cwd=source_root,
+        input_text=body,
+    )
+    return output + "\n"
+
+
+def normalize_html_with_pandoc(rendered: str, source_root: Path) -> str:
+    """Reparse rendered fragments so malformed legacy inline HTML is balanced."""
+
+    output = run(
+        ["pandoc", "--from=html", "--to=html5", "--wrap=none"],
+        cwd=source_root,
+        input_text=rendered,
+    )
+    return output + "\n"
+
+
+def wrap_document_tables(rendered: str) -> str:
+    """Give wide protocol tables a keyboard- and touch-scrollable container."""
+
+    wrapper = (
+        '<div class="bip-table-wrap" tabindex="0" role="region" '
+        'aria-label="Scrollable BIP table">'
+    )
+    output: list[str] = []
+    cursor = 0
+    depth = 0
+
+    for match in re.finditer(r"</?table\b[^>]*>", rendered, re.IGNORECASE):
+        output.append(rendered[cursor : match.start()])
+        tag = match.group(0)
+        closing = tag.lstrip().startswith("</")
+        if not closing:
+            if depth == 0:
+                output.append(wrapper)
+            depth += 1
+            output.append(tag)
+        else:
+            output.append(tag)
+            depth -= 1
+            if depth == 0:
+                output.append("</div>")
+        cursor = match.end()
+
+    output.append(rendered[cursor:])
+    if depth != 0:
+        raise BuildError("Unbalanced table markup after HTML normalization")
+    return "".join(output)
+
+
+def preprocess_mediawiki_blocks(source: str) -> str:
+    """Replace extension-only block tags with standards-compliant HTML."""
+
+    source = re.sub(
+        r"<poem\b[^>]*>", '<div class="bip-poem">', source, flags=re.IGNORECASE
+    )
+    return re.sub(r"</poem\s*>", "</div>", source, flags=re.IGNORECASE)
+
+
+def preprocess_mediawiki_files(source: str) -> str:
+    """Turn MediaWiki File links into portable HTML figures."""
+
+    pattern = re.compile(
+        r"^[ \t]*(?::+[ \t]*)?\[\[File:(?P<path>bip-\d{4}/[^|\]]+)"
+        r"(?P<options>(?:\|[^\]]*)?)\]\][ \t]*(?P<trailing>[^\n]*)"
+        r"(?:\n(?P<following_line>[^\n]+))?$",
+        re.IGNORECASE | re.MULTILINE,
+    )
+
+    def replace_file(match: re.Match[str]) -> str:
+        path = match.group("path").strip()
+        options = [part.strip() for part in match.group("options").split("|") if part.strip()]
+        trailing = match.group("trailing").strip()
+        following_line = (match.group("following_line") or "").strip()
+        controls = {"border", "center", "frame", "framed", "left", "right", "thumb", "thumbnail"}
+        explicit_alt = next(
+            (part.split("=", 1)[1].strip() for part in options if part.lower().startswith("alt=")),
+            "",
+        )
+        caption_options = [
+            part for part in options
+            if part.lower() not in controls
+            and not part.lower().startswith(("alt=", "link=", "page=", "upright="))
+            and not re.fullmatch(r"\d+(?:x\d+)?px", part, re.IGNORECASE)
+        ]
+        option_caption = caption_options[-1] if caption_options else ""
+        following_caption = ""
+        append_following = ""
+        if following_line.startswith(":"):
+            following_caption = following_line.lstrip(": ")
+        elif following_line and following_line == option_caption:
+            following_caption = following_line
+        elif following_line:
+            append_following = "\n" + following_line
+
+        caption = trailing or following_caption or option_caption
+        alt_text = re.sub(r"'{2,}", "", re.sub(r"<[^>]+>", "", caption))
+        alt = explicit_alt or alt_text or "BIP illustration"
+        escaped_path = html.escape(path, quote=True)
+        figure = (
+            f'<figure class="bip-figure"><a href="{escaped_path}">'
+            f'<img src="{escaped_path}" alt="{html.escape(alt, quote=True)}"></a>'
+        )
+        if caption:
+            caption_markup = caption if following_caption else html.escape(caption)
+            figure += f"<figcaption>{caption_markup}</figcaption>"
+        return figure + "</figure>" + append_following
+
+    return pattern.sub(replace_file, source)
+
+
+def normalize_markdown_footnotes(source: str) -> str:
+    """Indent unindented continuation lines in GFM footnote definitions.
+
+    A small number of BIPs use visually wrapped footnote definitions without
+    Markdown's required four-space continuation indent. GitHub displays these
+    as intended, but Pandoc otherwise truncates each note at its first line.
+    """
+
+    lines = source.splitlines()
+    normalized: list[str] = []
+    in_footnote = False
+
+    for line in lines:
+        if re.match(r"^\[\^[^]]+\]:", line):
+            in_footnote = True
+            normalized.append(line)
+            continue
+        if in_footnote and not line.strip():
+            in_footnote = False
+            normalized.append(line)
+            continue
+        if in_footnote and re.match(r"^\[[^]^]+\]:", line):
+            in_footnote = False
+        if in_footnote and line and not line.startswith((" ", "\t")):
+            normalized.append("    " + line)
+        else:
+            normalized.append(line)
+
+    trailing_newline = "\n" if source.endswith("\n") else ""
+    return "\n".join(normalized) + trailing_newline
+
+
+def reference_name(attributes: str) -> str | None:
+    match = re.search(
+        r"\bname\s*=?\s*(?:\"([^\"]+)\"|'([^']+)'|([^\s>]+))",
+        attributes,
+        re.IGNORECASE,
+    )
+    return next((value for value in match.groups() if value), None) if match else None
+
+
+def preprocess_mediawiki_references(source: str) -> str:
+    """Replace MediaWiki references before Pandoc sees nested list markup.
+
+    Pandoc understands simple <ref> elements, but can leave malformed DOM when
+    a reference appears inside a nested MediaWiki list. BIPs use references
+    heavily in exactly that way, so convert them to ordinary anchors and a
+    notes list first.
+    """
+
+    reference_pattern = re.compile(
+        r"<ref(?P<full_attributes>\s[^>]*)?>(?P<content>.*?)</ref\s*>"
+        r"|<ref(?P<short_attributes>\s[^>]*)?\s*/>",
+        re.IGNORECASE | re.DOTALL,
+    )
+    matches = list(reference_pattern.finditer(source))
+    if not matches:
+        return re.sub(r"<references\b[^>]*>", "", source, flags=re.IGNORECASE)
+
+    named_content: dict[str, str] = {}
+    for match in matches:
+        attributes = match.group("full_attributes") or match.group("short_attributes") or ""
+        name = reference_name(attributes)
+        content = (match.group("content") or "").strip()
+        if name and content and name not in named_content:
+            named_content[name] = content
+
+    notes: list[dict[str, object]] = []
+    named_notes: dict[str, dict[str, object]] = {}
+    output: list[str] = []
+    cursor = 0
+
+    for match in matches:
+        output.append(source[cursor : match.start()])
+        attributes = match.group("full_attributes") or match.group("short_attributes") or ""
+        name = reference_name(attributes)
+        content = (match.group("content") or "").strip()
+
+        note = named_notes.get(name) if name else None
+        if note is None:
+            if not content and name:
+                content = named_content.get(name, "")
+            if not content:
+                # Preserve a visible marker rather than silently inventing text
+                # for a malformed upstream reference.
+                content = "Reference text is not available in the source document."
+            note = {"number": len(notes) + 1, "content": content, "uses": 0}
+            notes.append(note)
+            if name:
+                named_notes[name] = note
+
+        note["uses"] = int(note["uses"]) + 1
+        number = int(note["number"])
+        use = int(note["uses"])
+        output.append(
+            f'<sup><span id="bip-ref-{number}-{use}"></span>'
+            f'&#91;[[#bip-note-{number}|{number}]]&#93;</sup>'
+        )
+        cursor = match.end()
+
+    output.append(source[cursor:])
+    processed = "".join(output)
+
+    note_items = []
+    for note in notes:
+        number = int(note["number"])
+        backlinks = " ".join(
+            f'[[#bip-ref-{number}-{use}|↩]]' for use in range(1, int(note["uses"]) + 1)
+        )
+        note_items.append(
+            f'<li><span id="bip-note-{number}"></span><div>{note["content"]}</div>'
+            f'<span class="bip-note-backlinks">{backlinks}</span></li>'
+        )
+    notes_markup = '<div class="bip-footnotes"><ol>' + "".join(note_items) + "</ol></div>"
+
+    references_pattern = re.compile(r"<references\b[^>]*>", re.IGNORECASE)
+    if references_pattern.search(processed):
+        processed = references_pattern.sub(notes_markup, processed, count=1)
+        processed = references_pattern.sub("", processed)
+    else:
+        processed += "\n\n==Footnotes==\n\n" + notes_markup
+    return processed
+
+
+def escape_unknown_html_tags(rendered: str) -> str:
+    """Show BIP placeholders such as <pubkey> instead of creating DOM tags."""
+
+    def replace_tag(match: re.Match[str]) -> str:
+        tag = match.group(2).lower()
+        if tag in STANDARD_HTML_TAGS:
+            return match.group(0)
+        if tag == "nowiki":
+            return ""
+        if tag == "poem":
+            return "</div>" if match.group(1) else '<div class="bip-poem">'
+        if tag in {"ref", "references"}:
+            return ""
+        return html.escape(match.group(0), quote=False)
+
+    return re.sub(r"<\s*(/?)\s*([A-Za-z][A-Za-z0-9:-]*)(?:\s[^<>]*?)?/?>", replace_tag, rendered)
+
+
+def normalize_ids(rendered: str) -> str:
+    # Many MediaWiki BIPs add a manual span before a heading to obtain the
+    # same GitHub-style anchor Pandoc now creates. Keep one ID, not two.
+    rendered = re.sub(
+        r"<p><span id=\"([^\"]+)\"></span></p>\s*(<h[1-6] id=\"\1\">)",
+        r"\2",
+        rendered,
+    )
+
+    def remove_nested_span(match: re.Match[str]) -> str:
+        opening, heading_id = match.group(1), match.group(2)
+        return opening if match.group(3) == heading_id else match.group(0)
+
+    rendered = re.sub(
+        r"(<h[1-6] id=\"([^\"]+)\">)\s*<span id=\"([^\"]+)\"></span>",
+        remove_nested_span,
+        rendered,
+    )
+
+    used: set[str] = set()
+
+    def unique_id(match: re.Match[str]) -> str:
+        original = html.unescape(match.group(1)).replace("_", " ")
+        base = slug(original) or "section"
+        value = base
+        suffix = 1
+        while value in used:
+            suffix += 1
+            value = f"{base}-{suffix}"
+        used.add(value)
+        return f'id="{value}"'
+
+    return re.sub(r'id="([^"]+)"', unique_id, rendered)
+
+
+def github_path_url(source_root: Path, relative: str, commit: str) -> str:
+    clean = relative.removeprefix("./").split("#", 1)[0]
+    fragment = relative[len(relative.split("#", 1)[0]) :]
+    candidate = source_root / clean
+    action = "tree" if candidate.is_dir() or clean.endswith("/") else "blob"
+    return f"https://github.com/bitcoin/bips/{action}/{commit}/{quote(clean, safe='/')}" + fragment
+
+
+def resolve_fragment(fragment: str, target_ids: set[str], target_number: int) -> str:
+    if not fragment:
+        return ""
+
+    identifier = unquote(fragment.removeprefix("#")).split("|", 1)[0]
+    identifier = re.sub(r"^user-content-", "", identifier, flags=re.IGNORECASE)
+    normalized = slug(identifier.replace("_", " "))
+    alternatives = [
+        identifier,
+        identifier.replace("_", "-"),
+        normalized,
+    ]
+
+    legacy_reference = re.fullmatch(r"cite-ref-(\d+)-(\d+)", normalized)
+    if legacy_reference:
+        alternatives.append(
+            f"bip-ref-{legacy_reference.group(1)}-{int(legacy_reference.group(2)) + 1}"
+        )
+    legacy_note = re.fullmatch(r"cite-note-(\d+)(?:-\d+)?", normalized)
+    if legacy_note:
+        alternatives.append(f"bip-note-{legacy_note.group(1)}")
+
+    alias = LEGACY_FRAGMENT_ALIASES.get(target_number, {}).get(normalized)
+    if alias:
+        alternatives.append(alias)
+
+    for alternative in alternatives:
+        if alternative in target_ids:
+            return "#" + alternative
+
+    compact = re.sub(r"[^a-z0-9]", "", normalized)
+    compact_matches = [
+        target for target in target_ids
+        if re.sub(r"[^a-z0-9]", "", target) == compact
+    ]
+    if len(compact_matches) == 1:
+        return "#" + compact_matches[0]
+
+    singular_matches = [
+        target for target in target_ids
+        if re.sub(r"[^a-z0-9]", "", target).removesuffix("s") == compact.removesuffix("s")
+    ]
+    if len(singular_matches) == 1:
+        return "#" + singular_matches[0]
+    return fragment
+
+
+def rewrite_links(
+    rendered: str,
+    source_root: Path,
+    commit: str,
+    current_number: int,
+    identifiers_by_bip: dict[int, set[str]],
+) -> str:
+    main_relative = re.compile(r"^(?:\./)?bip-(\d{4})\.(?:mediawiki|md)(#[^\s]*)?$")
+    main_github = re.compile(
+        r"^https://github\.com/bitcoin/bips/blob/(?:master|[0-9a-f]{40})/"
+        r"bip-(\d{4})\.(?:mediawiki|md)(#[^\s]*)?$"
+    )
+    auxiliary = re.compile(r"^(?:\./)?(bip-(\d{4})(?:/(.*))?)$")
+
+    # Categories are MediaWiki metadata rather than page content. Also undo a
+    # MediaWiki-reader false positive where a literal "Message:\n" in source
+    # code is interpreted as a link.
+    rendered = re.sub(
+        r'<p>\s*<a\s+href="Category:[^"]+"[^>]*>.*?</a>\s*</p>',
+        "",
+        rendered,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    rendered = re.sub(
+        r'<a\s+href="Message:[^"]*"[^>]*>(.*?)</a>',
+        r"\1",
+        rendered,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+
+    def replace_attribute(match: re.Match[str]) -> str:
+        attribute = match.group(1)
+        url = next(value for value in match.groups()[1:] if value is not None)
+
+        main_match = main_relative.fullmatch(url) or main_github.fullmatch(url)
+        if main_match:
+            number = int(main_match.group(1))
+            if number not in identifiers_by_bip:
+                if url.startswith("https://"):
+                    return match.group(0)
+                return f'{attribute}="{github_path_url(source_root, url, commit)}"'
+            fragment = resolve_fragment(
+                main_match.group(2) or "", identifiers_by_bip[number], number
+            )
+            return f'{attribute}="/bip/{number}/{fragment}"'
+
+        if url.startswith("#"):
+            fragment = resolve_fragment(
+                url, identifiers_by_bip[current_number], current_number
+            )
+            return f'{attribute}="{fragment}"'
+
+        if url in {"README.mediawiki", "./README.mediawiki"}:
+            return f'{attribute}="/bip/"'
+
+        auxiliary_match = auxiliary.fullmatch(url)
+        if auxiliary_match:
+            relative, padded_number, remainder = auxiliary_match.groups()
+            extension = Path((remainder or "").split("#", 1)[0]).suffix.lower()
+            if extension in IMAGE_EXTENSIONS:
+                number = int(padded_number)
+                target = quote(str(remainder), safe="/#")
+                return f'{attribute}="/bip/{number}/assets/{target}"'
+            return f'{attribute}="{github_path_url(source_root, relative, commit)}"'
+
+        shorthand = re.fullmatch(r"BIP[_-]0*(\d+)", url, re.IGNORECASE)
+        if shorthand and int(shorthand.group(1)) in identifiers_by_bip:
+            return f'{attribute}="/bip/{int(shorthand.group(1))}/"'
+
+        if url.lower().startswith("bitcoin:"):
+            return f'{attribute}="bitcoin:{url.split(":", 1)[1]}"'
+
+        if re.fullmatch(r"bip-[A-Za-z0-9_-]+\.(?:mediawiki|md)(?:#.*)?", url):
+            return f'{attribute}="{github_path_url(source_root, url, commit)}"'
+
+        # Old MediaWiki page references are external to the BIP repository.
+        # Point them at the Bitcoin Wiki instead of creating broken relative
+        # links on bitcoin.org.
+        if attribute == "href" and not re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", url):
+            page, separator, fragment = url.partition("#")
+            wiki_page = quote(page.replace(" ", "_"), safe="_-.()")
+            wiki_fragment = "#" + quote(fragment, safe="_-.") if separator else ""
+            return f'{attribute}="https://en.bitcoin.it/wiki/{wiki_page}{wiki_fragment}"'
+
+        return match.group(0)
+
+    rendered = re.sub(
+        r"\b(href|src)=(?:\"([^\"]*)\"|'([^']*)'|([^\s>]+))",
+        replace_attribute,
+        rendered,
+        flags=re.IGNORECASE,
+    )
+
+    # Avoid making a visitor's browser contact an unrelated image host. The
+    # single current use is a licence badge; the linked licence remains.
+    def external_image_link(match: re.Match[str]) -> str:
+        tag = match.group(0)
+        source_match = re.search(r'\bsrc="(https?://[^"]+)"', tag, re.IGNORECASE)
+        alt_match = re.search(r'\balt="([^"]*)"', tag, re.IGNORECASE)
+        assert source_match is not None
+        label = alt_match.group(1).strip() if alt_match else "View externally hosted image"
+        if not label:
+            label = "View externally hosted image"
+        return f'<a class="bip-external-image" href="{source_match.group(1)}">{label}</a>'
+
+    rendered = re.sub(
+        r'<img\b(?=[^>]*\bsrc="https?://[^"]+")[^>]*>',
+        external_image_link,
+        rendered,
+        flags=re.IGNORECASE,
+    )
+    rendered = re.sub(
+        r"<img\b(?![^>]*\bloading=)",
+        '<img loading="lazy" decoding="async"',
+        rendered,
+        flags=re.IGNORECASE,
+    )
+    rendered = re.sub(r"</img\s*>", "", rendered, flags=re.IGNORECASE)
+
+    def add_image_alt(match: re.Match[str]) -> str:
+        tag = match.group(0)
+        if re.search(r"\balt=", tag, re.IGNORECASE):
+            return tag
+        source_match = re.search(r'\bsrc="([^"]+)"', tag, re.IGNORECASE)
+        filename = Path(source_match.group(1).split("?", 1)[0]).stem if source_match else "diagram"
+        label = re.sub(r"[_-]+", " ", unquote(filename)).strip() or "diagram"
+        alt = html.escape(f"BIP {current_number} illustration: {label}", quote=True)
+        return re.sub(r"\s*/?>$", lambda end: f' alt="{alt}"{end.group(0)}', tag)
+
+    rendered = re.sub(r"<img\b[^>]*>", add_image_alt, rendered, flags=re.IGNORECASE)
+    return rendered
+
+
+def validate_rendered_html(rendered: str, context: str) -> None:
+    unsafe = UNSAFE_HTML.search(rendered)
+    if unsafe:
+        raise BuildError(f"Unsafe HTML in {context}: {unsafe.group(0)!r}")
+    if "{% endraw %}" in rendered:
+        raise BuildError(f"Liquid raw-block terminator found in {context}")
+
+    identifiers = re.findall(r'\bid="([^"]+)"', rendered)
+    duplicates = [name for name, count in collections.Counter(identifiers).items() if count > 1]
+    if duplicates:
+        raise BuildError(f"Duplicate HTML IDs in {context}: {', '.join(duplicates[:10])}")
+
+
+class AbstractExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.in_h2 = False
+        self.h2_text: list[str] = []
+        self.after_abstract = False
+        self.in_paragraph = False
+        self.paragraph_text: list[str] = []
+        self.result = ""
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "h2" and not self.result:
+            self.in_h2 = True
+            self.h2_text = []
+        elif tag == "p" and self.after_abstract and not self.result:
+            self.in_paragraph = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "h2" and self.in_h2:
+            heading = " ".join(self.h2_text).strip().lower()
+            self.after_abstract = heading == "abstract"
+            self.in_h2 = False
+        elif tag == "p" and self.in_paragraph:
+            self.result = re.sub(r"\s+", " ", " ".join(self.paragraph_text)).strip()
+            self.in_paragraph = False
+
+    def handle_data(self, data: str) -> None:
+        if self.in_h2:
+            self.h2_text.append(data)
+        elif self.in_paragraph:
+            self.paragraph_text.append(data)
+
+
+def description_for(bip: Bip) -> str:
+    extractor = AbstractExtractor()
+    extractor.feed(bip.rendered_html)
+    prefix = f"BIP {bip.number}: {bip.title}."
+    description = f"{prefix} {extractor.result}" if extractor.result else prefix
+    return textwrap.shorten(description, width=220, placeholder="…")
+
+
+def parse_authors(raw: str) -> list[dict[str, str]]:
+    authors = []
+    for line in raw.splitlines():
+        match = re.fullmatch(r"(.+?)\s*<([^<>]+)>", line.strip())
+        if not match:
+            raise BuildError(f"Unable to parse BIP author: {line!r}")
+        authors.append({"name": match.group(1).strip(), "email": match.group(2).strip()})
+    return authors
+
+
+def parse_discussions(headers: dict[str, str]) -> list[dict[str, str]]:
+    discussions = []
+    for key in ("Discussion", "Comments-URI"):
+        for line in headers.get(key, "").splitlines():
+            match = re.search(r"https?://\S+", line)
+            if not match:
+                continue
+            url = match.group(0)
+            label = line[: match.start()].strip().rstrip(":") or key.replace("-", " ")
+            discussions.append({"label": label, "url": url})
+    return discussions
+
+
+def parse_bip_numbers(value: str) -> list[int]:
+    return [int(number) for number in re.findall(r"\b\d+\b", value)]
+
+
+def yaml_value(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def page_front_matter(bip: Bip, commit: str, previous: Bip | None, following: Bip | None) -> str:
+    headers = bip.headers
+    source_url = f"https://github.com/bitcoin/bips/blob/{commit}/{bip.filename}"
+    history_url = f"https://github.com/bitcoin/bips/commits/master/{bip.filename}"
+    values: list[tuple[str, object]] = [
+        ("layout", "bip"),
+        ("lang", "en"),
+        ("id", "bip"),
+        ("hide_language_selector", True),
+        ("title", f"BIP {bip.number}: {bip.title}"),
+        ("description", bip.description),
+        ("canonical_url", f"https://bitcoin.org/bip/{bip.number}/"),
+        ("permalink", f"/bip/{bip.number}/"),
+        ("bip_number", bip.number),
+        ("bip_title", bip.title),
+        ("bip_status", bip.status),
+        ("bip_status_slug", bip.status_slug),
+        ("bip_type", headers["Type"]),
+        ("bip_layer", headers.get("Layer", "")),
+        ("bip_assigned", headers["Assigned"]),
+        ("bip_version", headers.get("Version", "")),
+        ("bip_license", headers.get("License", "Not specified")),
+        ("bip_license_code", headers.get("License-Code", "")),
+        ("bip_authors", parse_authors(headers["Authors"])),
+        ("bip_discussions", parse_discussions(headers)),
+        ("bip_requires", parse_bip_numbers(headers.get("Requires", ""))),
+        ("bip_replaces", parse_bip_numbers(headers.get("Replaces", ""))),
+        ("bip_proposed_replacement", parse_bip_numbers(headers.get("Proposed-Replacement", ""))),
+        ("bip_source_url", source_url),
+        ("bip_history_url", history_url),
+        ("bip_source_commit", commit),
+        ("bip_previous", {"number": previous.number, "title": previous.title} if previous else None),
+        ("bip_next", {"number": following.number, "title": following.title} if following else None),
+    ]
+    lines = ["---"]
+    lines.extend(f"{key}: {yaml_value(value)}" for key, value in values)
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def write_bip_page(
+    output_root: Path,
+    bip: Bip,
+    commit: str,
+    previous: Bip | None,
+    following: Bip | None,
+) -> None:
+    destination = output_root / str(bip.number) / "index.html"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    front_matter = page_front_matter(bip, commit, previous, following)
+    generated_note = (
+        f"<!-- Generated from bitcoin/bips {commit}; the document retains "
+        f"its declared {bip.headers.get('License', 'source')} licence. -->"
+    )
+    destination.write_text(
+        f"{front_matter}\n{generated_note}\n{{% raw %}}\n"
+        f"{bip.rendered_html}{{% endraw %}}\n",
+        encoding="utf-8",
+    )
+
+
+def status_counts(bips: list[Bip]) -> collections.Counter[str]:
+    return collections.Counter(bip.status for bip in bips)
+
+
+def index_body(bips: list[Bip], commit: str) -> str:
+    counts = status_counts(bips)
+    status_options = "".join(
+        f'<option value="{slug(status)}">{html.escape(status)} ({count})</option>'
+        for status, count in sorted(counts.items())
+    )
+    rows = []
+    for bip in bips:
+        searchable = (
+            f"{bip.number} {bip.title} {bip.status} {bip.headers['Type']} "
+            f"{bip.headers.get('Layer', '')}"
+        ).lower()
+        rows.append(
+            f'<tr class="bip-index-row" data-search="{html.escape(searchable, quote=True)}" '
+            f'data-status="{bip.status_slug}" data-type="{bip.type_slug}">'
+            f'<td class="bip-index-number"><a href="/bip/{bip.number}/">BIP {bip.number}</a></td>'
+            f'<td class="bip-index-title"><a href="/bip/{bip.number}/">{html.escape(bip.title)}</a></td>'
+            f'<td>{html.escape(bip.headers["Type"])}</td>'
+            f'<td><span class="bip-status bip-status--{bip.status_slug}">'
+            f"{html.escape(bip.status)}</span></td>"
+            "</tr>"
+        )
+
+    return f"""
+<section class="bip-index-intro" aria-labelledby="bip-index-heading">
+  <div class="container">
+    <p id="bip-index-heading">Browse {len(bips)} proposals mirrored from the
+      <a href="https://github.com/bitcoin/bips">bitcoin/bips repository</a>.</p>
+    <p class="bip-index-revision">Source revision
+      <a href="https://github.com/bitcoin/bips/tree/{commit}"><code>{commit[:12]}</code></a>.</p>
+  </div>
+</section>
+
+<section class="bip-index-browser" aria-label="BIP directory">
+  <div class="container">
+    <div class="bip-index-controls">
+      <div class="bip-index-field bip-index-field--search">
+        <label for="bip-search">Search by number, title, type or layer</label>
+        <input id="bip-search" type="search" inputmode="search" autocomplete="off"
+          placeholder="For example: 110, wallets, consensus">
+      </div>
+      <div class="bip-index-field">
+        <label for="bip-status-filter">Status</label>
+        <select id="bip-status-filter">
+          <option value="">All statuses ({len(bips)})</option>
+          {status_options}
+        </select>
+      </div>
+    </div>
+
+    <p id="bip-result-count" class="bip-result-count" aria-live="polite">Showing all {len(bips)} BIPs</p>
+    <div class="bip-index-table-wrap">
+      <table class="bip-index-table">
+        <thead>
+          <tr><th scope="col">Number</th><th scope="col">Title</th>
+            <th scope="col">Type</th><th scope="col">Status</th></tr>
+        </thead>
+        <tbody>{''.join(rows)}</tbody>
+      </table>
+    </div>
+    <p id="bip-no-results" class="bip-no-results" hidden>No BIPs match those filters.</p>
+  </div>
+</section>
+""".strip()
+
+
+def write_index(output_root: Path, bips: list[Bip], commit: str) -> None:
+    front_matter = "\n".join(
+        [
+            "---",
+            f"layout: {yaml_value('bip-index')}",
+            f"lang: {yaml_value('en')}",
+            f"id: {yaml_value('bip')}",
+            "hide_language_selector: true",
+            f"title: {yaml_value('Bitcoin Improvement Proposals')}",
+            "description: "
+            + yaml_value(
+                "Browse Bitcoin Improvement Proposals by number, title, type and "
+                "current repository status."
+            ),
+            f"canonical_url: {yaml_value('https://bitcoin.org/bip/')}",
+            f"permalink: {yaml_value('/bip/')}",
+            f"bip_count: {len(bips)}",
+            f"bip_source_commit: {yaml_value(commit)}",
+            "---",
+        ]
+    )
+    (output_root / "index.html").write_text(
+        f"{front_matter}\n{{% raw %}}\n{index_body(bips, commit)}\n{{% endraw %}}\n",
+        encoding="utf-8",
+    )
+
+
+def validate_svg(path: Path) -> None:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    unsafe = UNSAFE_SVG.search(text)
+    if unsafe:
+        raise BuildError(f"Unsafe SVG construct in {path}: {unsafe.group(0)!r}")
+
+
+def copy_assets(source_root: Path, output_root: Path, tracked_files: list[Path]) -> int:
+    count = 0
+    for source in tracked_files:
+        relative_to_root = source.relative_to(source_root)
+        if len(relative_to_root.parts) < 2:
+            continue
+        directory = relative_to_root.parts[0]
+        directory_match = re.fullmatch(r"bip-(\d{4})", directory)
+        if (
+            directory_match is None
+            or not source.is_file()
+            or source.is_symlink()
+            or source.suffix.lower() not in IMAGE_EXTENSIONS
+        ):
+            continue
+        if source.suffix.lower() == ".svg":
+            validate_svg(source)
+        relative = Path(*relative_to_root.parts[1:])
+        destination = output_root / str(int(directory_match.group(1))) / "assets" / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        count += 1
+    return count
+
+
+def build(
+    config_path: Path,
+    explicit_source: Path | None = None,
+    output_override: Path | None = None,
+) -> None:
+    config = load_config(config_path)
+    output_root = output_override or ROOT / str(config["output_directory"])
+
+    if output_root.exists():
+        shutil.rmtree(output_root)
+
+    enabled_plugins = os.environ.get("ENABLED_PLUGINS")
+    if enabled_plugins is not None and "bips" not in enabled_plugins.split():
+        print("BIPs disabled")
+        return
+
+    source_root, commit = ensure_source(config, explicit_source)
+    tracked_files = tracked_source_files(source_root)
+    source_paths = sorted(
+        path for path in tracked_files
+        if re.fullmatch(r"bip-\d{4}\.(?:mediawiki|md)", path.name)
+        and path.parent == source_root
+    )
+    bips = sorted((parse_bip(path) for path in source_paths), key=lambda item: item.number)
+
+    duplicate_numbers = [
+        number
+        for number, count in collections.Counter(bip.number for bip in bips).items()
+        if count > 1
+    ]
+    if duplicate_numbers:
+        raise BuildError(f"Duplicate BIP numbers: {duplicate_numbers}")
+    expected_bip_count = int(config["expected_bip_count"])
+    if len(bips) != expected_bip_count:
+        raise BuildError(
+            f"Found {len(bips)} BIPs, expected {expected_bip_count}; refusing a partial build"
+        )
+
+    output_root.mkdir(parents=True)
+    for bip in bips:
+        rendered = render_with_pandoc(bip, source_root)
+        rendered = escape_unknown_html_tags(rendered)
+        rendered = normalize_html_with_pandoc(rendered, source_root)
+        rendered = wrap_document_tables(rendered)
+        rendered = normalize_ids(rendered)
+        validate_rendered_html(rendered, bip.filename)
+        bip.rendered_html = rendered
+
+    identifiers_by_bip = {
+        bip.number: set(re.findall(r'\bid="([^"]+)"', bip.rendered_html)) for bip in bips
+    }
+    for bip in bips:
+        bip.rendered_html = rewrite_links(
+            bip.rendered_html,
+            source_root,
+            commit,
+            bip.number,
+            identifiers_by_bip,
+        )
+        validate_rendered_html(bip.rendered_html, bip.filename)
+        bip.description = description_for(bip)
+
+    for index, bip in enumerate(bips):
+        previous = bips[index - 1] if index else None
+        following = bips[index + 1] if index + 1 < len(bips) else None
+        write_bip_page(output_root, bip, commit, previous, following)
+
+    write_index(output_root, bips, commit)
+    asset_count = copy_assets(source_root, output_root, tracked_files)
+    expected_asset_count = int(config["expected_image_asset_count"])
+    if asset_count != expected_asset_count:
+        raise BuildError(
+            f"Copied {asset_count} image assets, expected {expected_asset_count}; "
+            "refusing a partial build"
+        )
+    print(f"Generated {len(bips)} BIP pages and copied {asset_count} image assets from {commit[:12]}")
+
+
+class OutputInspector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.ids: list[str] = []
+        self.legacy_links: list[str] = []
+        self.document_links: list[tuple[str, str]] = []
+        self.images_without_alt: list[str] = []
+        self.in_bip_document = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        classes = (attributes.get("class") or "").split()
+        if tag == "article" and "bip-document" in classes:
+            self.in_bip_document = True
+        if attributes.get("id"):
+            self.ids.append(str(attributes["id"]))
+        for name in ("href", "src"):
+            value = attributes.get(name) or ""
+            if re.match(r"(?:\./)?bip-\d{4}(?:\.(?:md|mediawiki)|/)", value):
+                self.legacy_links.append(value)
+            if self.in_bip_document and value:
+                self.document_links.append((name, value))
+        if self.in_bip_document and tag == "img" and "alt" not in attributes:
+            self.images_without_alt.append(str(attributes.get("src") or "unknown image"))
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "article" and self.in_bip_document:
+            self.in_bip_document = False
+
+
+def check_output(config_path: Path, output_root: Path) -> None:
+    config = load_config(config_path)
+    enabled_plugins = os.environ.get("ENABLED_PLUGINS")
+    if enabled_plugins is not None and "bips" not in enabled_plugins.split():
+        print("BIP output check disabled")
+        return
+
+    pages = sorted(output_root.glob("[0-9]*/index.html"))
+    expected_bip_count = int(config["expected_bip_count"])
+    if len(pages) != expected_bip_count:
+        raise BuildError(
+            f"Found {len(pages)} rendered BIP pages in {output_root}; "
+            f"expected {expected_bip_count}"
+        )
+    if not (output_root / "index.html").is_file() or not (output_root / "110" / "index.html").is_file():
+        raise BuildError("The BIP index or BIP 110 page was not rendered")
+
+    inspectors: dict[int, OutputInspector] = {}
+    identifiers_by_bip: dict[int, set[str]] = {}
+    for page in pages:
+        content = page.read_text(encoding="utf-8")
+        validate_rendered_html(content, str(page))
+        inspector = OutputInspector()
+        inspector.feed(content)
+        duplicates = [name for name, count in collections.Counter(inspector.ids).items() if count > 1]
+        if duplicates:
+            raise BuildError(f"Duplicate IDs in {page}: {', '.join(duplicates[:10])}")
+        if inspector.legacy_links:
+            raise BuildError(f"Unrewritten BIP link in {page}: {inspector.legacy_links[0]}")
+        if inspector.images_without_alt:
+            raise BuildError(f"Image without alt text in {page}: {inspector.images_without_alt[0]}")
+        number = int(page.parent.name)
+        inspectors[number] = inspector
+        identifiers_by_bip[number] = set(inspector.ids)
+
+    for source_number, inspector in inspectors.items():
+        for attribute, value in inspector.document_links:
+            asset = re.fullmatch(r"/bip/(\d+)/assets/([^?#]+)(?:[?#].*)?", value)
+            if asset:
+                asset_root = output_root / asset.group(1) / "assets"
+                asset_path = (asset_root / unquote(asset.group(2))).resolve()
+                try:
+                    asset_path.relative_to(asset_root.resolve())
+                except ValueError as exc:
+                    raise BuildError(f"Unsafe BIP asset path in BIP {source_number}: {value}") from exc
+                if not asset_path.is_file():
+                    raise BuildError(f"Missing BIP asset linked from BIP {source_number}: {value}")
+                continue
+
+            route = re.fullmatch(r"/bip/(\d+)/(?:#([^?]+))?", value)
+            if route:
+                target_number = int(route.group(1))
+                if target_number not in identifiers_by_bip:
+                    raise BuildError(f"Missing BIP route linked from BIP {source_number}: {value}")
+                fragment = unquote(route.group(2) or "")
+                if fragment and fragment not in identifiers_by_bip[target_number]:
+                    raise BuildError(f"Missing BIP fragment linked from BIP {source_number}: {value}")
+                continue
+
+            if value.startswith("#"):
+                fragment = unquote(value[1:])
+                if fragment and fragment not in identifiers_by_bip[source_number]:
+                    raise BuildError(f"Missing local fragment in BIP {source_number}: {value}")
+                continue
+
+            if not value.startswith("/") and not re.match(
+                r"^[A-Za-z][A-Za-z0-9+.-]*:", value
+            ):
+                raise BuildError(
+                    f"Ambiguous relative {attribute} URL in BIP {source_number}: {value}"
+                )
+    print(f"Verified {len(pages)} rendered BIP pages")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--source", type=Path, help="Use this exact pinned bitcoin/bips checkout")
+    parser.add_argument("--output", type=Path, help="Override the generated source directory")
+    parser.add_argument("--check-output", type=Path, help="Validate an already-rendered _site/bip directory")
+    args = parser.parse_args()
+
+    try:
+        if args.check_output:
+            check_output(args.config.resolve(), args.check_output.resolve())
+        else:
+            build(
+                args.config.resolve(),
+                args.source.resolve() if args.source else None,
+                args.output.resolve() if args.output else None,
+            )
+    except BuildError as exc:
+        print(f"BIP build error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/_build/test_bips.py
+++ b/_build/test_bips.py
@@ -402,5 +402,138 @@ Example abstract.
             BIPS.check_output(config, output)
 
 
+    def test_spanned_title_header_becomes_a_caption(self) -> None:
+        source = (
+            '{| class="wikitable"\n! colspan="3" | template request\n|-\n'
+            "! Key !! Type !! Description\n|-\n| a || b || c\n|}"
+        )
+        processed, tables = BIPS.preprocess_mediawiki_spanned_tables(source)
+        self.assertEqual({}, tables)
+        self.assertIn("|+ template request", processed)
+        self.assertNotIn("colspan", processed)
+
+    def test_rowspan_tables_become_protected_html(self) -> None:
+        source = (
+            "{|\n"
+            '!rowspan=3 style=""|Version\n'
+            "!colspan=2|Hash size\n"
+            "|-\n"
+            "| first line of a cell\n"
+            "continued on a soft-wrapped line\n"
+            "| <33 byte pubkey>\n"
+            "|}"
+        )
+        processed, tables = BIPS.preprocess_mediawiki_spanned_tables(source)
+        self.assertEqual(1, len(tables))
+        (token, markup), = tables.items()
+        self.assertIn(token, processed)
+        self.assertIn('rowspan="3"', markup)
+        self.assertIn('colspan="2"', markup)
+        self.assertNotIn("style", markup)
+        self.assertIn("first line of a cell continued on a soft-wrapped line", markup)
+        self.assertIn("&lt;33 byte pubkey>", markup)
+
+    def test_ragged_tables_are_protected(self) -> None:
+        source = (
+            "{|\n! Opcode\n! Cost\n|-\n"
+            "|OP_MIN\n|wordspan * 4\n|OTHER\n|}"
+        )
+        processed, tables = BIPS.preprocess_mediawiki_spanned_tables(source)
+        self.assertEqual(1, len(tables))
+        markup = next(iter(tables.values()))
+        for cell in ("OP_MIN", "wordspan * 4", "OTHER"):
+            self.assertIn(f"<td>{cell}</td>", markup)
+
+    def test_code_pipes_do_not_split_or_convert_cells(self) -> None:
+        source = (
+            "{|\n! Field !! Data type !! Comments\n|-\n"
+            "| 32bytes || hash || <code>hash(a || b || c)</code>\n|}"
+        )
+        processed, tables = BIPS.preprocess_mediawiki_spanned_tables(source)
+        self.assertEqual({}, tables)
+        self.assertIn("{|", processed)
+        self.assertIn("<code>hash(a &#124;&#124; b &#124;&#124; c)</code>", processed)
+
+    def test_tables_glued_to_raw_html_get_breathing_room(self) -> None:
+        source = "Introductory sentence:\n<br/>\n{| class=\"wikitable\"\n! A\n|}"
+        spaced = BIPS.preprocess_mediawiki_table_spacing(source)
+        self.assertIn("<br/>\n\n{|", spaced)
+        nested = "{|\n| outer cell\n{| inner\n|}\n|}"
+        self.assertEqual(nested, BIPS.preprocess_mediawiki_table_spacing(nested))
+
+    def test_nested_references_are_paired_correctly(self) -> None:
+        source = (
+            "Outer text<ref>Outer note with an inner"
+            "<ref name=inner>Inner note.</ref> marker.</ref> body continues.\n"
+            "<references />"
+        )
+        processed = BIPS.preprocess_mediawiki_references(source)
+        self.assertNotIn("<ref", processed.lower())
+        self.assertNotIn("</ref", processed.lower())
+        self.assertIn('id="bip-note-1"', processed)
+        self.assertIn('id="bip-note-2"', processed)
+        self.assertIn("body continues.", processed.split("bip-footnotes")[0])
+        outer_note = processed.split('id="bip-note-1"')[1].split("</li>")[0]
+        self.assertIn("#bip-note-2", outer_note)
+
+    def test_table_inside_a_reference_survives(self) -> None:
+        source = (
+            "Claim<ref>Explained by:\n{|\n! K !! V\n|-\n| pwd || 21\n|}\n</ref>.\n"
+            "<references />"
+        )
+        processed = BIPS.preprocess_mediawiki_references(source)
+        self.assertIn("<table>", processed)
+        self.assertIn("<td>pwd</td>", processed)
+
+    def test_stray_reference_closers_are_removed(self) -> None:
+        source = "Before</ref> middle<ref>note</ref> after.\n<references />"
+        processed = BIPS.preprocess_mediawiki_references(source)
+        self.assertNotIn("</ref", processed.lower())
+        self.assertIn("Before middle", processed)
+
+    def test_pandoc_version_gate(self) -> None:
+        self.assertEqual((3, 1), BIPS.parse_pandoc_version("pandoc 3.1.3"))
+        self.assertEqual((2, 9), BIPS.parse_pandoc_version("pandoc 2.9.2.1"))
+        self.assertLess(BIPS.parse_pandoc_version("pandoc 2.5"), BIPS.MINIMUM_PANDOC_VERSION)
+        with self.assertRaises(BIPS.BuildError):
+            BIPS.parse_pandoc_version("not pandoc at all")
+
+    def test_cell_parity_counter_bounds(self) -> None:
+        body = (
+            "<!-- {|\n| commented || out\n|} -->\n"
+            "<pre>{|\n| literal || example\n|}</pre>\n"
+            "{|\n"
+            '! colspan="2" | Title only\n'
+            "|-\n"
+            "! A !! B\n"
+            "|-\n"
+            "| <code>x || y</code> || value ||||\n"
+            "|}"
+        )
+        self.assertEqual(4, BIPS.count_source_table_cells(body))
+
+    def test_cell_parity_validator_rejects_losses(self) -> None:
+        bip = BIPS.Bip(
+            number=1,
+            filename="bip-0001.mediawiki",
+            source_path=Path("bip-0001.mediawiki"),
+            source_format="mediawiki",
+            headers={
+                "BIP": "1",
+                "Title": "T",
+                "Authors": "A <a@example.test>",
+                "Status": "Draft",
+                "Type": "Process",
+                "Assigned": "2025-01-02",
+            },
+            body="{|\n! A !! B\n|-\n| 1 || 2\n|}",
+            rendered_html="<table><tr><th>A</th><th>B</th></tr>"
+            "<tr><td>1</td><td>2</td></tr></table>",
+        )
+        BIPS.validate_table_cell_parity(bip)
+        bip.rendered_html = "<table><tr><th>A</th></tr><tr><td>1</td></tr></table>"
+        with self.assertRaises(BIPS.BuildError):
+            BIPS.validate_table_cell_parity(bip)
+
 if __name__ == "__main__":
     unittest.main()

--- a/_build/test_bips.py
+++ b/_build/test_bips.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import re
 import sys
@@ -309,6 +310,7 @@ Example abstract.
     def test_output_inspector_scopes_links_and_alt_checks_to_bip_content(self) -> None:
         inspector = BIPS.OutputInspector()
         inspector.feed(
+            '<head><meta name="description" content="Trusted site metadata"></head>'
             '<nav><a href="relative-menu-link">Menu</a></nav>'
             '<article class="article bip-document">'
             '<h2 id="abstract">Abstract</h2>'
@@ -317,6 +319,8 @@ Example abstract.
             '</article>'
         )
 
+        self.assertTrue(inspector.found_bip_document)
+        self.assertEqual([], inspector.unsafe_document_html)
         self.assertEqual(
             [
                 ("href", "/bip/9/#specification"),
@@ -326,6 +330,60 @@ Example abstract.
         )
         self.assertEqual(["/bip/9/assets/example.png"], inspector.images_without_alt)
         self.assertIn("abstract", inspector.ids)
+
+    def test_output_inspector_rejects_unsafe_html_inside_bip_content(self) -> None:
+        inspector = BIPS.OutputInspector()
+        inspector.feed(
+            '<meta name="description" content="Trusted site metadata">'
+            '<article class="article bip-document">'
+            '<meta http-equiv="refresh" content="0; url=https://example.test">'
+            '</article>'
+        )
+
+        self.assertEqual(["<meta"], inspector.unsafe_document_html)
+
+    def test_output_check_scopes_unsafe_html_validation_to_bip_content(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        config = root / "bips-source.json"
+        output = root / "bip"
+        page = output / "110" / "index.html"
+        page.parent.mkdir(parents=True)
+        (output / "index.html").write_text("BIP index", encoding="utf-8")
+        config.write_text(
+            json.dumps(
+                {
+                    "repository": "https://github.com/bitcoin/bips.git",
+                    "commit": "a" * 40,
+                    "cache_directory": "_cache/bitcoin-bips",
+                    "output_directory": "bip",
+                    "expected_bip_count": 1,
+                    "expected_image_asset_count": 1,
+                }
+            ),
+            encoding="utf-8",
+        )
+        trusted_head = '<head><meta name="description" content="BIP 110"></head>'
+        article = (
+            '<article class="article bip-document expanded">'
+            '<h2 id="abstract">Abstract</h2><p>Example.</p>'
+            '</article>'
+        )
+        page.write_text(trusted_head + article, encoding="utf-8")
+
+        BIPS.check_output(config, output)
+
+        page.write_text(
+            trusted_head
+            + article.replace(
+                '<p>Example.</p>',
+                '<meta http-equiv="refresh" content="0"><p>Example.</p>',
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(BIPS.BuildError):
+            BIPS.check_output(config, output)
 
 
 if __name__ == "__main__":

--- a/_build/test_bips.py
+++ b/_build/test_bips.py
@@ -198,6 +198,7 @@ Example abstract.
         rendered = (
             '<a href="bip-0009.mediawiki#GetBlockTemplate_changes">BIP 9</a>'
             '<a href="#Abstract">Abstract</a>'
+            '<a href="README.mediawiki">BIP index</a>'
         )
         identifiers = {9: {"getblocktemplate-changes"}, 110: {"abstract"}}
 
@@ -211,6 +212,19 @@ Example abstract.
 
         self.assertIn('href="/bip/9/#getblocktemplate-changes"', rewritten)
         self.assertIn('href="#abstract"', rewritten)
+        self.assertIn('href="/bips/"', rewritten)
+
+    def test_index_uses_plural_public_route(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        output = Path(temporary.name) / "bip"
+        output.mkdir()
+
+        BIPS.write_index(output, [], "a" * 40)
+
+        content = (output / "index.html").read_text(encoding="utf-8")
+        self.assertIn('canonical_url: "https://bitcoin.org/bips/"', content)
+        self.assertIn('permalink: "/bips/"', content)
 
     def test_legacy_github_and_reference_fragments_are_resolved(self) -> None:
         self.assertEqual(
@@ -350,7 +364,9 @@ Example abstract.
         output = root / "bip"
         page = output / "110" / "index.html"
         page.parent.mkdir(parents=True)
-        (output / "index.html").write_text("BIP index", encoding="utf-8")
+        index_page = root / "bips" / "index.html"
+        index_page.parent.mkdir(parents=True)
+        index_page.write_text("BIP index", encoding="utf-8")
         config.write_text(
             json.dumps(
                 {

--- a/_build/test_bips.py
+++ b/_build/test_bips.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+
+# This file is licensed under the MIT License (MIT) available on
+# https://opensource.org/licenses/MIT.
+
+"""Unit tests for the deterministic BIP HTML generator."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import re
+import sys
+import tempfile
+import unittest
+
+
+GENERATOR = Path(__file__).with_name("generate_bips.py")
+SPEC = importlib.util.spec_from_file_location("generate_bips", GENERATOR)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {GENERATOR}")
+BIPS = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BIPS
+SPEC.loader.exec_module(BIPS)
+
+
+class BipGeneratorTests(unittest.TestCase):
+    def write_source(self, name: str, content: str) -> Path:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        path = Path(temporary.name) / name
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_mediawiki_header_and_leading_notice_are_preserved(self) -> None:
+        path = self.write_source(
+            "bip-0110.mediawiki",
+            """This proposal is retained for historical reference.
+
+<pre>
+  BIP: 110
+  Layer: Consensus (soft fork)
+  Title: Example proposal
+  Authors: Alice Example <alice@example.test>
+  Comments-URI: https://example.test/discussion
+  Status: Draft
+  Type: Standards Track
+  Assigned: 2025-01-02
+</pre>
+
+==Abstract==
+Example abstract.
+""",
+        )
+
+        bip = BIPS.parse_bip(path)
+
+        self.assertEqual(110, bip.number)
+        self.assertEqual("Example proposal", bip.title)
+        self.assertEqual("Consensus (soft fork)", bip.headers["Layer"])
+        self.assertIn("historical reference", bip.body)
+        self.assertNotIn("BIP: 110", bip.body)
+
+    def test_markdown_header_and_continuation_line(self) -> None:
+        path = self.write_source(
+            "bip-0003.md",
+            """```
+  BIP: 3
+  Title: Markdown proposal
+  Authors: Alice Example <alice@example.test>
+           Bob Example <bob@example.test>
+  Status: Complete
+  Type: Process
+  Assigned: 2025-01-02
+```
+
+## Abstract
+
+Example abstract.
+""",
+        )
+
+        bip = BIPS.parse_bip(path)
+
+        self.assertEqual("markdown", bip.source_format)
+        self.assertEqual(
+            "Alice Example <alice@example.test>\nBob Example <bob@example.test>",
+            bip.headers["Authors"],
+        )
+
+    def test_named_references_create_one_note_and_multiple_backlinks(self) -> None:
+        source = (
+            "Text<ref name=sample>Reference body.</ref> and another use<ref name=sample/>.\n"
+            "<references />"
+        )
+
+        processed = BIPS.preprocess_mediawiki_references(source)
+
+        self.assertNotIn("<ref", processed.lower())
+        self.assertEqual(1, processed.count('id="bip-note-1"'))
+        self.assertIn("#bip-ref-1-1", processed)
+        self.assertIn("#bip-ref-1-2", processed)
+
+    def test_unindented_markdown_footnote_continuations_are_preserved(self) -> None:
+        source = "Text[^1].\n\n[^1]: First line\ncontinued line\n[^2]: Other note\n"
+
+        normalized = BIPS.normalize_markdown_footnotes(source)
+
+        self.assertIn("[^1]: First line\n    continued line", normalized)
+        self.assertIn("[^2]: Other note", normalized)
+
+    def test_mediawiki_file_markup_becomes_an_accessible_figure(self) -> None:
+        source = (
+            "[[File:bip-0156/1-dandelion.png|framed|center|"
+            "alt=An illustration|Figure 1]] Figure 1"
+        )
+
+        processed = BIPS.preprocess_mediawiki_files(source)
+
+        self.assertIn('<figure class="bip-figure">', processed)
+        self.assertIn('src="bip-0156/1-dandelion.png"', processed)
+        self.assertIn('alt="An illustration"', processed)
+        self.assertEqual(1, processed.count("Figure 1"))
+
+        indented = BIPS.preprocess_mediawiki_files(
+            "::[[File:bip-0443/example.png|framed|alt=Example|600px]]\n"
+            "::'''Figure 2:''' A <code>UTXO</code> example."
+        )
+        self.assertIn("<figcaption>'''Figure 2:''' A <code>UTXO</code> example.</figcaption>", indented)
+
+    def test_mediawiki_poem_tags_become_valid_html_blocks(self) -> None:
+        processed = BIPS.preprocess_mediawiki_blocks(
+            "<blockquote><poem>Quoted text.</poem></blockquote>"
+        )
+
+        self.assertEqual(
+            '<blockquote><div class="bip-poem">Quoted text.</div></blockquote>',
+            processed,
+        )
+
+    def test_tables_receive_a_scrollable_accessible_wrapper(self) -> None:
+        wrapped = BIPS.wrap_document_tables(
+            "<p>Before</p><table><tr><td>Value</td></tr></table><p>After</p>"
+        )
+
+        self.assertIn('class="bip-table-wrap"', wrapped)
+        self.assertIn('tabindex="0"', wrapped)
+        self.assertIn("<table><tr><td>Value</td></tr></table>", wrapped)
+
+        nested = BIPS.wrap_document_tables(
+            "<table><tr><td><table><tr><td>Nested</td></tr></table></td></tr></table>"
+        )
+        self.assertEqual(1, nested.count('class="bip-table-wrap"'))
+
+    def test_unknown_placeholders_are_escaped_but_html_is_retained(self) -> None:
+        rendered = '<p>Use <pubkey> and <hash value="x">.</p>'
+
+        escaped = BIPS.escape_unknown_html_tags(rendered)
+
+        self.assertEqual(
+            '<p>Use &lt;pubkey&gt; and &lt;hash value="x"&gt;.</p>',
+            escaped,
+        )
+
+    def test_duplicate_heading_anchors_are_normalized(self) -> None:
+        rendered = (
+            '<p><span id="abstract"></span></p><h2 id="abstract">Abstract</h2>'
+            '<h3 id="example"><span id="example"></span>Example</h3>'
+            '<p id="example">Text</p>'
+        )
+
+        normalized = BIPS.normalize_ids(rendered)
+
+        self.assertEqual(1, normalized.count('id="abstract"'))
+        self.assertEqual(1, normalized.count('id="example"'))
+        self.assertIn('id="example-2"', normalized)
+
+    def test_ids_with_spaces_and_underscores_become_safe_fragments(self) -> None:
+        normalized = BIPS.normalize_ids(
+            '<div id="Sign negation"></div><h2 id="low_s">Low S</h2>'
+        )
+
+        self.assertIn('id="sign-negation"', normalized)
+        self.assertIn('id="low-s"', normalized)
+
+    def test_generated_id_suffixes_cannot_collide_with_existing_ids(self) -> None:
+        normalized = BIPS.normalize_ids(
+            '<span id="code"></span><span id="code"></span><span id="code-2"></span>'
+        )
+
+        self.assertEqual(
+            ['id="code"', 'id="code-2"', 'id="code-2-2"'],
+            re.findall(r'id="[^"]+"', normalized),
+        )
+
+    def test_bip_links_and_fragments_use_pretty_local_routes(self) -> None:
+        rendered = (
+            '<a href="bip-0009.mediawiki#GetBlockTemplate_changes">BIP 9</a>'
+            '<a href="#Abstract">Abstract</a>'
+        )
+        identifiers = {9: {"getblocktemplate-changes"}, 110: {"abstract"}}
+
+        rewritten = BIPS.rewrite_links(
+            rendered,
+            Path("/tmp/bips-source-does-not-need-to-exist"),
+            "a" * 40,
+            110,
+            identifiers,
+        )
+
+        self.assertIn('href="/bip/9/#getblocktemplate-changes"', rewritten)
+        self.assertIn('href="#abstract"', rewritten)
+
+    def test_legacy_github_and_reference_fragments_are_resolved(self) -> None:
+        self.assertEqual(
+            "#common-signature-message-extension",
+            BIPS.resolve_fragment(
+                "#user-content-Common_Signature_Message_Extension",
+                {"common-signature-message-extension"},
+                342,
+            ),
+        )
+        self.assertEqual(
+            "#bip-ref-22-1",
+            BIPS.resolve_fragment("#cite_ref-22-0", {"bip-ref-22-1"}, 341),
+        )
+        self.assertEqual(
+            "#bip-note-3",
+            BIPS.resolve_fragment("#cite_note-3", {"bip-note-3"}, 118),
+        )
+        self.assertEqual(
+            "#bech32",
+            BIPS.resolve_fragment("#Bech32%7CBIP173", {"bech32"}, 173),
+        )
+
+    def test_remote_images_are_links_and_local_images_are_lazy(self) -> None:
+        rendered = (
+            '<img src="https://example.test/badge.svg" alt="Licence">'
+            '<img src="/bip/1/assets/figure.png" alt="Figure">'
+        )
+
+        rewritten = BIPS.rewrite_links(
+            rendered,
+            Path("/tmp/bips-source-does-not-need-to-exist"),
+            "a" * 40,
+            1,
+            {1: set()},
+        )
+
+        self.assertIn('class="bip-external-image"', rewritten)
+        self.assertNotIn('<img src="https://', rewritten)
+        self.assertIn('<img loading="lazy" decoding="async" src="/bip/1/assets/', rewritten)
+
+    def test_unquoted_images_directories_and_wiki_links_are_rewritten(self) -> None:
+        rendered = (
+            '<img src=bip-0001/process.png></img>'
+            '<a href="bip-0327">vectors</a>'
+            '<a href="Protocol_specification#compactsize">types</a>'
+            '<a href="BIP_0037">BIP 37</a>'
+        )
+
+        rewritten = BIPS.rewrite_links(
+            rendered,
+            Path("/tmp/bips-source-does-not-need-to-exist"),
+            "a" * 40,
+            1,
+            {1: set(), 37: set()},
+        )
+
+        self.assertIn('src="/bip/1/assets/process.png"', rewritten)
+        self.assertIn('alt="BIP 1 illustration: process"', rewritten)
+        self.assertNotIn("</img>", rewritten)
+        self.assertIn("https://github.com/bitcoin/bips/blob/", rewritten)
+        self.assertIn("https://en.bitcoin.it/wiki/Protocol_specification#compactsize", rewritten)
+        self.assertIn('href="/bip/37/"', rewritten)
+
+    def test_unsafe_html_is_rejected(self) -> None:
+        with self.assertRaises(BIPS.BuildError):
+            BIPS.validate_rendered_html('<script src="evil.js"></script>', "test")
+        with self.assertRaises(BIPS.BuildError):
+            BIPS.validate_rendered_html('<a href="javascript:alert(1)">x</a>', "test")
+
+    def test_description_uses_abstract_and_is_bounded(self) -> None:
+        bip = BIPS.Bip(
+            number=110,
+            filename="bip-0110.mediawiki",
+            source_path=Path("bip-0110.mediawiki"),
+            source_format="mediawiki",
+            headers={
+                "BIP": "110",
+                "Title": "Example proposal",
+                "Authors": "Alice Example <alice@example.test>",
+                "Status": "Draft",
+                "Type": "Standards Track",
+                "Assigned": "2025-01-02",
+            },
+            body="",
+            rendered_html="<h2>Abstract</h2><p>A useful description of the proposal.</p>",
+        )
+
+        description = BIPS.description_for(bip)
+
+        self.assertEqual(
+            "BIP 110: Example proposal. A useful description of the proposal.",
+            description,
+        )
+        self.assertLessEqual(len(description), 220)
+
+    def test_output_inspector_scopes_links_and_alt_checks_to_bip_content(self) -> None:
+        inspector = BIPS.OutputInspector()
+        inspector.feed(
+            '<nav><a href="relative-menu-link">Menu</a></nav>'
+            '<article class="article bip-document">'
+            '<h2 id="abstract">Abstract</h2>'
+            '<a href="/bip/9/#specification">BIP 9</a>'
+            '<img src="/bip/9/assets/example.png">'
+            '</article>'
+        )
+
+        self.assertEqual(
+            [
+                ("href", "/bip/9/#specification"),
+                ("src", "/bip/9/assets/example.png"),
+            ],
+            inspector.document_links,
+        )
+        self.assertEqual(["/bip/9/assets/example.png"], inspector.images_without_alt)
+        self.assertIn("abstract", inspector.ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_contrib/bco-htmlproof
+++ b/_contrib/bco-htmlproof
@@ -23,11 +23,11 @@ HTMLProofer.check_directory(
       /^\/stats/
     ],
     :swap_urls => {
-      /(css|png|rss|pdf|jpg|asc|xml)$/ => '\1$',
-      /^([^#]+[^\/$])$/ => '\1.html',
-      /^(.+)(#.+)/ => '\1.html\2',
-      /\/(.html#.+)/ => '\1',
-      /\$$/ => '',
+    /(css|png|rss|pdf|jpg|asc|xml)$/ => '\1$',
+    /^([^#]+[^\/$])$/ => '\1.html',
+    /^(.+[^\/])(#.+)$/ => '\1.html\2',
+    /\/(.html#.+)/ => '\1',
+    /\$$/ => '',
     },
   }
 ).run

--- a/_contrib/bco-htmlproof
+++ b/_contrib/bco-htmlproof
@@ -14,6 +14,12 @@ HTMLProofer.check_directory(
     :enforce_https => false,
     :check_internal_hash => false,
     :checks => ["Links"],
+    # BIP mirror pages are fully link-checked by the generator itself
+    # (_build/generate_bips.py --check-output validates every internal
+    # route, fragment and asset of all 210 pages); re-parsing them here
+    # is redundant and exhausts CI memory (the job gets OOM-killed).
+    # The /bips/ index page is still checked.
+    :ignore_files => [%r{/bip/}],
     :ignore_urls => [
       '#',
       /^$/,

--- a/_includes/layout/base/footer-license.html
+++ b/_includes/layout/base/footer-license.html
@@ -9,6 +9,7 @@ https://opensource.org/licenses/MIT.
       <div class="footerlicense">© Bitcoin Project 2009-{{ site.time | date: '%Y' }} {% translate footer layout %}</div>
       <div class="row footer-status-block">
         <a href="/en/alerts" class="statusmenu{% if site.STATUS == 1 %} alert{% endif %}">{% translate network-status layout %}</a>
+        {% unless page.hide_language_selector %}
         {% include layout/base/head-language-dropdown.html %} 
         <div id="footer-langselect" class="footer-langselect langselect">
           <label for="select-input-footer" class="center-select">
@@ -21,6 +22,7 @@ https://opensource.org/licenses/MIT.
             <span class="center-select__text">{{ page.lang }}</span>
           </label>
         </div>
+        {% endunless %}
       </div>
 <!--      <div class="row">  -->
         {% comment %}

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -37,7 +37,7 @@ https://opensource.org/licenses/MIT.
   <li><a class="is-expand">{% translate menu-resources layout %}</a>
     <ul>
       <li{% if page.id == 'resources' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate resources url %}">{% translate menu-resources layout %}</a>
-      <li{% if page.id == 'bip' %} class="active"{% endif %}><a href="/bip/">{% translate menu-bips layout %}</a></li>
+      <li{% if page.id == 'bip' %} class="active"{% endif %}><a href="/bips/">{% translate menu-bips layout %}</a></li>
       <li{% if page.id == 'exchanges' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate exchanges url %}">{% translate menu-exchanges layout %}</a></li>
       <li{% if page.id == 'community' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate community url %}">{% translate menu-community layout %}</a></li>
       {% comment %}

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -37,6 +37,7 @@ https://opensource.org/licenses/MIT.
   <li><a class="is-expand">{% translate menu-resources layout %}</a>
     <ul>
       <li{% if page.id == 'resources' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate resources url %}">{% translate menu-resources layout %}</a>
+      <li{% if page.id == 'bip' %} class="active"{% endif %}><a href="/bip/">{% translate menu-bips layout %}</a></li>
       <li{% if page.id == 'exchanges' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate exchanges url %}">{% translate menu-exchanges layout %}</a></li>
       <li{% if page.id == 'community' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate community url %}">{% translate menu-community layout %}</a></li>
       {% comment %}

--- a/_includes/layout/base/html-head.html
+++ b/_includes/layout/base/html-head.html
@@ -6,8 +6,11 @@ https://opensource.org/licenses/MIT.
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 <meta property="og:image" content="https://bitcoin.org/img/icons/opengraph.png?{{site.time | date: '%s'}}" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-<title>{% capture title %}{% translate title %}{% endcapture %}{% if title != '' %}{{ title }}{% else %}{{ page.title }}{% endif %}</title>
-{% capture metadescription %}{% translate metadescription %}{% endcapture %}{% if metadescription != '' %}<meta name="description" content="{{ metadescription }}">{% endif %}
+<title>{% capture title %}{% translate title %}{% endcapture %}{% if title != '' %}{{ title }}{% else %}{{ page.title | escape }}{% endif %}</title>
+{% capture metadescription %}{% translate metadescription %}{% endcapture %}{% if metadescription != '' %}<meta name="description" content="{{ metadescription | escape }}">{% elsif page.description %}<meta name="description" content="{{ page.description | escape }}">{% endif %}
+{% if page.bip_source_commit %}<meta property="og:title" content="{{ page.title | escape }}">{% endif %}
+{% if page.bip_source_commit and page.description %}<meta property="og:description" content="{{ page.description | escape }}">{% endif %}
+{% if page.bip_source_commit %}<meta property="og:url" content="{{ page.canonical_url | escape }}">{% endif %}
 {% include layout/base/hreflang.html %}
 <link rel="stylesheet" href="/css/font-awesome-4.4.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="/css/main.css?{{site.time | date: '%s'}}">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -19,8 +19,10 @@
   {% include layout/base/head-logo.html %}
   {% include layout/base/head-menu.html %}
   {% include layout/base/head-mobile-menu.html %}
+  {% unless page.hide_language_selector %}
   {% include layout/base/head-language-dropdown.html %}
   {% include layout/base/head-language-select.html %}
+  {% endunless %}
 </div></div>
 
 <div class="body">

--- a/_layouts/bip-index.html
+++ b/_layouts/bip-index.html
@@ -1,0 +1,25 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# https://opensource.org/licenses/MIT.
+layout: base
+end_of_page: |
+  <script type="text/javascript" src="/js/bips.js"></script>
+---
+
+<div class="bip-index-page">
+  <header class="bip-hero bip-index-hero">
+    <div class="container bip-hero__inner">
+      <p class="bip-hero__eyebrow">Technical proposals and documentation</p>
+      <h1>Bitcoin Improvement Proposals</h1>
+      <p class="bip-index-hero__summary">Search and read the BIPs mirrored from their canonical source repository.</p>
+    </div>
+  </header>
+
+  <div class="bip-neutrality-notice bip-index-notice container" role="note">
+    <strong>Neutral mirror.</strong> Listing a BIP does not imply adoption, Bitcoin community consensus, or endorsement
+    by Bitcoin.org. Status labels and document contents come from the
+    <a href="https://github.com/bitcoin/bips">bitcoin/bips repository</a>.
+  </div>
+
+  {{ content }}
+</div>

--- a/_layouts/bip.html
+++ b/_layouts/bip.html
@@ -109,7 +109,7 @@ end_of_page: |
       </aside>
 
       <main class="toccontent bip-content">
-        <article class="article bip-document">
+        <article class="article bip-document expanded">
           {{ content }}
         </article>
 

--- a/_layouts/bip.html
+++ b/_layouts/bip.html
@@ -23,7 +23,7 @@ end_of_page: |
 <div class="bip-page">
   <nav class="bip-toolbar" aria-label="BIP links">
     <div class="container bip-toolbar__inner">
-      <a href="/bip/">All BIPs</a>
+      <a href="/bips/">All BIPs</a>
       <a href="{{ page.bip_source_url | escape }}">Canonical source</a>
       <a href="{{ page.bip_history_url | escape }}">Revision history</a>
       {% if page.bip_discussions.size > 0 %}

--- a/_layouts/bip.html
+++ b/_layouts/bip.html
@@ -1,0 +1,137 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# https://opensource.org/licenses/MIT.
+layout: base
+end_of_page: |
+  <script>updateToc(); onScrollButton();</script>
+---
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": {{ page.bip_title | jsonify }},
+  "description": {{ page.description | jsonify }},
+  "dateCreated": {{ page.bip_assigned | jsonify }},
+  "version": {{ page.bip_version | jsonify }},
+  "mainEntityOfPage": {{ page.canonical_url | jsonify }},
+  "isBasedOn": {{ page.bip_source_url | jsonify }},
+  "author": [{% for author in page.bip_authors %}{"@type":"Person","name":{{ author.name | jsonify }}}{% unless forloop.last %},{% endunless %}{% endfor %}]
+}
+</script>
+
+<div class="bip-page">
+  <nav class="bip-toolbar" aria-label="BIP links">
+    <div class="container bip-toolbar__inner">
+      <a href="/bip/">All BIPs</a>
+      <a href="{{ page.bip_source_url | escape }}">Canonical source</a>
+      <a href="{{ page.bip_history_url | escape }}">Revision history</a>
+      {% if page.bip_discussions.size > 0 %}
+        <a href="{{ page.bip_discussions[0].url | escape }}">Discussion</a>
+      {% endif %}
+    </div>
+  </nav>
+
+  <header class="bip-hero">
+    <div class="container bip-hero__inner">
+      <p class="bip-hero__eyebrow">Bitcoin Improvement Proposal {{ page.bip_number }}</p>
+      <h1>{{ page.bip_title | escape }}</h1>
+      <div class="bip-hero__summary">
+        <span class="bip-status bip-status--{{ page.bip_status_slug }}">{{ page.bip_status | escape }}</span>
+        <span>{{ page.bip_type | escape }}</span>
+        {% if page.bip_layer != '' %}<span>{{ page.bip_layer | escape }}</span>{% endif %}
+      </div>
+    </div>
+  </header>
+
+  <section class="bip-overview" aria-label="BIP metadata">
+    <div class="container">
+      <dl class="bip-metadata">
+        <div class="bip-metadata__wide">
+          <dt>Authors</dt>
+          <dd>
+            {% for author in page.bip_authors %}
+              <a href="mailto:{{ author.email | uri_escape }}">{{ author.name | escape }}</a>{% unless forloop.last %}, {% endunless %}
+            {% endfor %}
+          </dd>
+        </div>
+        <div><dt>Status</dt><dd>{{ page.bip_status | escape }}</dd></div>
+        <div><dt>Type</dt><dd>{{ page.bip_type | escape }}</dd></div>
+        {% if page.bip_layer != '' %}<div><dt>Layer</dt><dd>{{ page.bip_layer | escape }}</dd></div>{% endif %}
+        <div><dt>Assigned</dt><dd>{{ page.bip_assigned | escape }}</dd></div>
+        {% if page.bip_version != '' %}<div><dt>Version</dt><dd>{{ page.bip_version | escape }}</dd></div>{% endif %}
+        <div><dt>Document licence</dt><dd>{{ page.bip_license | escape }}</dd></div>
+        {% if page.bip_license_code != '' %}<div><dt>Code licence</dt><dd>{{ page.bip_license_code | escape }}</dd></div>{% endif %}
+      </dl>
+
+      {% if page.bip_requires.size > 0 or page.bip_replaces.size > 0 or page.bip_proposed_replacement.size > 0 %}
+      <div class="bip-relations" aria-label="Related BIPs">
+        {% if page.bip_requires.size > 0 %}<span>Requires:
+          {% for number in page.bip_requires %}<a href="/bip/{{ number }}/">BIP {{ number }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
+        </span>{% endif %}
+        {% if page.bip_replaces.size > 0 %}<span>Replaces:
+          {% for number in page.bip_replaces %}<a href="/bip/{{ number }}/">BIP {{ number }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
+        </span>{% endif %}
+        {% if page.bip_proposed_replacement.size > 0 %}<span>Proposed replacement:
+          {% for number in page.bip_proposed_replacement %}<a href="/bip/{{ number }}/">BIP {{ number }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
+        </span>{% endif %}
+      </div>
+      {% endif %}
+
+      {% if page.bip_status == 'Closed' or page.bip_status == 'Draft' %}
+      <div class="bip-status-notice bip-status-notice--{{ page.bip_status_slug }}" role="note">
+        <strong>Repository status: {{ page.bip_status | escape }}.</strong>
+        This label comes directly from the canonical BIP source and may change in a later revision.
+      </div>
+      {% endif %}
+
+      <div class="bip-neutrality-notice" role="note">
+        <strong>About this mirror.</strong> A BIP is a proposal or technical document. Publication here does not imply
+        adoption, Bitcoin community consensus, or endorsement by Bitcoin.org. For authoritative text and history,
+        use the <a href="{{ page.bip_source_url | escape }}">canonical bitcoin/bips source</a>.
+      </div>
+    </div>
+  </section>
+
+  <div class="toc-container bip-reader">
+    <div class="row toc-row">
+      <aside id="toc" class="toc bip-toc" aria-label="On this page">
+        <div>
+          <button class="mob-sidebar-open" hidden>ON THIS PAGE</button>
+          <div class="sidebar">
+            <div class="sidebar-inner">
+              <button class="mob-sidebar-close" hidden aria-label="Close table of contents"></button>
+              <p class="bip-toc__title">On this page</p>
+              {% include helpers/toc.html html=content sanitize=true h_min=2 h_max=3 %}
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <main class="toccontent bip-content">
+        <article class="article bip-document">
+          {{ content }}
+        </article>
+
+        <p class="bip-source-note">
+          Rendered from bitcoin/bips revision
+          <a href="https://github.com/bitcoin/bips/tree/{{ page.bip_source_commit }}"><code>{{ page.bip_source_commit | slice: 0, 12 }}</code></a>.
+          The document is distributed under its declared {{ page.bip_license | escape }} licence.
+        </p>
+
+        <nav class="bip-prev-next" aria-label="Adjacent BIPs">
+          {% if page.bip_previous %}
+            <a class="bip-prev-next__previous" href="/bip/{{ page.bip_previous.number }}/">
+              <span>Previous</span>BIP {{ page.bip_previous.number }}: {{ page.bip_previous.title | escape }}
+            </a>
+          {% endif %}
+          {% if page.bip_next %}
+            <a class="bip-prev-next__next" href="/bip/{{ page.bip_next.number }}/">
+              <span>Next</span>BIP {{ page.bip_next.number }}: {{ page.bip_next.title | escape }}
+            </a>
+          {% endif %}
+        </nav>
+      </main>
+    </div>
+  </div>
+</div>

--- a/_sass/bips.scss
+++ b/_sass/bips.scss
@@ -1,0 +1,731 @@
+/*
+This file is licensed under the MIT License (MIT) available on
+https://opensource.org/licenses/MIT.
+*/
+
+.bip-toolbar {
+    color: #d9dadd;
+    background: #090c14;
+    border-top: 1px solid #252936;
+}
+.bip-toolbar__inner {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+.bip-toolbar a {
+    margin: 3px 28px 3px 0;
+    color: #d9dadd;
+    font-size: 93.75%;
+}
+.bip-toolbar a:hover {
+    color: #fff;
+    text-decoration: underline;
+}
+
+.bip-hero {
+    padding: 75px 30px 82px;
+    color: #fff;
+    background-color: #13161f;
+    background-image: radial-gradient(circle at 82% 20%, #2b303d 0, #13161f 43%, #090c14 100%);
+}
+.bip-hero__inner {
+    max-width: 970px;
+}
+.bip-hero__eyebrow {
+    margin-bottom: 15px;
+    color: #ff9500;
+    font-size: 93.75%;
+    font-weight: 600;
+    letter-spacing: 1.5px;
+    text-align: left;
+    text-transform: uppercase;
+}
+.bip-hero h1 {
+    max-width: 930px;
+    margin: 0;
+    font-size: 300%;
+    font-weight: 600;
+    line-height: 1.15;
+    text-align: left;
+}
+.bip-hero__summary {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    margin-top: 30px;
+}
+.bip-hero__summary > span:not(.bip-status) {
+    margin: 5px 0 5px 18px;
+    padding-left: 18px;
+    color: #c3c5ca;
+    border-left: 1px solid #4d5260;
+}
+
+.bip-status {
+    display: inline-block;
+    min-width: 70px;
+    padding: 5px 12px;
+    color: #31343b;
+    font-size: 81.25%;
+    font-weight: 600;
+    line-height: 1.25;
+    text-align: center;
+    text-transform: uppercase;
+    background: #eceef1;
+    border-radius: 16px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+}
+.bip-status--deployed,
+.bip-status--complete {
+    color: #185d32;
+    background: #dff3e7;
+}
+.bip-status--draft {
+    color: #805000;
+    background: #fff0ce;
+}
+.bip-status--closed {
+    color: #5d616b;
+    background: #e7e8eb;
+}
+
+.bip-overview {
+    padding: 55px 0;
+    background: #f7f8fa;
+    border-bottom: 1px solid #e1e3e7;
+}
+.bip-overview > .container {
+    max-width: 1030px;
+}
+.bip-metadata {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    margin: -10px;
+}
+.bip-metadata > div {
+    width: 25%;
+    padding: 10px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+}
+.bip-metadata > .bip-metadata__wide {
+    width: 50%;
+}
+.bip-metadata dt {
+    margin-bottom: 4px;
+    color: #858994;
+    font-size: 75%;
+    font-weight: 600;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+}
+.bip-metadata dd {
+    margin: 0;
+    color: #252936;
+    font-size: 106.25%;
+    line-height: 1.45;
+}
+.bip-relations {
+    margin-top: 30px;
+    padding-top: 25px;
+    color: #555a66;
+    border-top: 1px solid #dfe1e5;
+}
+.bip-relations span {
+    display: inline-block;
+    margin: 4px 30px 4px 0;
+}
+.bip-status-notice,
+.bip-neutrality-notice {
+    margin-top: 30px;
+    padding: 18px 22px;
+    color: #555a66;
+    line-height: 1.55;
+    text-align: left;
+    background: #fff;
+    border: 1px solid #dfe1e5;
+    border-left: 4px solid #9196a1;
+    border-radius: 2px;
+}
+.bip-status-notice--draft {
+    background: #fffaf0;
+    border-left-color: #e99a18;
+}
+.bip-status-notice--closed {
+    background: #f4f5f7;
+    border-left-color: #777c87;
+}
+.bip-neutrality-notice {
+    border-left-color: #3490e6;
+}
+
+.bip-reader .toc-row {
+    -webkit-box-align: start;
+        -ms-flex-align: start;
+            align-items: flex-start;
+    padding-top: 70px;
+    padding-bottom: 80px;
+}
+.bip-reader .bip-toc {
+    min-width: 285px;
+    width: 285px;
+}
+.bip-reader .bip-toc > div {
+    padding-right: 30px;
+}
+.bip-reader .bip-toc .scroll {
+    width: 285px;
+}
+.bip-toc__title {
+    margin-bottom: 18px;
+    color: #858994;
+    font-size: 75%;
+    font-weight: 600;
+    letter-spacing: .6px;
+    text-align: left;
+    text-transform: uppercase;
+}
+.bip-reader .toc div > ul > li {
+    margin-bottom: 12px;
+}
+.bip-reader .toc div > ul > li > a {
+    padding-right: 18px;
+    font-size: 106.25%;
+    line-height: 1.35;
+}
+.bip-reader .toc div > ul > li > ul > li:first-child {
+    margin-top: 10px;
+}
+.bip-reader .toc div > ul > li > ul a {
+    margin-bottom: 8px;
+    font-size: 93.75%;
+    line-height: 1.35;
+}
+.bip-reader .toc ul li ul li a:hover::before,
+.bip-reader .toc ul li ul li a.active::before {
+    right: -30px;
+}
+.bip-content {
+    max-width: 855px;
+    padding: 0 0 0 45px;
+}
+
+.bip-document {
+    color: #353945;
+    font-size: 112.5%;
+    line-height: 1.7;
+    text-align: left;
+}
+.bip-document > h2:first-child {
+    margin-top: 0;
+}
+.bip-document h2 {
+    margin: 65px 0 20px;
+    padding-bottom: 10px;
+    color: #f07f00;
+    font-size: 166.67%;
+    font-weight: 600;
+    line-height: 1.25;
+    border-bottom: 1px solid #e5e6e9;
+}
+.bip-document h3 {
+    margin: 42px 0 15px;
+    color: #171a23;
+    font-size: 133.33%;
+    font-weight: 600;
+    line-height: 1.35;
+}
+.bip-document h4,
+.bip-document h5,
+.bip-document h6 {
+    margin: 32px 0 12px;
+    color: #252936;
+    font-size: 111.11%;
+    font-weight: 600;
+    line-height: 1.4;
+}
+.bip-document p,
+.bip-content .bip-document p:last-child {
+    margin: 0 0 20px;
+    color: #414652;
+    font-size: 100%;
+    line-height: 1.7;
+}
+.bip-document li {
+    margin: 8px 0;
+    color: #414652;
+    font-size: 100%;
+    line-height: 1.6;
+}
+.bip-content .bip-document ol {
+    font-size: 100%;
+}
+.bip-document ul,
+.bip-document ol {
+    margin: 0 0 24px;
+    padding-left: 30px;
+}
+.bip-document blockquote {
+    margin: 28px 0;
+    padding: 20px 25px;
+    color: #555a66;
+    font-size: 100%;
+    background: #f7f8fa;
+    border: 0;
+    border-left: 4px solid #ff9500;
+}
+.bip-document blockquote p:last-child {
+    margin-bottom: 0;
+}
+.bip-document code {
+    padding: 2px 6px;
+    color: #20242f;
+    font-family: Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 88.89%;
+    line-height: inherit;
+    white-space: normal;
+    background: #f1f2f4;
+    border-radius: 3px;
+}
+.bip-document pre {
+    max-width: 100%;
+    margin: 25px 0;
+    padding: 20px;
+    overflow: auto;
+    color: #e7e9ed;
+    line-height: 1.5;
+    white-space: pre;
+    background: #171a23;
+    border-radius: 4px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+}
+.bip-document pre code {
+    padding: 0;
+    color: inherit;
+    font-size: 83.33%;
+    line-height: inherit;
+    white-space: pre;
+    background: transparent;
+}
+.bip-document table {
+    width: 100%;
+    margin: 0;
+    border-collapse: collapse;
+    font-size: 88.89%;
+}
+.bip-document .bip-table-wrap {
+    max-width: 100%;
+    margin: 28px 0;
+    overflow-x: auto;
+    border: 1px solid #dfe1e5;
+    -webkit-overflow-scrolling: touch;
+}
+.bip-document .bip-table-wrap:focus {
+    border-color: #ff9500;
+    outline: 2px solid #ffe0b5;
+}
+.bip-document table th {
+    color: #252936;
+    font-weight: 600;
+    text-align: left;
+    background: #f2f3f5;
+}
+.bip-document table td,
+.bip-document table th {
+    padding: 10px 12px;
+    line-height: 1.45;
+    vertical-align: top;
+    border: 1px solid #dfe1e5;
+}
+.bip-document table p {
+    margin: 0;
+    font-size: 100%;
+    line-height: 1.45;
+}
+.bip-document figure {
+    margin: 35px 0;
+    text-align: center;
+}
+.bip-document figure > p,
+.bip-document figcaption p {
+    margin: 0;
+    color: inherit;
+}
+.bip-document figcaption {
+    margin-top: 10px;
+    color: #777c87;
+    font-size: 83.33%;
+}
+.bip-document img {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid #e1e3e7;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+}
+.bip-document .bip-footnotes {
+    margin-top: 30px;
+    padding: 25px 25px 5px;
+    background: #f7f8fa;
+    border-radius: 3px;
+}
+.bip-document .bip-footnotes li {
+    margin-bottom: 20px;
+}
+.bip-document .bip-note-backlinks {
+    display: inline-block;
+    margin-top: 5px;
+    font-size: 88.89%;
+}
+.bip-document .bip-poem {
+    margin: 25px 0;
+    padding-left: 25px;
+    white-space: pre-line;
+    border-left: 3px solid #dfe1e5;
+}
+.bip-document sup {
+    line-height: 0;
+}
+.bip-external-image {
+    font-size: 88.89%;
+}
+
+.bip-source-note {
+    margin-top: 65px;
+    padding-top: 25px;
+    color: #777c87;
+    font-size: 87.5%;
+    line-height: 1.6;
+    text-align: left;
+    border-top: 1px solid #dfe1e5;
+}
+.bip-source-note code {
+    padding: 2px 5px;
+    font-family: Consolas, "Liberation Mono", Menlo, monospace;
+    background: #f1f2f4;
+}
+.bip-prev-next {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
+    margin-top: 35px;
+}
+.bip-prev-next a {
+    display: block;
+    width: 47%;
+    padding: 18px 20px;
+    color: #353945;
+    line-height: 1.35;
+    border: 1px solid #dfe1e5;
+    border-radius: 2px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+}
+.bip-prev-next a:hover {
+    color: #13161f;
+    border-color: #ff9500;
+}
+.bip-prev-next a span {
+    display: block;
+    margin-bottom: 5px;
+    color: #858994;
+    font-size: 75%;
+    font-weight: 600;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+}
+.bip-prev-next__next {
+    margin-left: auto;
+    text-align: right;
+}
+
+.bip-index-hero__summary {
+    max-width: 700px;
+    margin-top: 20px;
+    color: #c3c5ca;
+    font-size: 125%;
+    line-height: 1.5;
+    text-align: left;
+}
+.bip-index-notice {
+    max-width: 970px;
+    margin-top: 45px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+}
+.bip-index-intro {
+    padding: 45px 0 25px;
+}
+.bip-index-intro p {
+    color: #414652;
+    font-size: 125%;
+    line-height: 1.55;
+    text-align: left;
+}
+.bip-index-intro .bip-index-revision {
+    margin-top: 5px;
+    color: #858994;
+    font-size: 93.75%;
+}
+.bip-index-intro code {
+    font-family: Consolas, "Liberation Mono", Menlo, monospace;
+}
+.bip-index-browser {
+    padding: 15px 0 90px;
+}
+.bip-index-controls {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: end;
+        -ms-flex-align: end;
+            align-items: flex-end;
+    margin: 0 -8px 18px;
+}
+.bip-index-field {
+    width: 30%;
+    padding: 0 8px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+}
+.bip-index-field--search {
+    width: 70%;
+}
+.bip-index-field label {
+    display: block;
+    margin-bottom: 7px;
+    color: #555a66;
+    font-size: 87.5%;
+    font-weight: 600;
+    text-align: left;
+}
+.bip-index-field input,
+.bip-index-field select {
+    width: 100%;
+    height: 48px;
+    padding: 0 15px;
+    color: #252936;
+    font-family: inherit;
+    font-size: 100%;
+    background: #fff;
+    border: 1px solid #cfd2d8;
+    border-radius: 2px;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+}
+.bip-index-field input:focus,
+.bip-index-field select:focus {
+    border-color: #ff9500;
+    outline: 2px solid #ffe0b5;
+}
+.bip-result-count {
+    margin: 0 0 12px;
+    color: #777c87;
+    font-size: 87.5%;
+    text-align: left;
+}
+.bip-index-table-wrap {
+    overflow-x: auto;
+    border: 1px solid #dfe1e5;
+    border-radius: 2px;
+}
+.bip-index-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+}
+.bip-index-table th {
+    padding: 14px 16px;
+    color: #555a66;
+    font-size: 81.25%;
+    font-weight: 600;
+    letter-spacing: .4px;
+    text-transform: uppercase;
+    background: #f2f3f5;
+    border: 0;
+    border-bottom: 1px solid #dfe1e5;
+}
+.bip-index-table td {
+    padding: 13px 16px;
+    color: #555a66;
+    line-height: 1.4;
+    border: 0;
+    border-bottom: 1px solid #eceef1;
+}
+.bip-index-table tr:last-child td {
+    border-bottom: 0;
+}
+.bip-index-table tr:hover td {
+    background: #fffaf3;
+}
+.bip-index-number {
+    width: 100px;
+    white-space: nowrap;
+}
+.bip-index-number a {
+    color: #f07f00;
+    font-weight: 600;
+}
+.bip-index-title a {
+    color: #252936;
+    font-weight: 600;
+}
+.bip-no-results {
+    padding: 45px;
+    color: #777c87;
+    text-align: center;
+    background: #f7f8fa;
+}
+
+@media handheld, only screen and ( max-width: 60em ), only screen and ( max-device-width: 60em ) {
+    .bip-metadata > div,
+    .bip-metadata > .bip-metadata__wide {
+        width: 50%;
+    }
+    .bip-reader .bip-toc,
+    .bip-reader .bip-toc .scroll {
+        min-width: 245px;
+        width: 245px;
+    }
+    .bip-content {
+        padding-left: 30px;
+    }
+    .bip-document table {
+        min-width: 640px;
+    }
+}
+
+@media handheld, only screen and ( max-width: 40em ), only screen and ( max-device-width: 40em ) {
+    .bip-toolbar__inner {
+        padding-right: 15px;
+        padding-left: 15px;
+    }
+    .bip-toolbar a {
+        margin-right: 18px;
+    }
+    .bip-hero {
+        padding: 55px 15px 60px;
+    }
+    .bip-hero h1 {
+        font-size: 225%;
+    }
+    .bip-hero__summary > span:not(.bip-status) {
+        margin-left: 10px;
+        padding-left: 10px;
+    }
+    .bip-overview {
+        padding: 40px 0;
+    }
+    .bip-metadata > div,
+    .bip-metadata > .bip-metadata__wide {
+        width: 100%;
+    }
+    .bip-status-notice,
+    .bip-neutrality-notice {
+        padding: 16px;
+    }
+    .bip-reader .bip-toc {
+        width: 100%;
+    }
+    .bip-content {
+        max-width: none;
+        padding: 30px 15px 0;
+    }
+    .bip-content .bip-document > * {
+        padding-right: 0;
+        padding-left: 0;
+    }
+    .bip-document h2 {
+        margin-top: 50px;
+        font-size: 150%;
+    }
+    .bip-document h3 {
+        font-size: 125%;
+    }
+    .bip-document pre {
+        margin-right: -15px;
+        margin-left: -15px;
+        border-radius: 0;
+    }
+    .bip-prev-next {
+        display: block;
+    }
+    .bip-prev-next a {
+        width: 100%;
+        margin-bottom: 12px;
+    }
+    .bip-index-controls {
+        display: block;
+    }
+    .bip-index-field,
+    .bip-index-field--search {
+        width: 100%;
+        margin-bottom: 15px;
+    }
+    .bip-index-table {
+        min-width: 650px;
+    }
+}
+
+@media print {
+    .bip-toolbar,
+    .bip-toc,
+    .bip-prev-next,
+    .bip-status-notice,
+    .bip-index-controls {
+        display: none;
+    }
+    .bip-hero {
+        padding: 20px 0 30px;
+        color: #000;
+        background: #fff;
+        border-bottom: 2px solid #000;
+    }
+    .bip-hero h1,
+    .bip-hero__eyebrow,
+    .bip-hero__summary > span:not(.bip-status) {
+        color: #000;
+    }
+    .bip-overview {
+        padding: 25px 0;
+        background: #fff;
+    }
+    .bip-neutrality-notice {
+        margin-top: 15px;
+    }
+    .bip-reader .toc-row {
+        padding: 30px 0;
+    }
+    .bip-content {
+        max-width: none;
+        padding: 0;
+        border: 0;
+    }
+    .bip-document pre {
+        color: #000;
+        white-space: pre-wrap;
+        background: #f2f2f2;
+    }
+    .bip-document a {
+        color: #000;
+        text-decoration: underline;
+    }
+}

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -1217,6 +1217,7 @@ en:
     menu-bitcoin-for-businesses: Businesses
     menu-bitcoin-for-developers: Developers
     menu-bitcoin-for-individuals: Individuals
+    menu-bips: "Bitcoin Improvement Proposals"
     menu-community: Community
     menu-development: Development
     menu-developer-documentation: Documentation

--- a/css/main.scss
+++ b/css/main.scss
@@ -5,5 +5,6 @@
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
         "normalize",
-        "screen"
+        "screen",
+        "bips"
 ;

--- a/docs/setting-up-your-environment.md
+++ b/docs/setting-up-your-environment.md
@@ -29,7 +29,12 @@ dependencies and tools, which are pretty easy on any modern Linux:
 On recent versions of Ubuntu and Debian, you can run the following
 command to ensure you have the required libraries, headers, and tools:
 
-    sudo apt-get install build-essential git libicu-dev zlib1g-dev
+    sudo apt-get install build-essential git libicu-dev pandoc python3 zlib1g-dev
+
+Python and Pandoc generate the local HTML mirror of the BIP documents. The
+generator fetches the exact `bitcoin/bips` revision pinned in
+`_build/bips-source.json`, caches it in `_cache`, and refuses to build a partial
+or different revision.
 
 **Install RVM**
 
@@ -153,6 +158,7 @@ Plugins include:
 |--------------|---------|----------------|------------------------
 | alerts       | 5       | --             | Network alert pages
 | autocrossref | 90      | --             | Developer documentation
+| bips         | 40      | GitHub.com     | Bitcoin Improvement Proposals
 | contributors | 5       | GitHub.com     | Contributor listings
 | glossary     | 30      | --             | Developer glossary
 | redirects    | 20      | --             | Redirects from old URLs

--- a/js/base.js
+++ b/js/base.js
@@ -142,15 +142,23 @@ function onTouchClick(e, callback, callbackClick) {
 }
 
 function mobileMenuShow(e) {
-  // Show the mobile menu when the visitors touch the menu icon.
-  var show = function() {
-    var mm = document.getElementById('menusimple');
-    var ml = document.getElementById('langselect');
-    mm.style.display = ml.style.display = (mm.style.display === 'block') ? '' : 'block';
-    addClass(mm, 'menutap');
-    cancelEvent(e);
-  };
-  onTouchClick(e, show);
+    var show = function() {
+        var mm = document.getElementById('menusimple');
+        var ml = document.getElementById('langselect');
+        var display = (mm.style.display === 'block') ? '' : 'block';
+
+        mm.style.display = display;
+
+        // Some pages, such as BIP pages, have no language selector.
+        if (ml) {
+            ml.style.display = display;
+        }
+
+        addClass(mm, 'menutap');
+        cancelEvent(e);
+    };
+
+    onTouchClick(e, show);
 }
 
 function mobileMenuHover(e) {

--- a/js/bips.js
+++ b/js/bips.js
@@ -1,0 +1,46 @@
+// This file is licensed under the MIT License (MIT) available on
+// https://opensource.org/licenses/MIT.
+
+"use strict";
+
+(function() {
+  var search = document.getElementById('bip-search');
+  var status = document.getElementById('bip-status-filter');
+  var resultCount = document.getElementById('bip-result-count');
+  var noResults = document.getElementById('bip-no-results');
+
+  if (!search || !status || !resultCount || !noResults) return;
+
+  var rows = document.getElementsByClassName('bip-index-row');
+
+  function normalized(value) {
+    return value.toLowerCase().replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ');
+  }
+
+  function filterBips() {
+    var query = normalized(search.value);
+    var selectedStatus = status.value;
+    var shown = 0;
+
+    for (var index = 0; index < rows.length; index++) {
+      var row = rows[index];
+      var matchesQuery = !query || normalized(row.getAttribute('data-search')).indexOf(query) !== -1;
+      var matchesStatus = !selectedStatus || row.getAttribute('data-status') === selectedStatus;
+      var visible = matchesQuery && matchesStatus;
+
+      row.style.display = visible ? '' : 'none';
+      row.setAttribute('aria-hidden', visible ? 'false' : 'true');
+      if (visible) shown++;
+    }
+
+    resultCount.textContent = shown === rows.length ?
+      'Showing all ' + rows.length + ' BIPs' :
+      'Showing ' + shown + ' of ' + rows.length + ' BIPs';
+    noResults.hidden = shown !== 0;
+  }
+
+  addEvent(search, 'input', filterBips);
+  addEvent(search, 'keyup', filterBips);
+  addEvent(status, 'change', filterBips);
+  filterBips();
+}());


### PR DESCRIPTION
Adds a dedicated Bitcoin Improvement Proposals section to Bitcoin.org at `/bips/`.

BIPs are converted from the canonical [bitcoin/bips](https://github.com/bitcoin/bips) repository into readable, static HTML pages. Individual proposals are available at clean URLs such as `/bip/110/`.

## Features

* Searchable BIP index with status filtering.
* Responsive, readable BIP document pages.
* Metadata including authors, status, type, layer, licence and assigned date.
* Links to the canonical source, revision history and discussions.
* Relationships between BIPs, including requirements and replacements.
* Page table of contents and previous/next navigation.
* Neutrality notices clarifying that publication does not imply adoption or endorsement.
* Canonical URLs, Open Graph metadata and `TechArticle` structured data.
* Navigation and footer links to the new BIP section.

## Build process

* Generates the pages from a pinned `bitcoin/bips` commit for reproducible builds.
* Copies and validates referenced BIP images and other assets.
* Rejects incomplete, unsafe or inconsistent generated output.
* Integrates BIP generation and validation into the Makefile and CI process.
* Includes automated tests for parsing, conversion, metadata and output validation.

## Test plan

* Needs `pandoc` and `python3` installed
* Run `python3 _build/test_bips.py`.
* Generate the BIP section and confirm all expected pages and assets are produced.
* Open `/bips/` and test search and status filtering.
* Open `/bip/110/` and verify formatting, metadata, links and table-of-contents navigation.
* Test desktop and mobile navigation.
* Confirm canonical and structured metadata are present in the generated HTML.

@devdavidejesus Can you test everything is working properly?

_**Do not merge**_ as the required dependencies are not yet installed on the build server.