### PR TITLE
Remove three dormant projects from the Development page

### DIFF
--- a/_templates/development.html
+++ b/_templates/development.html
@@ -105,7 +105,6 @@ Want to contribute to a different project?
 
 <ul class="devprojectlist">
   <li><a href="https://github.com/goatpig/BitcoinArmory">Armory</a> - A wallet with enhanced security features, written in C++.</li>
-  <li><a href="https://github.com/luke-jr/bfgminer">BFGMiner</a> - A modular miner, written in C.</li>
   <li><a href="https://github.com/bitcoin-wallet/bitcoin-wallet">Bitcoin Wallet</a> - A SPV wallet for Android, written in Java.</li>
   <li><a href="https://github.com/bitcoinj/bitcoinj">bitcoinj</a> - A library for SPV wallets, written in Java.</li>
   <li><a href="https://github.com/btcsuite/btcd">btcd</a> - A full node, written in Go.</li>
@@ -113,14 +112,12 @@ Want to contribute to a different project?
   <li><a href="https://github.com/btcsuite/btcwallet">btcwallet</a> - A hierarchical deterministic wallet daemon, written in Go.</li>
   <li><a href="https://bitbucket.org/ckolivas/ckpool">ckpool</a> - A fast mining pool server application, written in C.</li>
   <li><a href="https://github.com/spesmilo/electrum">Electrum</a> - A fast server-trusting wallet, written in Python.</li>
-  <li><a href="https://github.com/luke-jr/eloipool">Eloipool</a> - A fast mining pool server application, written in Python.</li>
   <li><a href="https://github.com/jprupp/haskoin-core">Haskoin</a> - An implementation of the Bitcoin protocol, written in Haskell.</li>
   <li><a href="https://github.com/libbitcoin/libbitcoin-system">Libbitcoin</a> - A cross-platform development toolkit, written in C++.</li>
   <li><a href="https://github.com/libbitcoin/libbitcoin-server/">Libbitcoin Server</a> - A full node and query server, built on libbitcoin.</li>
   <li><a href="https://github.com/libbitcoin/libbitcoin-explorer">Libbitcoin Explorer</a> - A command line tool, built on libbitcoin.</li>
   <li><a href="https://github.com/MetacoSA/NBitcoin">NBitcoin</a> - A cross-platform library, written in C#.</li>
   <li><a href="https://github.com/petertodd/python-bitcoinlib">python-bitcoinlib</a> - A library for structures and protocols, written in Python.</li>
-  <li><a href="https://github.com/luke-jr/python-blkmaker">Python Blkmaker</a> - A client library for the getblocktemplate mining protocol, written in Python.</li>
   <li class="more"><a onclick="librariesShow(event)" ontouchstart="librariesShow(event);" class="link-js">{% translate moremore %}</a></li>
 </ul>
 </div>


### PR DESCRIPTION
Follow-up to #4902.

Remove the Python Blkmaker, Eloipool, and BFGMiner entries from the Development page.

As discussed in #4902, while the repositories are still functional, their default branches have not seen meaningful activity for several years. The discussion concluded that these projects no longer fit the purpose of the section as well as currently active projects that are more relevant to new contributors.

This keeps the Development page focused on projects that are actively maintained and suitable for new contributors.

Closes #4902.