### PR TITLE
Remove Coinext from exchanges (winding down operations)

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -423,8 +423,6 @@ id: exchanges
           <br>
           <a class="marketplace-link" href="https://brasilbitcoin.com.br/">Brasil Bitcoin</a>
           <br>
-          <a class="marketplace-link" href="https://coinext.com.br/">Coinext</a>
-          <br>
           <a class="marketplace-link" href="https://foxbit.com.br/">Foxbit</a>
           <br>
           <a class="marketplace-link" href="https://mercadobitcoin.com.br/">Mercado Bitcoin</a>


### PR DESCRIPTION
Coinext is winding down its exchange operations. New accounts and deposits were closed on 3 September 2026, trading ends on 15 October 2026 and crypto withdrawals on 20 October 2026, per the official notice: https://coinext.com.br/suporte/coinext-encerramento-duvidas-frequentes
