### PR TITLE
Show the Price menu entry on English pages only

### DIFF
--- a/_includes/layout/base/footer-menu.html
+++ b/_includes/layout/base/footer-menu.html
@@ -125,7 +125,9 @@ https://opensource.org/licenses/MIT.
     </div>
     <div class="footermenu-item footermenu-other">
       <p class="footer-title">{% translate menu-other layout %}:</p>
-      <a href="/price/">{% translate menu-price layout %}</a>
+      {% if page.lang == 'en' %}
+          <a href="/price/">{% translate menu-price layout %}</a>
+      {% endif %}
       {% if page.lang == 'en' %}
       <a href="/{{ page.lang }}/{% translate scams url %}">{% translate menu-scams layout %}</a>
       {% endif %}

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -67,5 +67,5 @@ https://opensource.org/licenses/MIT.
     </ul>
   </li>
   <li{% if page.id == 'faq' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate faq url %}">{% translate menu-faq layout %}</a></li>
-  <li{% if page.id == 'price' %} class="active"{% endif %}><a href="/price/">{% translate menu-price layout %}</a></li>
+  {% if page.lang == 'en' %}<li{% if page.id == 'price' %} class="active"{% endif %}><a href="/price/">{% translate menu-price layout %}</a></li>{% endif %}
 </ul>


### PR DESCRIPTION
The Price page is English-only, so the menu entry (header and footer) is now gated to English pages. The `menu-price` string stays translatable for when the page gets localized.