### PR TITLE
Declutter the individual wallet pages

### DIFF
--- a/_layouts/wallet-container.html
+++ b/_layouts/wallet-container.html
@@ -162,8 +162,8 @@ layout: base
                 {% assign ratingClass = 'neutral' %}
               {% endif %}
 
-              <article class="wallet-criterion-card wallet-rating-{{ ratingClass }}">
-                <div class="wallet-criterion-heading">
+              <details class="wallet-criterion-card wallet-rating-{{ ratingClass }}"{% if ratingClass == 'fail' %} open{% endif %}>
+                <summary class="wallet-criterion-heading">
                   <div class="wallet-criterion-heading-copy">
                     <p class="wallet-criterion-name">
                       {% translate wizard-criteria-{{checkName}} choose-your-wallet %}
@@ -181,7 +181,7 @@ layout: base
                       {% translate wallet-scoring-fail choose-your-wallet %}
                     {% endif %}
                   </span>
-                </div>
+                </summary>
 
                 <div class="wallet-criterion-description">
                   {% capture criterionDescription %}{% translate {{checkValue}}txt choose-your-wallet %}{% endcapture %}
@@ -225,7 +225,7 @@ layout: base
                     </div>
                   {% endif %}
                 </div>
-              </article>
+              </details>
               {% endif %}
             {% endfor %}
           </div>

--- a/_sass/_wallet-detail-modern.scss
+++ b/_sass/_wallet-detail-modern.scss
@@ -1100,3 +1100,42 @@ html[lang='fa'] .wallet-detail-page .wallet-similar-browse-arrow {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Wallet page declutter: criterion descriptions collapse until requested,
+   and the similar-wallet cards show a glyph-only score strip. The words
+   stay in the DOM for screen readers. */
+.wallet-detail-page .wallet-criterion-card > .wallet-criterion-heading {
+  cursor: pointer;
+  list-style: none;
+}
+
+.wallet-detail-page .wallet-criterion-heading::-webkit-details-marker {
+  display: none;
+}
+
+.wallet-detail-page .wallet-criterion-heading .wallet-rating-label::after {
+  content: " \25BE";
+}
+
+.wallet-detail-page .wallet-criterion-card[open] > .wallet-criterion-heading .wallet-rating-label::after {
+  content: " \25B4";
+}
+
+.wallet-detail-page .wallet-similar-scores {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.wallet-detail-page .wallet-similar-criterion,
+.wallet-detail-page .wallet-similar-rating > span:not(.wallet-score-mark) {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
Second half of the feedback on #4976 (companion to #4978): the individual wallet pages (e.g. /en/wallets/mobile/ios/unstoppable/).

- Each criterion card collapses into a `details` element — name, verdict and rating stay visible; the full description expands on demand. Criteria rated caution start expanded.
- The similar-wallet cards reduce to a glyph-only score strip; the words remain in the DOM (visually hidden) for screen readers.
- Reuses the `details`/`summary` pattern the page already uses for features — no new translatable text.
