### PR TITLE
Refresh the Lightning resources card

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -66,10 +66,28 @@ id: resources
         <img src="/img/icons/ico_lightning.svg?{{site.time | date: '%s'}}" alt="Icon">
         <h2 id="lightning">{% translate lightning %}</h2>
         <p>
+          <a href="https://lightning.network/lightning-network-paper.pdf">Lightning Network whitepaper</a>
+        </p>
+        <p>
           <a href="https://www.lopp.net/lightning-information.html">Jameson Lopp's Lightning Resources</a>
         </p>
         <p>
-          <a href="https://lightning.network">Lightning Network</a>
+          <a href="https://github.com/lnbook/lnbook">Mastering the Lightning Network</a>
+        </p>
+        <p>
+          <a href="https://github.com/lightning/bolts">Lightning specifications (BOLTs)</a>
+        </p>
+        <p>
+          <a href="https://github.com/lightningnetwork/lnd">LND</a>
+        </p>
+        <p>
+          <a href="https://corelightning.org">Core Lightning</a>
+        </p>
+        <p>
+          <a href="https://github.com/ACINQ/eclair">Eclair</a>
+        </p>
+        <p>
+          <a href="https://lightningdevkit.org">Lightning Dev Kit</a>
         </p>
       </div>
 


### PR DESCRIPTION
The Lightning card on /en/resources offered two links, one of them the lightning.network site — unchanged since November 2018 (per its Last-Modified header) but labeled as a general resource. This refresh:

- Relabels that entry as what it durably is: the Lightning Network whitepaper (linking the paper itself)
- Keeps Jameson Lopp's curated resource list
- Adds the Mastering the Lightning Network book, the BOLT specifications, and four open-source Lightning projects: the LND, Core Lightning and Eclair node implementations, and the Lightning Dev Kit library

All links verified live. Labels are hardcoded English like the rest of the card — no new translatable text.
