### PR TITLE
Remove Bitcoin.de from the exchanges page

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -214,8 +214,6 @@ id: exchanges
       <p>
         <a class="marketplace-link" href="https://www.binance.com">Binance</a>
         <br>
-        <a class="marketplace-link" href="https://www.bitcoin.de/">Bitcoin.de</a>
-        <br>
         <a class="marketplace-link" href="https://bitfinex.com/">Bitfinex</a>
         <br>
         <a class="marketplace-link" href="https://bitflyer.com/en-eu/">bitFlyer</a>


### PR DESCRIPTION
Bitcoin.de's own homepage (status notice dated August 21, 2026) states that trading and deposits are paused until further notice pending its MiCAR authorization — only withdrawals are being processed. Trading has been suspended since June 12, so the page is currently pointing users at a venue where bitcoin cannot be bought. Happy to re-add it when the platform relaunches.