### PR TITLE
Update the privacy page's dated references

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -634,7 +634,7 @@ text:
   typical_144_block_catchup_time_in_minutes: 5
   ## Before updating this, verify all assertions are still correct: git grep site.text.assertion_month
   ## Use ISO-8601 format, but feel free to round to the nearest month
-  assertion_month: 2017-06-01
+  assertion_month: 2026-08-01
 
 collections:
   ## _alerts

--- a/en/bitcoin-core/features/privacy.md
+++ b/en/bitcoin-core/features/privacy.md
@@ -55,7 +55,7 @@ third_party_privacy:
 {% include bitcoin-core/download-bitcoin-core.html %}
 
 > What if every time you spent or received cash, all the transaction
-> details were published to your Twitter or Facebook feed for all your
+> details were published to your social media feed for all your
 > friends to see? You probably wouldn't want to use cash any more.
 
 Every confirmed Bitcoin transaction is published to the blockchain
@@ -397,12 +397,10 @@ Isn't that worth occasionally starting up a few seconds slower?
   </div>
 
   <div id="spv_decentralized_peer" title="P2P Decentralized Peer Discovery" markdown="block">
-  The following P2P lightweight wallets use decentralized peer discovery
-  by default.
+  We don't currently know of any P2P lightweight wallets that use
+  decentralized peer discovery by default.
 
-  - BRD
-
-  If you know of another compliant lightweight wallet, please [tell us
+  If you know of a compliant lightweight wallet, please [tell us
   about it][docs issue].
   </div>
 


### PR DESCRIPTION
Three small updates: the peer-discovery popup listed the BRD wallet, which stopped processing transactions in March 2022 and was fully shut down after the Coinbase acquisition — its domain is now parked for sale, so the popup now says we don't currently know of a compliant wallet and keeps the invitation to tell us about one. The opening metaphor says \"social media feed\" instead of naming brands, so it doesn't age. And `assertion_month` moves from June 2017 to August 2026, with its single use re-verified per the config's own instruction.