### PR TITLE
resources: add LearnBitcoin.com to Learn

### DIFF
--- a/_templates/resources.html
+++ b/_templates/resources.html
@@ -25,6 +25,9 @@ id: resources
           <a href="https://btcbasicsforeveryone.com/">Bitcoin Basics</a>
         </p>
         <p>
+          <a href="https://www.learnbitcoin.com">LearnBitcoin.com</a>
+        </p>
+        <p>
           <a href="https://www.lopp.net/bitcoin-information.html">Jameson Lopp's Bitcoin Resources</a>
         </p>
         <p>


### PR DESCRIPTION
Adds LearnBitcoin.com to the Learn resources. It is a free, Bitcoin-only education site: a six-chapter guided path from "what is money" to running a node, 17 long-form sourced deep dives, and a ~470-term glossary. No paywall, no signup, no ads, no affiliate links, no altcoins. Content is CC-BY-SA with the source on GitHub (treib-holdings/learnbitcoin-content). Same category as Learn Me A Bitcoin and Bitcoin Basics already listed. I run the site.
