### PR TITLE
Add /en/halving: Bitcoin halving countdown page

### DIFF
--- a/_includes/layout/base/footer-menu.html
+++ b/_includes/layout/base/footer-menu.html
@@ -82,6 +82,11 @@ https://opensource.org/licenses/MIT.
           <a href="/bips/">{% translate menu-bips layout %}</a>
         </li>
         {% if page.lang == 'en' %}
+        <li{% if page.id == 'halving' %} class="active"{% endif %}>
+          <a href="/{{ page.lang }}/{% translate halving url %}">{% translate menu-halving layout %}</a>
+        </li>
+        {% endif %}
+        {% if page.lang == 'en' %}
         <li>
           <a href="https://developer.bitcoin.org/">{% translate menu-developer-documentation layout %}</a>
         </li>

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -42,6 +42,13 @@ https://opensource.org/licenses/MIT.
       <li{% if page.id == 'community' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate community url %}">{% translate menu-community layout %}</a></li>
       <li{% if page.id == 'bip' %} class="active"{% endif %}><a href="/bips/">{% translate menu-bips layout %}</a></li>
       {% comment %}
+        After the halving page is translated, add the language to the
+        condition below
+      {% endcomment %}
+      {% if page.lang == 'en' %}
+      <li{% if page.id == 'halving' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate halving url %}">{% translate menu-halving layout %}</a></li>
+      {% endif %}
+      {% comment %}
         After the developer-documentation page is translated, add the language
         to the condition below
       {% endcomment %}

--- a/_sass/_halving.scss
+++ b/_sass/_halving.scss
@@ -1,0 +1,59 @@
+.halving-stats {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin: 32px 0;
+}
+.halving-stat {
+    -ms-flex: 1 1 180px;
+    flex: 1 1 180px;
+    padding: 20px;
+    border: 1px solid #e0e6eb;
+    border-radius: 8px;
+    text-align: center;
+}
+.halving-stat-value {
+    display: block;
+    font-size: 175%;
+    font-weight: 600;
+    color: #f7931a;
+}
+.halving-stat-label {
+    display: block;
+    margin-top: 6px;
+    font-size: 87.5%;
+    color: #6b7f8f;
+}
+.halving-progress {
+    height: 10px;
+    border-radius: 5px;
+    background: #e0e6eb;
+    overflow: hidden;
+    margin: 8px 0 40px;
+}
+.halving-progress-bar {
+    height: 100%;
+    width: 0;
+    border-radius: 5px;
+    background: #f7931a;
+}
+.halving-chart-wrap {
+    margin: 24px 0 40px;
+}
+.halving-chart-wrap canvas {
+    width: 100%;
+    height: auto;
+}
+.halving-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 24px 0 40px;
+}
+.halving-table th,
+.halving-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid #e0e6eb;
+    text-align: left;
+}

--- a/_sass/_halving.scss
+++ b/_sass/_halving.scss
@@ -57,3 +57,6 @@
     border-bottom: 1px solid #e0e6eb;
     text-align: left;
 }
+.halving-end {
+    margin-bottom: 64px;
+}

--- a/_templates/halving.html
+++ b/_templates/halving.html
@@ -2,17 +2,9 @@
 # This file is licensed under the MIT License (MIT) available on
 # https://opensource.org/licenses/MIT.
 
-layout: base
+layout: sidebar
 id: halving
 ---
-<div class="hero">
-  <div class="container hero-container">
-    <h1>{% translate pagetitle %}</h1>
-    <p class="summarytxt">{% translate summary %}</p>
-  </div>
-</div>
-<div class="container">
-
   <div class="halving-stats">
     <div class="halving-stat"><span class="halving-stat-value" id="halving-remaining">&mdash;</span><span class="halving-stat-label">{% translate statremaining %}</span></div>
     <div class="halving-stat"><span class="halving-stat-value" id="halving-date">&mdash;</span><span class="halving-stat-label">{% translate statdate %}</span></div>
@@ -23,13 +15,13 @@ id: halving
   <p>{% translate progresstxt %}</p>
   <div class="halving-progress"><div class="halving-progress-bar" id="halving-progress-bar"></div></div>
 
-  <h2>{% translate chartsubsidy %}</h2>
+  <h2 id="reward-chart">{% translate chartsubsidy %}</h2>
   <div class="halving-chart-wrap"><canvas id="halving-subsidy-chart" width="900" height="420" data-label-x="{% translate chartblocks %}"></canvas></div>
 
-  <h2>{% translate chartsupply %}</h2>
+  <h2 id="supply-chart">{% translate chartsupply %}</h2>
   <div class="halving-chart-wrap"><canvas id="halving-supply-chart" width="900" height="420" data-label-cap="{% translate chartcap %}" data-label-x="{% translate chartblocks %}"></canvas></div>
 
-  <h2>{% translate historytitle %}</h2>
+  <h2 id="history">{% translate historytitle %}</h2>
   <table class="halving-table">
     <thead><tr><th>{% translate colevent %}</th><th>{% translate coldate %}</th><th>{% translate colblock %}</th><th>{% translate colreward %}</th></tr></thead>
     <tbody>
@@ -41,14 +33,13 @@ id: halving
     </tbody>
   </table>
 
-  <h2>{% translate whatis %}</h2>
+  <h2 id="what-is-the-halving">{% translate whatis %}</h2>
   <p>{% translate whatistxt %}</p>
-  <h2>{% translate why %}</h2>
+  <h2 id="why-fixed-supply">{% translate why %}</h2>
   <p>{% translate whytxt %}</p>
-  <h2>{% translate miners %}</h2>
+  <h2 id="miners">{% translate miners %}</h2>
   <p>{% translate minerstxt %}</p>
-  <h2>{% translate howest %}</h2>
-  <p>{% translate howesttxt %}</p>
+  <h2 id="date-estimate">{% translate howest %}</h2>
+  <p class="halving-end">{% translate howesttxt %}</p>
 
-</div>
 <script src="/js/halving.js?{{site.time | date: '%s'}}"></script>

--- a/_templates/halving.html
+++ b/_templates/halving.html
@@ -1,0 +1,54 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# https://opensource.org/licenses/MIT.
+
+layout: base
+id: halving
+---
+<div class="hero">
+  <div class="container hero-container">
+    <h1>{% translate pagetitle %}</h1>
+    <p class="summarytxt">{% translate summary %}</p>
+  </div>
+</div>
+<div class="container">
+
+  <div class="halving-stats">
+    <div class="halving-stat"><span class="halving-stat-value" id="halving-remaining">&mdash;</span><span class="halving-stat-label">{% translate statremaining %}</span></div>
+    <div class="halving-stat"><span class="halving-stat-value" id="halving-date">&mdash;</span><span class="halving-stat-label">{% translate statdate %}</span></div>
+    <div class="halving-stat"><span class="halving-stat-value" id="halving-height">&mdash;</span><span class="halving-stat-label">{% translate statheight %}</span></div>
+    <div class="halving-stat"><span class="halving-stat-value">3.125 BTC</span><span class="halving-stat-label">{% translate statreward %}</span></div>
+    <div class="halving-stat"><span class="halving-stat-value">1.5625 BTC</span><span class="halving-stat-label">{% translate statnext %}</span></div>
+  </div>
+  <p>{% translate progresstxt %}</p>
+  <div class="halving-progress"><div class="halving-progress-bar" id="halving-progress-bar"></div></div>
+
+  <h2>{% translate chartsubsidy %}</h2>
+  <div class="halving-chart-wrap"><canvas id="halving-subsidy-chart" width="900" height="420" data-label-x="{% translate chartblocks %}"></canvas></div>
+
+  <h2>{% translate chartsupply %}</h2>
+  <div class="halving-chart-wrap"><canvas id="halving-supply-chart" width="900" height="420" data-label-cap="{% translate chartcap %}" data-label-x="{% translate chartblocks %}"></canvas></div>
+
+  <h2>{% translate historytitle %}</h2>
+  <table class="halving-table">
+    <thead><tr><th>{% translate colevent %}</th><th>{% translate coldate %}</th><th>{% translate colblock %}</th><th>{% translate colreward %}</th></tr></thead>
+    <tbody>
+      <tr><td>{% translate event1 %}</td><td>2012-11-28</td><td>210,000</td><td>25 BTC</td></tr>
+      <tr><td>{% translate event2 %}</td><td>2016-07-09</td><td>420,000</td><td>12.5 BTC</td></tr>
+      <tr><td>{% translate event3 %}</td><td>2020-05-11</td><td>630,000</td><td>6.25 BTC</td></tr>
+      <tr><td>{% translate event4 %}</td><td>2024-04-20</td><td>840,000</td><td>3.125 BTC</td></tr>
+      <tr><td>{% translate eventnext %}</td><td>2028 ({% translate estimated %})</td><td>1,050,000</td><td>1.5625 BTC</td></tr>
+    </tbody>
+  </table>
+
+  <h2>{% translate whatis %}</h2>
+  <p>{% translate whatistxt %}</p>
+  <h2>{% translate why %}</h2>
+  <p>{% translate whytxt %}</p>
+  <h2>{% translate miners %}</h2>
+  <p>{% translate minerstxt %}</p>
+  <h2>{% translate howest %}</h2>
+  <p>{% translate howesttxt %}</p>
+
+</div>
+<script src="/js/halving.js?{{site.time | date: '%s'}}"></script>

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -884,6 +884,39 @@ en:
     list3: "Low processing fees"
     desc: "Bitcoin uses peer-to-peer technology to operate with no central authority or banks; managing transactions and the issuing of bitcoins is carried out collectively by the network. <b>Bitcoin is open-source; its design is public, nobody owns or controls Bitcoin and <a href=\"#support-bitcoin#\">everyone can take part</a></b>. Through many of its unique properties, Bitcoin allows exciting uses that could not be covered by any previous payment system."
     overview: "Get a quick overview for"
+  halving:
+    title: "Bitcoin Halving Countdown - Bitcoin"
+    pagetitle: "Bitcoin Halving Countdown"
+    summary: "Roughly every four years, the reward that Bitcoin pays for mining a block is cut in half. This page tracks the countdown to the next halving and explains why the schedule exists."
+    statheight: "Current block height"
+    statremaining: "Blocks until the halving"
+    statdate: "Estimated date"
+    statreward: "Current block reward"
+    statnext: "Reward after the halving"
+    progresstxt: "Progress through the current halving period"
+    chartsubsidy: "Block reward over time"
+    chartsupply: "Total supply approaching 21 million"
+    chartcap: "21 million cap"
+    chartblocks: "Block height"
+    historytitle: "Halving history"
+    colevent: "Event"
+    coldate: "Date"
+    colblock: "Block"
+    colreward: "New reward"
+    event1: "First halving"
+    event2: "Second halving"
+    event3: "Third halving"
+    event4: "Fourth halving"
+    eventnext: "Fifth halving"
+    estimated: "estimated"
+    whatis: "What is the halving?"
+    whatistxt: "New bitcoins enter circulation as a reward to the miner of each block. Every 210,000 blocks — roughly four years — that reward is cut in half. This event is called the halving. It started at 50 bitcoins per block in 2009 and reaches zero around the year 2140, when all bitcoins will have been issued."
+    why: "Why does Bitcoin do this?"
+    whytxt: "Bitcoin has a fixed supply: there will never be more than 21 million bitcoins. The halving schedule is how that limit is enforced — issuance slows down predictably until it stops entirely. Unlike money that can be printed at will, nobody can decide to create more bitcoins."
+    miners: "What happens to miners?"
+    minerstxt: "Each halving reduces the new bitcoins miners earn per block, so transaction fees make up a growing share of their income. Over time, fees are expected to replace the block reward entirely as the incentive that keeps the network secure."
+    howest: "How is the date estimated?"
+    howesttxt: "Bitcoin targets one block every ten minutes on average, so the date of block 1,050,000 can only be estimated. Blocks tend to arrive slightly faster when mining power grows, which is why halvings usually land a little earlier than a simple calendar projection. The countdown above recalculates from the live block height every time the page loads."
   innovation:
     title: "Innovation - Bitcoin"
     pagetitle: "Innovation in Payment Systems"
@@ -1220,6 +1253,7 @@ en:
     menu-bitcoin-for-developers: Developers
     menu-bitcoin-for-individuals: Individuals
     menu-bips: "BIPs list"
+    menu-halving: "Halving countdown"
     menu-price: "Price"
     menu-community: Community
     menu-development: Development
@@ -1290,6 +1324,7 @@ en:
     buy: buy
     sell: sell
     choose-your-wallet: choose-your-wallet
+    halving: halving
     community: community
     developer-documentation: developer-documentation
     developer-examples: developer-examples

--- a/css/main.scss
+++ b/css/main.scss
@@ -7,5 +7,6 @@
         "normalize",
         "screen",
         "bips",
-        "price"
+        "price",
+        "halving"
 ;

--- a/js/halving.js
+++ b/js/halving.js
@@ -1,0 +1,215 @@
+/*
+This file is licensed under the MIT License (MIT) available on
+https://opensource.org/licenses/MIT.
+*/
+
+(function () {
+  'use strict';
+
+  var INTERVAL = 210000;
+  var NEXT_BLOCK = 1050000;
+  var SECONDS_PER_BLOCK = 600;
+  var MAX_BLOCK = 1260000;
+  var CAP = 21000000;
+  var YEARS = ['2012', '2016', '2020', '2024', '2028'];
+  var ORANGE = '#f7931a';
+  var GRID = '#e0e6eb';
+  var LABEL = '#6b7f8f';
+  var FONT = '12px "Titillium Web", Arial, sans-serif';
+  var lastHeight = null;
+
+  function byId(id) { return document.getElementById(id); }
+
+  function fmt(n) {
+    try { return n.toLocaleString(document.documentElement.lang || 'en'); }
+    catch (e) { return String(n); }
+  }
+
+  function subsidyAt(block) {
+    return 50 / Math.pow(2, Math.floor(block / INTERVAL));
+  }
+
+  function supplyAt(block) {
+    var total = 0;
+    var era = Math.floor(block / INTERVAL);
+    var i;
+    for (i = 0; i < era; i++) {
+      total += INTERVAL * (50 / Math.pow(2, i));
+    }
+    return total + (block - era * INTERVAL) * (50 / Math.pow(2, era));
+  }
+
+  function setupCanvas(canvas) {
+    var dpr = window.devicePixelRatio || 1;
+    var w = 900;
+    var h = 420;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    var ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+    return { ctx: ctx, w: w, h: h, l: 70, r: 30, t: 30, b: 45 };
+  }
+
+  function xPos(g, block) {
+    return g.l + (block / MAX_BLOCK) * (g.w - g.l - g.r);
+  }
+
+  function yPos(g, v, max) {
+    return g.h - g.b - (v / max) * (g.h - g.t - g.b);
+  }
+
+  function drawFrame(g, canvas, yMax, yTicks, yFmt) {
+    var ctx = g.ctx;
+    var i, b, x, y;
+    ctx.font = FONT;
+    ctx.strokeStyle = GRID;
+    ctx.fillStyle = LABEL;
+    ctx.lineWidth = 1;
+    for (i = 0; i < yTicks.length; i++) {
+      y = yPos(g, yTicks[i], yMax);
+      ctx.beginPath();
+      ctx.moveTo(g.l, y);
+      ctx.lineTo(g.w - g.r, y);
+      ctx.stroke();
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(yFmt(yTicks[i]), g.l - 8, y);
+    }
+    ctx.setLineDash([4, 4]);
+    for (i = 1; i <= 5; i++) {
+      b = i * INTERVAL;
+      x = xPos(g, b);
+      ctx.beginPath();
+      ctx.moveTo(x, g.t);
+      ctx.lineTo(x, g.h - g.b);
+      ctx.stroke();
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'alphabetic';
+      ctx.fillText(YEARS[i - 1], x, g.t - 8);
+      ctx.fillText((b / 1000) + 'k', x, g.h - g.b + 18);
+    }
+    ctx.setLineDash([]);
+    ctx.textAlign = 'center';
+    ctx.fillText(canvas.getAttribute('data-label-x') || '', (g.l + g.w - g.r) / 2, g.h - 8);
+  }
+
+  function drawDot(g, block, v, yMax) {
+    var ctx = g.ctx;
+    ctx.fillStyle = ORANGE;
+    ctx.beginPath();
+    ctx.arc(xPos(g, block), yPos(g, v, yMax), 6, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+
+  function drawSubsidy() {
+    var canvas = byId('halving-subsidy-chart');
+    if (!canvas || !canvas.getContext) { return; }
+    var g = setupCanvas(canvas);
+    var ctx = g.ctx;
+    var i, x0, x1, y;
+    drawFrame(g, canvas, 50, [0, 12.5, 25, 37.5, 50], function (v) { return String(v); });
+    ctx.strokeStyle = ORANGE;
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    for (i = 0; i < 6; i++) {
+      x0 = xPos(g, i * INTERVAL);
+      x1 = xPos(g, (i + 1) * INTERVAL);
+      y = yPos(g, 50 / Math.pow(2, i), 50);
+      if (i === 0) { ctx.moveTo(x0, y); } else { ctx.lineTo(x0, y); }
+      ctx.lineTo(x1, y);
+    }
+    ctx.stroke();
+    if (lastHeight) { drawDot(g, lastHeight, subsidyAt(lastHeight), 50); }
+  }
+
+  function drawSupply() {
+    var canvas = byId('halving-supply-chart');
+    if (!canvas || !canvas.getContext) { return; }
+    var g = setupCanvas(canvas);
+    var ctx = g.ctx;
+    var i, b, y;
+    drawFrame(g, canvas, CAP, [0, 7000000, 14000000, 21000000], function (v) { return (v / 1000000) + 'M'; });
+    y = yPos(g, CAP, CAP);
+    ctx.strokeStyle = LABEL;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([6, 4]);
+    ctx.beginPath();
+    ctx.moveTo(g.l, y);
+    ctx.lineTo(g.w - g.r, y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.fillStyle = LABEL;
+    ctx.textAlign = 'right';
+    ctx.fillText(canvas.getAttribute('data-label-cap') || '', g.w - g.r - 4, y - 6);
+    ctx.strokeStyle = ORANGE;
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(xPos(g, 0), yPos(g, 0, CAP));
+    for (i = 1; i <= 6; i++) {
+      b = i * INTERVAL;
+      ctx.lineTo(xPos(g, b), yPos(g, supplyAt(b), CAP));
+    }
+    ctx.stroke();
+    if (lastHeight) { drawDot(g, lastHeight, supplyAt(lastHeight), CAP); }
+  }
+
+  function drawAll() {
+    drawSubsidy();
+    drawSupply();
+  }
+
+  function update(height) {
+    var remaining = NEXT_BLOCK - height;
+    if (remaining < 0) { remaining = 0; }
+    var eta = new Date(Date.now() + remaining * SECONDS_PER_BLOCK * 1000);
+    var done = INTERVAL - remaining;
+    var pct = Math.round((done / INTERVAL) * 100);
+    byId('halving-height').textContent = fmt(height);
+    byId('halving-remaining').textContent = fmt(remaining);
+    try {
+      byId('halving-date').textContent = eta.toLocaleDateString(
+        document.documentElement.lang || 'en',
+        { year: 'numeric', month: 'short' }
+      );
+    } catch (e) {
+      byId('halving-date').textContent = eta.getFullYear();
+    }
+    byId('halving-progress-bar').style.width = pct + '%';
+    lastHeight = height;
+    drawAll();
+  }
+
+  function load() {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'https://blockchain.info/q/getblockcount?cors=true', true);
+    xhr.timeout = 10000;
+    xhr.onload = function () {
+      var h = parseInt(xhr.responseText, 10);
+      if (xhr.status === 200 && h > 800000 && h < NEXT_BLOCK + INTERVAL) {
+        update(h);
+      }
+    };
+    xhr.send();
+  }
+
+  function start() {
+    drawAll();
+    load();
+  }
+
+  var resizeTimer = null;
+  window.addEventListener('resize', function () {
+    if (resizeTimer) { clearTimeout(resizeTimer); }
+    resizeTimer = setTimeout(drawAll, 150);
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+}());


### PR DESCRIPTION
A halving countdown and learning page at /en/halving, in the sidebar layout with the floating table of contents. Live countdown from the current block height (blockchain.info, keyless, already CSP-allowed), estimated date, progress through the current period, two annotated charts drawn in-page (block reward over time, total supply approaching the 21M cap — pure math, no chart libraries), the halving history table, and plain-language sections on what the halving is, why it exists, what it means for miners and how the date is estimated. Translatable like any template page; the Resources menu entry is gated to English until translations land, following the developer-documentation pattern.