### PR TITLE
Add a transaction fees page

### DIFF
--- a/_includes/layout/base/footer-menu.html
+++ b/_includes/layout/base/footer-menu.html
@@ -134,6 +134,9 @@ https://opensource.org/licenses/MIT.
           <a href="/price/">{% translate menu-price layout %}</a>
       {% endif %}
       {% if page.lang == 'en' %}
+          <a href="/fees/">{% translate menu-fees layout %}</a>
+      {% endif %}
+      {% if page.lang == 'en' %}
       <a href="/{{ page.lang }}/{% translate scams url %}">{% translate menu-scams layout %}</a>
       {% endif %}
       <a href="/{{ page.lang }}/{% translate legal url %}">{% translate menu-legal layout %}</a>

--- a/_includes/layout/base/head-menu.html
+++ b/_includes/layout/base/head-menu.html
@@ -73,6 +73,7 @@ https://opensource.org/licenses/MIT.
       <li{% if page.id == 'development' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate development url %}">{% translate menu-development layout %}</a></li>
     </ul>
   </li>
-  <li{% if page.id == 'faq' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate faq url %}">{% translate menu-faq layout %}</a></li>
   {% if page.lang == 'en' %}<li{% if page.id == 'price' %} class="active"{% endif %}><a href="/price/">{% translate menu-price layout %}</a></li>{% endif %}
+  {% if page.lang == 'en' %}<li{% if page.id == 'fees' %} class="active"{% endif %}><a href="/fees/">{% translate menu-fees layout %}</a></li>{% endif %}
+  <li{% if page.id == 'faq' %} class="active"{% endif %}><a href="/{{ page.lang }}/{% translate faq url %}">{% translate menu-faq layout %}</a></li>
 </ul>

--- a/_sass/_fees.scss
+++ b/_sass/_fees.scss
@@ -1,0 +1,162 @@
+/*
+This file is licensed under the MIT License (MIT) available on
+https://opensource.org/licenses/MIT.
+*/
+
+.fees-page {
+  color: #4d5060;
+  background: #fffaf5;
+}
+
+.fees-hero {
+  position: relative;
+  overflow: hidden;
+  padding: 56px 0 60px;
+  color: #fff;
+  background: #090c14;
+  text-align: center;
+}
+
+.fees-hero::before,
+.fees-hero::after {
+  content: '';
+  position: absolute;
+  border: 1px solid rgba(255, 255, 255, 0.19);
+  border-radius: 50%;
+}
+
+.fees-hero::before {
+  width: 420px;
+  height: 420px;
+  top: -230px;
+  right: -45px;
+}
+
+.fees-hero::after {
+  width: 260px;
+  height: 260px;
+  left: -120px;
+  bottom: -190px;
+}
+
+.fees-hero .container {
+  position: relative;
+  z-index: 1;
+}
+
+.fees-eyebrow {
+  margin: 0 0 8px;
+  font-size: 87.5%;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.fees-hero h1 {
+  margin: 0 0 10px;
+  font-size: 350%;
+  font-weight: 600;
+  color: #fff;
+}
+
+.fees-hero__summary {
+  margin: 0 auto 36px;
+  max-width: 560px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.fees-tiers {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.fees-tier {
+  padding: 22px 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+}
+
+.fees-tier__label {
+  margin: 0;
+  font-weight: 700;
+  color: #fff;
+}
+
+.fees-tier__target {
+  margin: 2px 0 14px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.fees-tier__rate {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.fees-tier__unit {
+  font-size: 14px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.fees-tier__cost {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.fees-updated {
+  margin: 24px 0 4px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.fees-note {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.fees-content {
+  max-width: 760px;
+  padding: 44px 20px 60px;
+}
+
+.fees-section {
+  margin: 0 0 32px;
+}
+
+.fees-section h2 {
+  margin: 0 0 10px;
+}
+
+.fees-section p {
+  margin: 0;
+  line-height: 1.65;
+  color: #4d5060;
+}
+
+.fees-attribution {
+  margin: 40px 0 0;
+  padding-top: 20px;
+  border-top: 1px solid #e6e1dc;
+  font-size: 13px;
+  color: #8a8d93;
+}
+
+@media (max-width: 760px) {
+  .fees-tiers {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .fees-hero h1 {
+    font-size: 250%;
+  }
+}

--- a/_translations/en.yml
+++ b/_translations/en.yml
@@ -1306,6 +1306,7 @@ en:
     menu-bips: "BIPs list"
     menu-halving: "Halving"
     menu-price: "Price"
+    menu-fees: "Fees"
     menu-community: Community
     menu-development: Development
     menu-developer-documentation: Documentation

--- a/css/main.scss
+++ b/css/main.scss
@@ -8,5 +8,6 @@
         "screen",
         "bips",
         "price",
-        "halving"
+        "halving",
+        "fees"
 ;

--- a/fees/index.html
+++ b/fees/index.html
@@ -53,32 +53,32 @@ end_of_page: |
 
   <div class="container fees-content">
     <section class="fees-section">
-      <h2>What is a transaction fee?</h2>
+      <h2 id="what-is-a-transaction-fee">What is a transaction fee?</h2>
       <p>Every Bitcoin transaction includes a small fee. The fee does not go to any company or to this website: it is collected by the miner who includes your transaction in a block. Fees reward miners for securing the network, and they act as the price of space in the next block, which is limited.</p>
     </section>
 
     <section class="fees-section">
-      <h2>Why fees change</h2>
+      <h2 id="why-fees-change">Why fees change</h2>
       <p>Block space is roughly constant, but the number of people trying to transact is not. When many transactions compete at once, fees rise; when the network is quiet, fees fall. The same transaction can cost noticeably more on a busy day than on a calm one. Nothing is wrong in either case &mdash; the fee market is simply doing its job of deciding whose transactions go first.</p>
     </section>
 
     <section class="fees-section">
-      <h2>How fees are measured: sat/vB</h2>
+      <h2 id="how-fees-are-measured">How fees are measured: sat/vB</h2>
       <p>Fees are quoted in satoshis per virtual byte (sat/vB). You pay for the <em>size</em> of your transaction in the block, not for the amount of bitcoin you send: moving a small payment and moving a fortune can cost the same fee if the transactions are the same size. A satoshi is the smallest unit of bitcoin (100,000,000 satoshis = 1 BTC). A simple payment &mdash; one input, two outputs &mdash; takes up around 140 virtual bytes; transactions with more inputs and outputs are larger.</p>
     </section>
 
     <section class="fees-section">
-      <h2>Choosing a fee</h2>
+      <h2 id="choosing-a-fee">Choosing a fee</h2>
       <p>Most wallets estimate fees for you and let you choose between speed and economy: a higher rate aims for the next block, a lower rate waits until the network is quieter. Different wallets can suggest different numbers for the same moment &mdash; fee estimation is a prediction, not an exact science. If your payment is not urgent, choosing a lower fee and waiting is a perfectly good strategy.</p>
     </section>
 
     <section class="fees-section">
-      <h2>If your transaction seems stuck</h2>
+      <h2 id="if-your-transaction-seems-stuck">If your transaction seems stuck</h2>
       <p>A transaction with a low fee during a busy period is not lost &mdash; it is waiting in a queue (the mempool) until space is available. It may confirm once demand for block space falls. Many wallets can also speed up a waiting transaction by increasing its fee (a feature called Replace-by-Fee), or you can simply wait: an unconfirmed transaction either confirms or is eventually dropped by the network &mdash; and in that case the funds simply remain spendable in your wallet, because they never actually left it.</p>
     </section>
 
     <section class="fees-section">
-      <h2>Small and everyday payments</h2>
+      <h2 id="small-and-everyday-payments">Small and everyday payments</h2>
       <p>For small or frequent payments, the <a href="/en/resources#lightning">Lightning Network</a> offers near-instant transfers with fees that are typically a tiny fraction of a cent. It works on top of Bitcoin and is supported by a growing number of wallets and merchants &mdash; see <a href="/en/spend-bitcoin">Spend Bitcoin</a> for places that accept it.</p>
     </section>
 

--- a/fees/index.html
+++ b/fees/index.html
@@ -1,0 +1,87 @@
+---
+# This file is licensed under the MIT License (MIT) available on
+# https://opensource.org/licenses/MIT.
+
+layout: base
+lang: en
+id: fees
+title: Bitcoin Transaction Fees Today - Live Fee Rates | Bitcoin.org
+description: See current Bitcoin transaction fee rates, understand how fees work, why they change, and how to choose the right fee for your transaction.
+permalink: /fees/
+hide_language_selector: true
+end_of_page: |
+  <script type="text/javascript" src="/js/fees.js"></script>
+---
+
+<main class="fees-page" id="fees-page">
+  <section class="fees-hero">
+    <div class="container">
+      <p class="fees-eyebrow">Bitcoin network data</p>
+      <h1>Bitcoin transaction fees</h1>
+      <p class="fees-hero__summary">What it costs to send a transaction right now &mdash; and how fees work.</p>
+
+      <div class="fees-tiers" aria-live="polite" aria-atomic="true">
+        <div class="fees-tier">
+          <p class="fees-tier__label">Fastest</p>
+          <p class="fees-tier__target">next block</p>
+          <p class="fees-tier__rate"><span id="fee-rate-fastest">&mdash;</span> <span class="fees-tier__unit">sat/vB</span></p>
+          <p class="fees-tier__cost" id="fee-cost-fastest">&nbsp;</p>
+        </div>
+        <div class="fees-tier">
+          <p class="fees-tier__label">Fast</p>
+          <p class="fees-tier__target">about 30 minutes</p>
+          <p class="fees-tier__rate"><span id="fee-rate-half">&mdash;</span> <span class="fees-tier__unit">sat/vB</span></p>
+          <p class="fees-tier__cost" id="fee-cost-half">&nbsp;</p>
+        </div>
+        <div class="fees-tier">
+          <p class="fees-tier__label">Standard</p>
+          <p class="fees-tier__target">about an hour</p>
+          <p class="fees-tier__rate"><span id="fee-rate-hour">&mdash;</span> <span class="fees-tier__unit">sat/vB</span></p>
+          <p class="fees-tier__cost" id="fee-cost-hour">&nbsp;</p>
+        </div>
+        <div class="fees-tier">
+          <p class="fees-tier__label">Economy</p>
+          <p class="fees-tier__target">no hurry</p>
+          <p class="fees-tier__rate"><span id="fee-rate-economy">&mdash;</span> <span class="fees-tier__unit">sat/vB</span></p>
+          <p class="fees-tier__cost" id="fee-cost-economy">&nbsp;</p>
+        </div>
+      </div>
+      <p class="fees-updated" id="fees-updated">Connecting to network data&hellip;</p>
+      <p class="fees-note">Approximate cost for a typical transaction of about 140 vB. Your wallet shows the exact fee before you send.</p>
+    </div>
+  </section>
+
+  <div class="container fees-content">
+    <section class="fees-section">
+      <h2>What is a transaction fee?</h2>
+      <p>Every Bitcoin transaction includes a small fee. The fee does not go to any company or to this website: it is collected by the miner who includes your transaction in a block. Fees reward miners for securing the network, and they act as the price of space in the next block, which is limited.</p>
+    </section>
+
+    <section class="fees-section">
+      <h2>Why fees change</h2>
+      <p>Block space is roughly constant, but the number of people trying to transact is not. When many transactions compete at once, fees rise; when the network is quiet, fees fall. The same transaction can cost noticeably more on a busy day than on a calm one. Nothing is wrong in either case &mdash; the fee market is simply doing its job of deciding whose transactions go first.</p>
+    </section>
+
+    <section class="fees-section">
+      <h2>How fees are measured: sat/vB</h2>
+      <p>Fees are quoted in satoshis per virtual byte (sat/vB). You pay for the <em>size</em> of your transaction in the block, not for the amount of bitcoin you send: moving a small payment and moving a fortune can cost the same fee if the transactions are the same size. A satoshi is the smallest unit of bitcoin (100,000,000 satoshis = 1 BTC). A simple payment &mdash; one input, two outputs &mdash; takes up around 140 virtual bytes; transactions with more inputs and outputs are larger.</p>
+    </section>
+
+    <section class="fees-section">
+      <h2>Choosing a fee</h2>
+      <p>Most wallets estimate fees for you and let you choose between speed and economy: a higher rate aims for the next block, a lower rate waits until the network is quieter. Different wallets can suggest different numbers for the same moment &mdash; fee estimation is a prediction, not an exact science. If your payment is not urgent, choosing a lower fee and waiting is a perfectly good strategy.</p>
+    </section>
+
+    <section class="fees-section">
+      <h2>If your transaction seems stuck</h2>
+      <p>A transaction with a low fee during a busy period is not lost &mdash; it is waiting in a queue (the mempool) until space is available. It may confirm once demand for block space falls. Many wallets can also speed up a waiting transaction by increasing its fee (a feature called Replace-by-Fee), or you can simply wait: an unconfirmed transaction either confirms or is eventually dropped by the network &mdash; and in that case the funds simply remain spendable in your wallet, because they never actually left it.</p>
+    </section>
+
+    <section class="fees-section">
+      <h2>Small and everyday payments</h2>
+      <p>For small or frequent payments, the <a href="/en/resources#lightning">Lightning Network</a> offers near-instant transfers with fees that are typically a tiny fraction of a cent. It works on top of Bitcoin and is supported by a growing number of wallets and merchants &mdash; see <a href="/en/spend-bitcoin">Spend Bitcoin</a> for places that accept it.</p>
+    </section>
+
+    <p class="fees-attribution">Live estimates from mempool.space, with blockstream.info as a fallback, fetched directly in your browser. This page never handles your funds.</p>
+  </div>
+</main>

--- a/js/fees.js
+++ b/js/fees.js
@@ -1,0 +1,140 @@
+/*
+This file is licensed under the MIT License (MIT) available on
+https://opensource.org/licenses/MIT.
+*/
+
+(function() {
+    'use strict';
+
+    var MEMPOOL_URL = 'https://mempool.space/api/v1/fees/recommended';
+    var BLOCKSTREAM_URL = 'https://blockstream.info/api/fee-estimates';
+    var PRICE_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd';
+    var FEES_CACHE_KEY = 'bitcoin-org-fees-v1';
+    var PRICE_CACHE_KEY = 'bitcoin-org-fees-usd-v1';
+    var FEES_TTL = 2 * 60 * 1000;
+    var PRICE_TTL = 5 * 60 * 1000;
+    var REQUEST_TIMEOUT = 8000;
+    var REFRESH_INTERVAL = 60 * 1000;
+    var TYPICAL_VBYTES = 140;
+
+    var tiers = [
+        { key: 'fastestFee', rateId: 'fee-rate-fastest', costId: 'fee-cost-fastest' },
+        { key: 'halfHourFee', rateId: 'fee-rate-half', costId: 'fee-cost-half' },
+        { key: 'hourFee', rateId: 'fee-rate-hour', costId: 'fee-cost-hour' },
+        { key: 'economyFee', rateId: 'fee-rate-economy', costId: 'fee-cost-economy' }
+    ];
+
+    function fetchJson(url) {
+        return new Promise(function(resolve, reject) {
+            var timer = setTimeout(function() { reject(new Error('timeout')); }, REQUEST_TIMEOUT);
+            fetch(url, { cache: 'no-store' }).then(function(res) {
+                clearTimeout(timer);
+                if (!res.ok) { reject(new Error('http ' + res.status)); return; }
+                resolve(res.json());
+            }).catch(function(err) { clearTimeout(timer); reject(err); });
+        });
+    }
+
+    function readCache(key, ttl) {
+        try {
+            var raw = window.localStorage.getItem(key);
+            if (!raw) { return null; }
+            var entry = JSON.parse(raw);
+            if (!entry || typeof entry.time !== 'number') { return null; }
+            if (Date.now() - entry.time > ttl) { return null; }
+            return entry.data;
+        } catch (e) { return null; }
+    }
+
+    function writeCache(key, data) {
+        try {
+            window.localStorage.setItem(key, JSON.stringify({ time: Date.now(), data: data }));
+        } catch (e) { /* storage unavailable */ }
+    }
+
+    function normalizeBlockstream(data) {
+        function pick(target) {
+            var v = data[String(target)];
+            return typeof v === 'number' ? v : null;
+        }
+        var fastest = pick(1), half = pick(3), hour = pick(6);
+        var economy = pick(144) || pick(72) || pick(25);
+        if (fastest === null || half === null || hour === null || economy === null) { return null; }
+        return { fastestFee: fastest, halfHourFee: half, hourFee: hour, economyFee: economy };
+    }
+
+    function formatRate(rate) {
+        if (typeof rate !== 'number' || !(rate > 0)) { return null; }
+        if (rate >= 10) { return String(Math.round(rate)); }
+        var rounded = Math.round(rate * 10) / 10;
+        return String(rounded % 1 === 0 ? Math.round(rounded) : rounded);
+    }
+
+    function renderFees(data, usdPrice) {
+        var ok = false;
+        tiers.forEach(function(tier) {
+            var rateEl = document.getElementById(tier.rateId);
+            var costEl = document.getElementById(tier.costId);
+            if (!rateEl || !costEl) { return; }
+            var formatted = formatRate(data && data[tier.key]);
+            if (formatted === null) { rateEl.textContent = '\u2014'; costEl.innerHTML = '&nbsp;'; return; }
+            ok = true;
+            rateEl.textContent = formatted;
+            var sats = Math.round(data[tier.key] * TYPICAL_VBYTES);
+            var text = '\u2248 ' + sats.toLocaleString('en-US') + ' sats';
+            if (typeof usdPrice === 'number' && usdPrice > 0) {
+                var usd = sats / 1e8 * usdPrice;
+                text += ' (' + (usd < 0.01 ? '<\u200a$0.01' : '$' + usd.toFixed(2)) + ')';
+            }
+            costEl.textContent = text;
+        });
+        return ok;
+    }
+
+    function setStatus(message) {
+        var el = document.getElementById('fees-updated');
+        if (el) { el.textContent = message; }
+    }
+
+    function loadPrice() {
+        var cached = readCache(PRICE_CACHE_KEY, PRICE_TTL);
+        if (cached !== null) { return Promise.resolve(cached); }
+        return fetchJson(PRICE_URL).then(function(data) {
+            var usd = data && data.bitcoin && data.bitcoin.usd;
+            if (typeof usd === 'number') { writeCache(PRICE_CACHE_KEY, usd); return usd; }
+            return null;
+        }).catch(function() { return null; });
+    }
+
+    function loadFees() {
+        var cached = readCache(FEES_CACHE_KEY, FEES_TTL);
+        if (cached !== null) { return Promise.resolve(cached); }
+        return fetchJson(MEMPOOL_URL).then(function(data) {
+            if (data && typeof data.fastestFee === 'number') { writeCache(FEES_CACHE_KEY, data); return data; }
+            throw new Error('unexpected payload');
+        }).catch(function() {
+            return fetchJson(BLOCKSTREAM_URL).then(function(data) {
+                var normalized = normalizeBlockstream(data);
+                if (normalized) { writeCache(FEES_CACHE_KEY, normalized); return normalized; }
+                throw new Error('unexpected fallback payload');
+            });
+        });
+    }
+
+    function refresh() {
+        Promise.all([loadFees(), loadPrice()]).then(function(results) {
+            if (renderFees(results[0], results[1])) {
+                setStatus('Live estimates \u00b7 updated ' + new Date().toLocaleTimeString());
+            } else {
+                setStatus('Live fee data is unavailable right now. Please try again in a moment.');
+            }
+        }).catch(function() {
+            setStatus('Live fee data is unavailable right now. Please try again in a moment.');
+        });
+    }
+
+    if (document.getElementById('fees-page')) {
+        refresh();
+        window.setInterval(refresh, REFRESH_INTERVAL);
+    }
+}());

--- a/js/fees.js
+++ b/js/fees.js
@@ -3,6 +3,8 @@ This file is licensed under the MIT License (MIT) available on
 https://opensource.org/licenses/MIT.
 */
 
+/* global Promise, fetch */
+
 (function() {
     'use strict';
 
@@ -64,7 +66,7 @@ https://opensource.org/licenses/MIT.
     }
 
     function formatRate(rate) {
-        if (typeof rate !== 'number' || !(rate > 0)) { return null; }
+        if (typeof rate !== 'number' || isNaN(rate) || rate <= 0) { return null; }
         if (rate >= 10) { return String(Math.round(rate)); }
         var rounded = Math.round(rate * 10) / 10;
         return String(rounded % 1 === 0 ? Math.round(rounded) : rounded);


### PR DESCRIPTION
Adds a transaction fees page at /fees/ for newcomers wondering what it costs to send Bitcoin:

- Live fee estimates by confirmation target, in sat/vB plus the approximate cost of a simple (~140 vB) transaction in sats and USD
- Plain-language sections: what a fee is, why fees change, how sat/vB works, choosing a fee, stuck transactions (mempool/RBF), and Lightning for small payments — with links to /en/resources#lightning and /en/spend-bitcoin
- Live data fetched client-side from mempool.space with blockstream.info as a fallback, briefly cached in localStorage; the page degrades gracefully if the APIs are unreachable and never handles funds
- English-only and gated in the menus, following the /price/ pattern and visual identity; the FAQ menu entry moves to the end so Price and Fees sit together; one menu translation key added

Static copy contains no perishable numbers, so it stays accurate as fee conditions change.
