### PR TITLE
Point the card image tags at a cache-fresh URL

### DIFF
--- a/_includes/layout/base/html-head.html
+++ b/_includes/layout/base/html-head.html
@@ -4,7 +4,7 @@ https://opensource.org/licenses/MIT.
 {% endcomment %}
 
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-<meta property="og:image" content="https://bitcoin.org/img/icons/opengraph.png">
+<meta property="og:image" content="https://bitcoin.org/img/icons/opengraph-card.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -31,7 +31,7 @@ https://opensource.org/licenses/MIT.
 {% elsif page.lang == 'en' and page.description %}
 <meta name="twitter:description" content="{{ page.description | escape }}">
 {% endif %}
-<meta name="twitter:image" content="https://bitcoin.org/img/icons/opengraph.png">
+<meta name="twitter:image" content="https://bitcoin.org/img/icons/opengraph-card.png">
 {% include layout/base/hreflang.html %}
 <link rel="stylesheet" href="/css/font-awesome-4.4.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="/css/main.css?{{site.time | date: '%s'}}">


### PR DESCRIPTION
Card scrapers cache the image by its URL with long TTLs — the old `opengraph.png` URL sits behind a 30-day edge cache, so X kept showing the previous 500×500 image even after the deploy. `opengraph-card.png` is the same 1200×630 file at a URL no cache has ever seen, so both og:image and twitter:image now point there and every platform picks up the new card on its next scrape.