### PR TITLE
Remove the dormant Italian organization from the Community page

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -178,13 +178,6 @@ id: community
           </div>
         </div>
         
-        <div class="row organizations-item">
-          <img class="organization-img" src="/img/flags/IT.svg?{{site.time | date: '%s'}}" alt="Italian flag">
-          <div>
-            <h3 class="organization-country" id="italy">Italy</h3>
-            <a class="organization-link" href="https://www.bitcoin-italia.org/">Bitcoin Foundation Italia</a>
-          </div>
-        </div>   
         
         
         <div class="row organizations-item">


### PR DESCRIPTION
Resolves the item left open for discussion in #4826: bitcoin-italia.org has been dormant since February 2021, and its HTTPS certificate is now broken. No objections in the month since. Closes #4826.