### PR TITLE
Declutter the wallet results table

### DIFF
--- a/_includes/layout/base/wallets-selector.html
+++ b/_includes/layout/base/wallets-selector.html
@@ -475,6 +475,13 @@ https://opensource.org/licenses/MIT.
             </div>
           </div>
 
+          <div class="wallet-score-legend">
+            <span class="wallet-legend-item"><span class="wallet-score wallet-good"></span>{% translate wallet-scoring-good choose-your-wallet %}</span>
+            <span class="wallet-legend-item"><span class="wallet-score wallet-pass"></span>{% translate wallet-scoring-pass choose-your-wallet %}</span>
+            <span class="wallet-legend-item"><span class="wallet-score wallet-caution"></span>{% translate wallet-scoring-fail choose-your-wallet %}</span>
+            <span class="wallet-legend-item"><span class="wallet-score wallet-neutral"></span>{% translate wallet-scoring-neutral choose-your-wallet %}</span>
+          </div>
+
           <div class="table-sort">
             <h3 id="walletTableSortTitle" class="table-sort-title">{% translate wallet-selector-criteria choose-your-wallet %}:</h3>
             <div id="tableAccordion" class="acc">
@@ -554,25 +561,6 @@ https://opensource.org/licenses/MIT.
                 {% endfor %}
               {% endfor %}
             {% endfor %}
-          </div>
-
-          <div class="wallet-hints-row">
-            <div class="wallet-hint">
-              <div class="wallet-good"></div>
-              <p class="wallet-hint-text">{% translate wallet-scoring-good choose-your-wallet %}</p>
-            </div>
-            <div class="wallet-hint">
-              <div class="wallet-pass"></div>
-              <p class="wallet-hint-text">{% translate wallet-scoring-pass choose-your-wallet %}</p>
-            </div>
-            <div class="wallet-hint">
-              <div class="wallet-caution"></div>
-              <p class="wallet-hint-text">{% translate wallet-scoring-fail choose-your-wallet %}</p>
-            </div>
-            <div class="wallet-hint">
-              <div class="wallet-neutral"></div>
-              <p class="wallet-hint-text">{% translate wallet-scoring-neutral choose-your-wallet %}</p>
-            </div>
           </div>
 
         </div>

--- a/_sass/_wallet-finder-modern.scss
+++ b/_sass/_wallet-finder-modern.scss
@@ -2236,3 +2236,40 @@ html[lang='fa'] .wallet-finder-page .wallet-link.visible:hover {
     animation-iteration-count: 1 !important;
   }
 }
+
+/* Results declutter: the per-cell score words move into a single legend
+   above the table. The words stay in the DOM for screen readers. */
+.wallet-finder-page .wallet-score-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  margin: 0 0 14px;
+  padding: 0 24px;
+}
+
+.wallet-finder-page .wallet-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--wallet-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.wallet-finder-page .wallet-legend-item .wallet-score {
+  width: 11px;
+  height: 11px;
+  margin: 0;
+}
+
+.wallet-finder-page .wallet-table-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/_sass/_wallet-finder-modern.scss
+++ b/_sass/_wallet-finder-modern.scss
@@ -2243,7 +2243,7 @@ html[lang='fa'] .wallet-finder-page .wallet-link.visible:hover {
   display: flex;
   flex-wrap: wrap;
   gap: 8px 20px;
-  margin: 0 0 14px;
+  margin: 16px 0 14px;
   padding: 0 24px;
 }
 


### PR DESCRIPTION
Follow-up to the feedback on #4976: the results page declutter, scoped to reuse-only.

- One glyph per cell: the per-cell score words become visually hidden (kept in the DOM for screen readers).
- The score legend moves from below the table to above it, stated once.
- Everything reuses the existing `wallet-scoring-*` translated strings — no new translatable text.
