### PR TITLE
Update the validation page's dated links

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -440,7 +440,7 @@ https://opensource.org/licenses/MIT.
 [fake satoshi transaction]: https://www.reddit.com/r/Bitcoin/comments/3fv42j/blockchaininfo_spoofed_transactions_problem_aug_4/
 [forum tech support]: https://bitcointalk.org/index.php?board=4.0
 [ghash betcoin double spend]: https://bitcointalk.org/index.php?topic=321630.msg3445371
-[gitian sigs]: https://github.com/bitcoin/gitian.sigs
+[gitian sigs]: https://github.com/bitcoin-core/guix.sigs
 [high-speed block relay network]: https://www.mail-archive.com/bitcoin-development@lists.sourceforge.net/msg03189.html
 [HMAC-SHA512]: https://en.wikipedia.org/wiki/HMAC
 [HTTP basic authentication]: https://en.wikipedia.org/wiki/Basic_access_authentication

--- a/en/bitcoin-core/features/validation.md
+++ b/en/bitcoin-core/features/validation.md
@@ -146,7 +146,7 @@ that the operators of StrongCoin could steal bitcoins from their users
 at any time even though the users supposedly controlled their own
 private keys.
 
-**Learn More:** [OzCoin Hacked, Stolen Funds Seized and Returned by StrongCoin](https://bitcoinmagazine.com/4273/ozcoin-hacked-stolen-funds-seized-and-returned-by-strongcoin/)
+**Learn More:** [OzCoin Hacked, Stolen Funds Seized and Returned by StrongCoin](https://bitcoinmagazine.com/business/ozcoin-hacked-stolen-funds-seized-and-returned-by-strongcoin-1366822516)
 </td>
 </tr>
 
@@ -288,7 +288,7 @@ prevented some users of the lightweight BreadWallet from connecting to
 honest nodes. Since the spy nodes didn't relay transactions, BreadWallet
 users stopped receiving notification of new transactions.
 
-**Learn more:** [Chainalysis CEO Denies 'Sybil Attack' on Bitcoin's Network](https://www.coindesk.com/chainalysis-ceo-denies-launching-sybil-attack-on-bitcoin-network/)
+**Learn more:** [Chainalysis CEO Denies 'Sybil Attack' on Bitcoin's Network](https://web.archive.org/web/2015/https://www.coindesk.com/chainalysis-ceo-denies-launching-sybil-attack-on-bitcoin-network/)
 </td>
 </tr>
 
@@ -437,7 +437,7 @@ Core right now:
    power users, businesses, and programmers. The [user interface][bcc
    user interface] page provides an overview, the [installation
    instructions][bandwidth sharing guide] can help you get started, and
-   the [RPC](https://developer.bitcoin.org/reference/rpc/)documentation can help you find specific
+   the [RPC](https://developer.bitcoin.org/reference/rpc/) documentation can help you find specific
    commands. If you're using [`getnewaddress`](https://developer.bitcoin.org/reference/rpc/getnewaddress.html) to
    create receiving addresses, your received transactions will be fully
    validated.


### PR DESCRIPTION
Four small updates found while auditing the validation page: the public build-auditor signatures reference pointed at the archived `bitcoin/gitian.sigs` — Bitcoin Core replaced Gitian with Guix around 2021, so it now points at `bitcoin-core/guix.sigs`. The CoinDesk article about the 2015 Chainalysis incident returns a 404, so the link now goes to the Internet Archive snapshot. The Bitcoin Magazine OzCoin link moves from its 2013-era URL to the current canonical one. And a missing space made "RPC documentation" render as one word.