### PR TITLE
wallets: drop legacy_addresses from BitBox02

### DIFF
--- a/_wallets/bitbox.md
+++ b/_wallets/bitbox.md
@@ -16,7 +16,7 @@ platform:
         link: "https://bitbox.swiss/bitbox02/"
         source: "https://github.com/BitBoxSwiss/bitbox02-firmware"
         screenshot: "bitbox02.png"
-        features: "bech32 hardware_wallet legacy_addresses multisig segwit taproot"
+        features: "bech32 hardware_wallet multisig segwit taproot"
         check:
           control: "checkgoodcontrolfull"
           validation: "checkneutralvalidationvariable"


### PR DESCRIPTION
The BitBox02 entry declares `legacy_addresses`, but the wallet cannot generate a legacy receive address.

Verified in the firmware source declared by this entry: the address types the device derives for itself are P2WPKH-P2SH, P2WPKH and P2TR. There is no P2PKH, so a `1...` address cannot be produced at all. Wrapped SegWit would satisfy the `3...` form the criterion mentions, but the companion application removed it from the receive flow, leaving native SegWit and Taproot as the only options in the address-type selector.

Sending to legacy addresses works normally and is unaffected by this change. The criterion asks that it be easy and obvious for users to generate a legacy format receive address, which this wallet does not support.