### PR TITLE
Update the Spend Bitcoin card on the Resources page

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -117,7 +117,7 @@ id: resources
           <a href="https://www.bitrefill.com/">Bitrefill</a>
         </p>
         <p>
-          <a href="https://gyft.com/bitcoin/">Gyft</a>
+          <a href="https://galaxymind.space/">Galaxy Mind</a>
         </p>
         <p>
           <a href="https://btcmap.org/">BTCMap.org</a>


### PR DESCRIPTION
Replaces Gyft with Galaxy Mind on the Resources page card, matching the [Spending Bitcoin page](https://bitcoin.org/en/spend-bitcoin) recommendations. Bitrefill and BTCMap.org already match.