### PR TITLE
Update BULL Android transparency rating

### DIFF
--- a/_wallets/bull.md
+++ b/_wallets/bull.md
@@ -20,7 +20,7 @@ platform:
         check:
           control: "checkgoodcontrolfull"
           validation: "checkpassvalidationservers" # default Bull Bitcoin electrum server but support custom servers
-          transparency: "checkpasstransparencyopensource"
+          transparency: "checkgoodtransparencydeterministic"
           environment: "checkpassenvironmentmobile"
           privacy: "checkpassprivacybasic" # default reveals addresses to Bull electrum server; Payjoin v2 and Tor supported
           fees: "checkgoodfeecontrolfull" # rbf


### PR DESCRIPTION
## Summary

- Update BULL's Android transparency rating from basic open-source transparency to complete deterministic-build transparency.
- Keep the iOS rating unchanged because the verification covers the Android package.

## Rationale

WalletScrutiny independently reproduced the BULL 6.13.0 Android build. This satisfies bitcoin.org's criterion for the good transparency score: an open-source wallet with a deterministic build.

Verification: https://walletscrutiny.com/mobile/com.bullbitcoin.mobile/#verificationId=8b0bf12ebeb4ca0e5eeb8637a1353c0297a5061204cbc0e9e2905462f45bf040

Follow-up to #4555.

## Validation

- `git diff --check`
- Parsed `_wallets/bull.md` as YAML and confirmed both platform transparency ratings are valid values from `quality-assurance/schemas/wallets.yaml`.
