### PR TITLE
Modernize the Community page links

### DIFF
--- a/_templates/community.html
+++ b/_templates/community.html
@@ -71,16 +71,15 @@ id: community
           <a href="https://vk.com/bitcoin">Страница на ВКонтакте</a>
         </p>{% endif %}
         <p>
-          <a href="https://twitter.com/search?q=bitcoin">{% translate linktwitter %}</a>
+          <a href="https://x.com/search?q=bitcoin">{% translate linktwitter %}</a>
         </p>
-        <p>{% translate facebook %}</p>
       </div>
     
       <div class="community-card card">
         <h2 id="meetups">
           <img src="/img/icons/ico_meetups.svg?{{site.time | date: '%s'}}" class="titleicon" alt="Icon">{% translate meetups %}</h2>
         <p>
-          <a href="https://bitcoin.meetup.com/">{% translate meetupgroup %}</a>
+          <a href="https://www.meetup.com/topics/bitcoin/">{% translate meetupgroup %}</a>
         </p>
         <p>
           <a href="https://bitcointalk.org/index.php?board=86.0">{% translate meetupbitcointalk %}</a>
@@ -105,9 +104,6 @@ id: community
         </p>
         <p>#bitcoin-market
           <small>{% translate chanmarket %}</small>
-        </p>
-        <p>#bitcoin-mining
-          <small>{% translate chanmining %}</small>
         </p>
         {% if page.lang == 'fr' %}
         <p>#bitcoin-fr

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -179,10 +179,8 @@ en:
     chandev: "(Development and technical)"
     chanotc: "(Over The Counter exchange)"
     chanmarket: "(Live quotes from markets)"
-    chanmining: "(Bitcoin mining related)"
     social: "Social networks"
     linktwitter: "Twitter"
-    facebook: '<a href="https://www.facebook.com/hashtag/bitcoin">Facebook</a>'
     meetups: "Meetups"
     meetupevents: "Bitcoin Conferences And Events"
     meetupgroup: "Bitcoin Meetup Groups"


### PR DESCRIPTION
The factual fixes from #4825: Twitter search now points at x.com, the Facebook hashtag feed is removed, the dead bitcoin.meetup.com subdomain is replaced with the [live Meetup topic page](https://www.meetup.com/topics/bitcoin/), and the abandoned #bitcoin-mining IRC channel is dropped. The Events link was already resolved by the Events page removal, and the editorial additions discussed there (Nostr etc.) received no input, so they stay out for now. Closes #4825.