### PR TITLE
Restore parity between the header and footer menus

### DIFF
--- a/_includes/layout/base/footer-menu.html
+++ b/_includes/layout/base/footer-menu.html
@@ -78,6 +78,14 @@ https://opensource.org/licenses/MIT.
         <li{% if page.id == 'community' %} class="active"{% endif %}>
           <a href="/{{ page.lang }}/{% translate community url %}">{% translate menu-community layout %}</a>
         </li>
+        <li{% if page.id == 'bip' %} class="active"{% endif %}>
+          <a href="/bips/">{% translate menu-bips layout %}</a>
+        </li>
+        {% if page.lang == 'en' %}
+        <li>
+          <a href="https://developer.bitcoin.org/">{% translate menu-developer-documentation layout %}</a>
+        </li>
+        {% endif %}
         <li{% if page.id == 'vocabulary' %} class="active"{% endif %}>
           <a href="/{{ page.lang }}/{% translate vocabulary url %}">{% translate menu-vocabulary layout %}
           </a>

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -11,6 +11,7 @@ https://opensource.org/licenses/MIT.
       <li><a href="https://developer.bitcoin.org/">{% translate menu-bitcoin-for-developers layout %}</a></li>
       <li{% if page.id == 'getting-started' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate getting-started url %}">{% translate menu-getting-started layout %}</a></li>
       <li{% if page.id == 'how-it-works' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate how-it-works url %}">{% translate menu-how-it-works layout %}</a></li>
+      <li{% if page.id == 'you-need-to-know' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate you-need-to-know url %}">{% translate menu-you-need-to-know layout %}</a></li>
       {% if
          page.lang == 'en' or
          page.lang == 'de' or


### PR DESCRIPTION
While browsing the site after the BIPs launch I noticed the header and footer menus have drifted apart — some destinations exist in one but not the other. This PR restores parity between them, mirroring each entry where it was missing (+9 lines, no other changes):

**Resources** (footer was missing two entries the header has):
- **BIPs list** → `/bips/` — added to the footer, right after Community, matching the header order
- **Documentation** → `developer.bitcoin.org` — added to the footer, preserving the header's English-only gate (`{% if page.lang == 'en' %}`), so untranslated locales keep hiding it in both menus

**Introduction** (header was missing one entry the footer has):
- **You need to know** → added to the header dropdown after How it works, matching the footer order

After this, the three shared sections (Introduction, Resources, Participate) offer the same destinations in the same order in both menus. Left untouched on purpose: FAQ and Innovation (top-level tabs without a footer column — editorial call) and the footer-only Other column (Legal, Privacy, Press, About), which is standard footer design.

Verified with a full local build: every mirrored link renders and resolves on the English pages, and the language gate holds (Documentation does not leak into non-EN footers).

cc @Cobra-Bitcoin — small polish follow-up to the BIPs launch; happy to adjust if any of these placements should differ.